### PR TITLE
fix(app-shell): refine map mode exit logic in ShellProvider

### DIFF
--- a/apps/web/src/features/app-shell/context/shell-context.tsx
+++ b/apps/web/src/features/app-shell/context/shell-context.tsx
@@ -25,12 +25,13 @@ export function ShellProvider({ children }: { children: ReactNode }) {
 
   const setViewAndExitMapMode = useCallback(
     (next: ShellView) => {
-      if (mapMode) {
-        setMapModeState(false);
+      if (mapMode && next === view) {
+        setMapMode(false);
+        return;
       }
       setView(next);
     },
-    [mapMode, setView]
+    [mapMode, view, setMapMode, setView]
   );
 
   const value = useMemo(


### PR DESCRIPTION
## 📝 Description

Correction du comportement mobile des onglets du shell : lorsque le bottom sheet est fermé (mode carte), un clic sur l’onglet déjà sélectionné rouvre désormais le shell, comme pour les autres onglets.

## 🎯 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI update (no functional changes)
- [ ] ♻️ Code refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update

## 🔗 Related Issues

## 🚀 Changes Made

- Mise à jour de `setViewAndExitMapMode` dans `ShellProvider` : si le shell est en mode carte et que l’utilisateur reclique le même onglet, appel explicite de `setMapMode(false)` pour mettre à jour l’URL et l’état
- Évite le no-op de `setView` quand la vue est inchangée (early return dans `useUrlParamState`), qui laissait `mapMode=1` dans l’URL et empêchait la réouverture du sheet

## 🧪 Testing

- [x] Tested locally with `pnpm dev`
- [ ] Preview deploys successfully on AWS Amplify
- [x] All quality checks pass (lint, typecheck, format)
- [ ] Unit tests pass
- [ ] E2E tests pass (if applicable)

## 📸 Screenshots/Videos

N/A — vérifier manuellement sur mobile : fermer le shell (mode carte), recliquer l’onglet actif → le sheet doit se rouvrir.

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated if needed
- [x] No console errors or warnings
- [x] Removed any debug code
- [x] Translations added for any new text