### PR TITLE
feat(api): add pagination support for list and shared POI routes

### DIFF
--- a/apps/api/__test__/list/routes.test.ts
+++ b/apps/api/__test__/list/routes.test.ts
@@ -269,7 +269,7 @@ describe("List Routes", () => {
   });
 
   describe("GET /list/:listid/pois", () => {
-    it("should return POIs in a list", async () => {
+    it("should return POIs in a list with pagination", async () => {
       const list = await prisma.poiList.create({
         data: { name: "Test List", createdBy: userId },
       });
@@ -289,6 +289,9 @@ describe("List Routes", () => {
       expect(res.status).toBe(200);
       expect(res.body.savedPois).toHaveLength(1);
       expect(res.body.savedPois[0].poi.name).toBe("Test POI");
+      expect(res.body.pagination).toBeDefined();
+      expect(res.body.pagination.page).toBe(1);
+      expect(res.body.pagination.total).toBe(1);
     });
 
     it("should return 404 for non-existent list", async () => {
@@ -881,7 +884,7 @@ describe("List Routes", () => {
   });
 
   describe("GET /list/:listId/collaborators", () => {
-    it("should return collaborators for owner", async () => {
+    it("should return collaborators for owner with pagination", async () => {
       const list = await prisma.poiList.create({
         data: { name: "My List", createdBy: userId },
       });
@@ -907,9 +910,12 @@ describe("List Routes", () => {
       expect(res.body.collaborators).toHaveLength(1);
       expect(res.body.collaborators[0].user.email).toBe("collab@example.com");
       expect(res.body.collaborators[0].role).toBe("EDITOR");
+      expect(res.body.pagination).toBeDefined();
+      expect(res.body.pagination.page).toBe(1);
+      expect(res.body.pagination.total).toBe(1);
     });
 
-    it("should return collaborators for collaborator", async () => {
+    it("should return collaborators for collaborator with pagination", async () => {
       const otherUser = await prisma.user.create({
         data: {
           email: "owner-collabs@example.com",
@@ -932,6 +938,7 @@ describe("List Routes", () => {
 
       expect(res.status).toBe(200);
       expect(res.body.collaborators).toHaveLength(1);
+      expect(res.body.pagination).toBeDefined();
     });
 
     it("should return 404 for non-collaborator on private list", async () => {

--- a/apps/api/__test__/shared/routes.test.ts
+++ b/apps/api/__test__/shared/routes.test.ts
@@ -146,7 +146,7 @@ describe("Shared Routes", () => {
   });
 
   describe("GET /shared/:shareToken/pois", () => {
-    it("should return POIs from a shared list without authentication", async () => {
+    it("should return POIs from a shared list with pagination", async () => {
       const poi = await prisma.poi.create({
         data: {
           name: "Test POI",
@@ -171,6 +171,9 @@ describe("Shared Routes", () => {
       expect(res.body.pois[0]).toHaveProperty("name", "Test POI");
       expect(res.body.pois[0]).toHaveProperty("description", "A test POI");
       expect(res.body.pois[0]).not.toHaveProperty("createdBy");
+      expect(res.body.pagination).toBeDefined();
+      expect(res.body.pagination.page).toBe(1);
+      expect(res.body.pagination.total).toBe(1);
     });
 
     it("should return Google Place Cache POIs", async () => {
@@ -237,6 +240,8 @@ describe("Shared Routes", () => {
 
       expect(res.status).toBe(200);
       expect(res.body.pois).toEqual([]);
+      expect(res.body.pagination).toBeDefined();
+      expect(res.body.pagination.total).toBe(0);
     });
 
     it("should return 404 for invalid token", async () => {

--- a/apps/api/src/swagger/schemas/list.schema.ts
+++ b/apps/api/src/swagger/schemas/list.schema.ts
@@ -120,8 +120,9 @@ export const listSchemas = {
         type: "array",
         items: { $ref: "#/components/schemas/Collaborator" },
       },
+      pagination: { $ref: "#/components/schemas/PaginationResponse" },
     },
-    required: ["collaborators"],
+    required: ["collaborators", "pagination"],
   },
   InviteCollaboratorResponse: {
     type: "object",

--- a/apps/api/src/swagger/schemas/poi.schema.ts
+++ b/apps/api/src/swagger/schemas/poi.schema.ts
@@ -275,8 +275,9 @@ export const poiSchemas = {
           },
         },
       },
+      pagination: { $ref: "#/components/schemas/PaginationResponse" },
     },
-    required: ["savedPois"],
+    required: ["savedPois", "pagination"],
   },
   SharedListResponse: {
     type: "object",
@@ -311,7 +312,8 @@ export const poiSchemas = {
     type: "object",
     properties: {
       pois: { type: "array", items: { type: "object" } },
+      pagination: { $ref: "#/components/schemas/PaginationResponse" },
     },
-    required: ["pois"],
+    required: ["pois", "pagination"],
   },
 } as const;


### PR DESCRIPTION
## 📝 Description

Ajout du support de la pagination et de filtres pour les endpoints de listes et de POIs partagés. Les clients peuvent désormais spécifier les paramètres `page` et `limit` pour paginer les résultats, et utiliser des filtres par recherche de nom et visibilité pour les listes.

## 🎯 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI update (no functional changes)
- [ ] ♻️ Code refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [x] ✅ Test update

## 🔗 Related Issues

## 🚀 Changes Made

- Ajout du support de pagination pour les endpoints `GET /list/:listId/pois`, `GET /shared/:shareToken/pois` et `GET /list/:listId/collaborators` avec paramètres `page` et `limit`
- Ajout de filtres pour l'endpoint `GET /list` : recherche par nom (paramètre `search`) et filtrage par visibilité (paramètre `visibility`)
- Amélioration de la validation des paramètres de pagination avec Zod pour l'endpoint `GET /list`
- Mise à jour de la structure de réponse pour inclure un objet `pagination` avec `page`, `limit`, `total` et `totalPages` dans tous les endpoints concernés
- Mise à jour de la documentation Swagger pour inclure les détails de pagination dans les schémas de réponse
- Mise à jour des tests pour valider la fonctionnalité de pagination

## 🧪 Testing

- [x] Tested locally with `pnpm dev`
- [x] All quality checks pass (`pnpm lint`)
- [x] Unit tests pass (`pnpm test`)
- [ ] Database migrations applied if needed

## 📸 Screenshots/Videos

N/A

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated if needed
- [x] No console errors or warnings
- [x] Removed any debug code