### PR TITLE
fix(app-shell): fix mobile shell tab navigation

### DIFF
--- a/apps/web/src/features/app-shell/context/shell-context.tsx
+++ b/apps/web/src/features/app-shell/context/shell-context.tsx
@@ -25,10 +25,12 @@ export function ShellProvider({ children }: { children: ReactNode }) {
 
   const setViewAndExitMapMode = useCallback(
     (next: ShellView) => {
+      if (mapMode) {
+        setMapModeState(false);
+      }
       setView(next);
-      setMapMode(false);
     },
-    [setView, setMapMode]
+    [mapMode, setView]
   );
 
   const value = useMemo(

--- a/apps/web/src/lib/navigation/use-url-param-state.ts
+++ b/apps/web/src/lib/navigation/use-url-param-state.ts
@@ -86,12 +86,17 @@ export function useUrlParamState<T>({
 
   const setValueAndPush = useCallback(
     (next: T) => {
-      setValue(next);
       if (isSyncingFromUrl.current) {
         isSyncingFromUrl.current = false;
+        setValue(next);
         return;
       }
 
+      if (Object.is(next, valueRef.current)) {
+        return;
+      }
+
+      setValue(next);
       const qs = buildHref(searchParams, next);
       router.push(`${pathname}${qs}`, { scroll: false });
     },


### PR DESCRIPTION
## 📝 Description

Correction d’un bug sur mobile : les onglets Explorer, Listes et Profil ne changeaient pas au tap, car deux mises à jour d’URL se chevauchaient et la seconde écrasait le changement d’onglet.

## 🎯 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI update (no functional changes)
- [ ] ♻️ Code refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update

## 🔗 Related Issues

## 🚀 Changes Made

- `setViewAndExitMapMode` : un seul `router.push` via `setView` (le param `mapMode` est déjà retiré par le builder de vue) ; mise à jour locale du mode carte uniquement si nécessaire
- `useUrlParamState` : ignore les pushes quand la valeur est inchangée ; ordre corrigé lors d’une sync depuis l’URL

## 🧪 Testing

- [x] Tested locally with `pnpm dev`
- [ ] Preview deploys successfully on AWS Amplify
- [x] All quality checks pass (lint, typecheck, format)
- [ ] Unit tests pass
- [ ] E2E tests pass (if applicable)

## 📸 Screenshots/Videos

N/A

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated if needed
- [x] No console errors or warnings
- [x] Removed any debug code
- [x] Translations added for any new text

---

## 🔗 Preview

Preview-URL: (will be added automatically by deploy:preview job)