### PR TITLE
feat(api): implement cookie-based refresh token handling

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -21,6 +21,7 @@
     "@prisma/client": "^6.19.0",
     "@scalar/express-api-reference": "^0.8.25",
     "bcrypt": "^6.0.0",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
@@ -38,6 +39,7 @@
   },
   "devDependencies": {
     "@types/bcrypt": "^6.0.0",
+    "@types/cookie-parser": "^1.4.10",
     "@types/cors": "^2.8.19",
     "@types/express": "^4.17.21",
     "@types/jsonwebtoken": "^9.0.10",

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1,4 +1,5 @@
 import { apiReference } from "@scalar/express-api-reference";
+import cookieParser from "cookie-parser";
 import cors from "cors";
 import express, { Request, Response, NextFunction } from "express";
 import helmet from "helmet";
@@ -40,6 +41,7 @@ export function createServer() {
     })
   );
   app.use(express.json({ limit: "1mb" }));
+  app.use(cookieParser());
 
   app.use(
     "/docs",

--- a/apps/api/src/swagger/schemas/auth.schema.ts
+++ b/apps/api/src/swagger/schemas/auth.schema.ts
@@ -86,16 +86,14 @@ export const authSchemas = {
     properties: {
       user: { $ref: "#/components/schemas/UserBasic" },
       accessToken: { type: "string" },
-      refreshToken: { type: "string" },
     },
-    required: ["user", "accessToken", "refreshToken"],
+    required: ["user", "accessToken"],
     example: {
       user: {
         id: "1234567890",
         email: "test@example.com",
       },
       accessToken: "1234567890",
-      refreshToken: "1234567890",
     },
   },
   RefreshTokenResponse: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       bcrypt:
         specifier: ^6.0.0
         version: 6.0.0
+      cookie-parser:
+        specifier: ^1.4.7
+        version: 1.4.7
       cors:
         specifier: ^2.8.5
         version: 2.8.5
@@ -114,6 +117,9 @@ importers:
       "@types/bcrypt":
         specifier: ^6.0.0
         version: 6.0.0
+      "@types/cookie-parser":
+        specifier: ^1.4.10
+        version: 1.4.10(@types/express@4.17.25)
       "@types/cors":
         specifier: ^2.8.19
         version: 2.8.19
@@ -1613,6 +1619,14 @@ packages:
         integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==,
       }
 
+  "@types/cookie-parser@1.4.10":
+    resolution:
+      {
+        integrity: sha512-B4xqkqfZ8Wek+rCOeRxsjMS9OgvzebEzzLYw7NHYuvzb7IdxOkI0ZHGgeEBX4PUM7QGVvNSK60T3OvWj3YfBRg==,
+      }
+    peerDependencies:
+      "@types/express": "*"
+
   "@types/cookiejar@2.1.5":
     resolution:
       {
@@ -2335,6 +2349,13 @@ packages:
       }
     engines: { node: ">= 0.6" }
 
+  cookie-parser@1.4.7:
+    resolution:
+      {
+        integrity: sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==,
+      }
+    engines: { node: ">= 0.8.0" }
+
   cookie-signature@1.0.6:
     resolution:
       {
@@ -2345,6 +2366,13 @@ packages:
     resolution:
       {
         integrity: sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==,
+      }
+    engines: { node: ">= 0.6" }
+
+  cookie@0.7.2:
+    resolution:
+      {
+        integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==,
       }
     engines: { node: ">= 0.6" }
 
@@ -6406,6 +6434,10 @@ snapshots:
     dependencies:
       "@types/node": 22.19.1
 
+  "@types/cookie-parser@1.4.10(@types/express@4.17.25)":
+    dependencies:
+      "@types/express": 4.17.25
+
   "@types/cookiejar@2.1.5": {}
 
   "@types/cors@2.8.19":
@@ -6906,9 +6938,16 @@ snapshots:
 
   content-type@1.0.5: {}
 
+  cookie-parser@1.4.7:
+    dependencies:
+      cookie: 0.7.2
+      cookie-signature: 1.0.6
+
   cookie-signature@1.0.6: {}
 
   cookie@0.7.1: {}
+
+  cookie@0.7.2: {}
 
   cookiejar@2.1.4: {}
 


### PR DESCRIPTION
## 📝 Description

Implémentation de la gestion des refresh tokens via des cookies HttpOnly pour améliorer la sécurité. Les refresh tokens ne sont plus exposés dans les réponses JSON et sont désormais stockés dans des cookies sécurisés accessibles uniquement via HTTP.

## 🎯 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI update (no functional changes)
- [ ] ♻️ Code refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [x] ✅ Test update

## 🔗 Related Issues

## 🚀 Changes Made

- Ajout du middleware `cookie-parser` pour gérer les cookies dans l'API
- Mise à jour de la route de login pour définir le refresh token comme cookie HttpOnly avec les options de sécurité appropriées (secure en production, sameSite strict)
- Modification de la route de refresh token pour récupérer le token depuis les cookies au lieu du corps de la requête
- Suppression du refresh token de la réponse JSON pour éviter son exposition
- Mise à jour de la route de logout pour supprimer le cookie de refresh token
- Mise à jour des tests pour valider la nouvelle gestion des cookies pour les refresh tokens
- Mise à jour de la documentation Swagger pour refléter les changements dans les schémas de réponse

## 🧪 Testing

- [x] Tested locally with `pnpm dev`
- [x] All quality checks pass (`pnpm lint`)
- [x] Unit tests pass (`pnpm test`)
- [ ] Database migrations applied if needed

## 📸 Screenshots/Videos

N/A

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated if needed
- [x] No console errors or warnings
- [x] Removed any debug code