### PR TITLE
feat(i18n): add English and French translations for list management

### DIFF
--- a/apps/web/src/lib/i18n/locales/en/lists.json
+++ b/apps/web/src/lib/i18n/locales/en/lists.json
@@ -1,0 +1,62 @@
+{
+  "index": {
+    "title": "Lists",
+    "create": "Create a list",
+    "empty": {
+      "title": "No lists yet",
+      "description": "",
+      "cta": "Create a list"
+    },
+    "search": {
+      "placeholder": "Search lists…",
+      "minLengthHint": ""
+    }
+  },
+  "create": {
+    "title": "New list",
+    "submit": "Create"
+  },
+  "detail": {
+    "title": "List",
+    "back": "Back to lists",
+    "poisComingSoon": "Places coming soon"
+  },
+  "edit": {
+    "title": "Edit list",
+    "readOnly": "You can only view this list",
+    "submit": "Save"
+  },
+  "delete": {
+    "title": "Delete list",
+    "confirm": "Delete this list?",
+    "submit": "Delete"
+  },
+  "fields": {
+    "name": "Name",
+    "description": "Description",
+    "visibility": "Visibility"
+  },
+  "visibility": {
+    "PRIVATE": { "label": "Private" },
+    "SHARED": { "label": "Shared" },
+    "PUBLIC": { "label": "Public" }
+  },
+  "role": {
+    "OWNER": "Owner",
+    "EDITOR": "Editor",
+    "VIEWER": "Viewer",
+    "ADMIN": "Admin"
+  },
+  "createList": {
+    "success": "",
+    "error": ""
+  },
+  "updateList": {
+    "success": "",
+    "error": ""
+  },
+  "deleteList": {
+    "success": "",
+    "error": ""
+  }
+}

--- a/apps/web/src/lib/i18n/locales/fr/lists.json
+++ b/apps/web/src/lib/i18n/locales/fr/lists.json
@@ -1,0 +1,62 @@
+{
+  "index": {
+    "title": "Listes",
+    "create": "Créer une liste",
+    "empty": {
+      "title": "Aucune liste pour l'instant",
+      "description": "",
+      "cta": "Créer une liste"
+    },
+    "search": {
+      "placeholder": "Rechercher une liste…",
+      "minLengthHint": ""
+    }
+  },
+  "create": {
+    "title": "Nouvelle liste",
+    "submit": "Créer"
+  },
+  "detail": {
+    "title": "Liste",
+    "back": "Retour aux listes",
+    "poisComingSoon": "Lieux à venir"
+  },
+  "edit": {
+    "title": "Modifier la liste",
+    "readOnly": "Tu peux seulement consulter cette liste",
+    "submit": "Enregistrer"
+  },
+  "delete": {
+    "title": "Supprimer la liste",
+    "confirm": "Supprimer cette liste ?",
+    "submit": "Supprimer"
+  },
+  "fields": {
+    "name": "Nom",
+    "description": "Description",
+    "visibility": "Visibilité"
+  },
+  "visibility": {
+    "PRIVATE": { "label": "Privée" },
+    "SHARED": { "label": "Partagée" },
+    "PUBLIC": { "label": "Publique" }
+  },
+  "role": {
+    "OWNER": "Propriétaire",
+    "EDITOR": "Éditeur",
+    "VIEWER": "Lecteur",
+    "ADMIN": "Administrateur"
+  },
+  "createList": {
+    "success": "",
+    "error": ""
+  },
+  "updateList": {
+    "success": "",
+    "error": ""
+  },
+  "deleteList": {
+    "success": "",
+    "error": ""
+  }
+}


### PR DESCRIPTION
## 📝 Description

Ajout du namespace i18n `lists` (anglais et français) pour préparer la feature Listes CRUD côté web. Fichiers squelette avec structure alignée sur `profile.json` ; certaines clés (toasts, hints) sont volontairement laissées vides pour complétion dans les tickets UI suivants.

## 🎯 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI update (no functional changes)
- [ ] ♻️ Code refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update

## 🔗 Related Issues

Closes NIR-53

## 🚀 Changes Made

- Ajout de `apps/web/src/lib/i18n/locales/en/lists.json` (squelette EN)
- Ajout de `apps/web/src/lib/i18n/locales/fr/lists.json` (squelette FR, parité des clés)
- Sections prévues : index, création, détail, édition, suppression, champs communs, visibilité (`PRIVATE` / `SHARED` / `PUBLIC`), rôles (`OWNER` / `EDITOR` / `VIEWER` / `ADMIN`), messages create/update/delete (placeholders vides)
- Chargement automatique via `loadMessages` dans `config.ts` (aucune modification de config requise)

## 🧪 Testing

- [x] Tested locally with `pnpm dev`
- [ ] Preview deploys successfully on AWS Amplify
- [x] All quality checks pass (lint, typecheck, format)
- [ ] Unit tests pass
- [ ] E2E tests pass (if applicable)

## 📸 Screenshots/Videos

N/A

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated if needed
- [x] No console errors or warnings
- [x] Removed any debug code
- [x] Translations added for any new text