### PR TITLE
fix(ci-cd): restrict branch triggers and add Docker image pruning

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -2,9 +2,8 @@ name: CI/CD
 
 on:
   push:
-    # CI tourne sur toutes les branches
+    branches: [main, staging]
   pull_request:
-    # CI tourne sur toutes les PR
 
 jobs:
   filter:
@@ -338,6 +337,9 @@ jobs:
           script: |
             set -e
 
+            # Prune unused Docker images to prevent disk space issues
+            docker image prune -a -f
+
             # Load the new image
             docker load < /tmp/nirby-api.tar.gz
             docker tag nirby-api:${{ github.sha }} nirby-api:latest
@@ -427,6 +429,9 @@ jobs:
           script: |
             set -e
 
+            # Prune unused Docker images to prevent disk space issues
+            docker image prune -a -f
+
             # Load the new image
             docker load < /tmp/nirby-web.tar.gz
             docker tag nirby-web:${{ github.sha }} nirby-web:latest
@@ -493,6 +498,9 @@ jobs:
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
             set -e
+
+            # Prune unused Docker images to prevent disk space issues
+            docker image prune -a -f
 
             # Load the new image
             docker load < /tmp/nirby-api.tar.gz
@@ -582,6 +590,9 @@ jobs:
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
             set -e
+
+            # Prune unused Docker images to prevent disk space issues
+            docker image prune -a -f
 
             # Load the new image
             docker load < /tmp/nirby-web.tar.gz


### PR DESCRIPTION
## 📝 Description

Ajustements du workflow CI/CD : restriction des branches déclenchant le pipeline et ajout du nettoyage des images Docker inutilisées pour limiter l'utilisation disque lors des déploiements.

## 🎯 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI update (no functional changes)
- [ ] ♻️ Code refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update

## 🔗 Related Issues

## 🚀 Changes Made

- Restriction des triggers `push` aux branches `main` et `staging` uniquement (le CI ne tourne plus sur toutes les branches)
- Ajout de `docker image prune -a -f` dans les scripts de déploiement (API et web, staging et production) pour libérer l'espace disque avant le chargement des nouvelles images
- Simplification de la configuration des triggers en supprimant les commentaires superflus

## 🧪 Testing

- [x] Tested locally with `pnpm dev`
- [x] All quality checks pass (`pnpm lint`)
- [ ] Unit tests pass (`pnpm test`)
- [ ] Database migrations applied if needed

## 📸 Screenshots/Videos

N/A

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated if needed
- [x] No console errors or warnings
- [x] Removed any debug code