### PR TITLE
feat(poi): add validation for opening and closing hours in POI schema

### DIFF
--- a/apps/api/src/poi/routes.ts
+++ b/apps/api/src/poi/routes.ts
@@ -164,19 +164,31 @@ const updatePoiSchema = z.object({
  *                       properties:
  *                         day:
  *                           type: integer
+ *                           minimum: 0
+ *                           maximum: 6
  *                         hour:
  *                           type: integer
+ *                           minimum: 0
+ *                           maximum: 23
  *                         minute:
  *                           type: integer
+ *                           minimum: 0
+ *                           maximum: 59
  *                     close:
  *                       type: object
  *                       properties:
  *                         day:
  *                           type: integer
+ *                           minimum: 0
+ *                           maximum: 6
  *                         hour:
  *                           type: integer
+ *                           minimum: 0
+ *                           maximum: 23
  *                         minute:
  *                           type: integer
+ *                           minimum: 0
+ *                           maximum: 59
  *               photoUrls:
  *                 type: array
  *                 items:
@@ -415,6 +427,37 @@ poiRouter.get("/:id", requireAuth, async (req, res) => {
  *                 type: array
  *                 items:
  *                   type: object
+ *                   properties:
+ *                     open:
+ *                       type: object
+ *                       properties:
+ *                         day:
+ *                           type: integer
+ *                           minimum: 0
+ *                           maximum: 6
+ *                         hour:
+ *                           type: integer
+ *                           minimum: 0
+ *                           maximum: 23
+ *                         minute:
+ *                           type: integer
+ *                           minimum: 0
+ *                           maximum: 59
+ *                     close:
+ *                       type: object
+ *                       properties:
+ *                         day:
+ *                           type: integer
+ *                           minimum: 0
+ *                           maximum: 6
+ *                         hour:
+ *                           type: integer
+ *                           minimum: 0
+ *                           maximum: 23
+ *                         minute:
+ *                           type: integer
+ *                           minimum: 0
+ *                           maximum: 59
  *               photoUrls:
  *                 type: array
  *                 items:


### PR DESCRIPTION
## 📝 Description

Amélioration de la documentation OpenAPI des endpoints POI en ajoutant les contraintes de validation min/max pour les champs des horaires d'ouverture.

## 🎯 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [ ] 🎨 Style/UI update (no functional changes)
- [ ] ♻️ Code refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update

## 🔗 Related Issues

## 🚀 Changes Made

- Ajout des contraintes `minimum` et `maximum` pour le champ `day` (0-6) dans le schéma `openingHours`
- Ajout des contraintes `minimum` et `maximum` pour le champ `hour` (0-23) dans le schéma `openingHours`
- Ajout des contraintes `minimum` et `maximum` pour le champ `minute` (0-59) dans le schéma `openingHours`
- Application des mêmes contraintes pour les endpoints POST et PUT de `/poi`

## 🧪 Testing

- [x] Tested locally with `pnpm dev`
- [x] All quality checks pass (`pnpm lint`)
- [x] Unit tests pass (`pnpm test`)
- [ ] Database migrations applied if needed

## 📸 Screenshots/Videos

N/A

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated if needed
- [x] No console errors or warnings
- [x] Removed any debug code