### PR TITLE
feat(lists): add create list form and shell navigation

### DIFF
--- a/apps/web/src/app/(app)/shell-view.tsx
+++ b/apps/web/src/app/(app)/shell-view.tsx
@@ -3,18 +3,15 @@
 import type { ComponentType } from "react";
 
 import type { ShellView } from "@/features/app-shell";
+import { ListsShellView } from "@/features/lists";
 import { ProfileShellView } from "@/features/profile";
 
 function ExplorePlaceholder() {
   return <p className="py-6 text-sm text-muted-foreground">Explorer — contenu à venir.</p>;
 }
 
-function ListsPlaceholder() {
-  return <p className="py-6 text-sm text-muted-foreground">Listes — contenu à venir.</p>;
-}
-
 export const shellViewComponents: Record<ShellView, ComponentType> = {
   explore: ExplorePlaceholder,
-  lists: ListsPlaceholder,
+  lists: ListsShellView,
   profile: ProfileShellView,
 };

--- a/apps/web/src/components/ui/index.ts
+++ b/apps/web/src/components/ui/index.ts
@@ -11,6 +11,7 @@ export * from "./input";
 export * from "./label";
 export * from "./language-selector";
 export * from "./separator";
+export * from "./select";
 export * from "./sheet";
 export * from "./skeleton";
 export * from "./sonner";

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
+import { Select as SelectPrimitive } from "radix-ui";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Select({ ...props }: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />;
+}
+
+function SelectGroup({ ...props }: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />;
+}
+
+function SelectValue({ ...props }: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />;
+}
+
+function SelectTrigger({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger>) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      className={cn(
+        "flex h-12 w-full min-w-0 items-center justify-between gap-2 rounded-2xl border border-border/50 bg-muted/40 px-4 py-1 text-md shadow-none transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm lg:h-9 lg:text-sm",
+        "focus-visible:border-ring focus-visible:ring-primary/30 focus-visible:ring-[3px]",
+        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+        "data-placeholder:text-muted-foreground *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 *:data-[slot=select-value]:text-left",
+        "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="size-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  );
+}
+
+function SelectContent({
+  className,
+  children,
+  position = "item-aligned",
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-select-content-available-height) min-w-32 origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-2xl border shadow-md",
+          position === "popper" &&
+            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          className
+        )}
+        position={position}
+        align={align}
+        sideOffset={sideOffset}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            "p-1",
+            position === "popper" &&
+              "h-(--radix-select-trigger-height) w-full min-w-(--radix-select-trigger-width) scroll-my-1"
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  );
+}
+
+function SelectLabel({ className, ...props }: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn("px-2 py-1.5 text-sm font-medium text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        className
+      )}
+      {...props}
+    >
+      <span className="absolute right-2 flex size-3.5 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  );
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("bg-border pointer-events-none -mx-1 my-1 h-px", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn("flex cursor-default items-center justify-center py-1", className)}
+      {...props}
+    >
+      <ChevronUpIcon className="size-4" />
+    </SelectPrimitive.ScrollUpButton>
+  );
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn("flex cursor-default items-center justify-center py-1", className)}
+      {...props}
+    >
+      <ChevronDownIcon className="size-4" />
+    </SelectPrimitive.ScrollDownButton>
+  );
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+};

--- a/apps/web/src/features/lists/components/lists-section-layout.tsx
+++ b/apps/web/src/features/lists/components/lists-section-layout.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { ArrowLeft } from "lucide-react";
+import { useTranslations } from "next-intl";
+import type { ReactNode } from "react";
+
+import { Button } from "@/components/ui";
+
+type ListsSubViewHeaderProps = {
+  title: string;
+  description?: string;
+  onBack: () => void;
+};
+
+function ListsSubViewHeader({ title, description, onBack }: ListsSubViewHeaderProps) {
+  const t = useTranslations();
+
+  return (
+    <header className="grid gap-2 pb-2">
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        onClick={onBack}
+        className="-ml-2 w-fit gap-1.5 px-2 text-muted-foreground hover:text-foreground"
+      >
+        <ArrowLeft className="size-4" />
+        {t("common.buttons.back")}
+      </Button>
+      <div>
+        <h2 className="font-display text-lg font-semibold tracking-tight">{title}</h2>
+        {description && <p className="text-sm text-muted-foreground">{description}</p>}
+      </div>
+    </header>
+  );
+}
+
+export type ListsSectionLayoutProps = {
+  title: string;
+  description?: string;
+  onBack: () => void;
+  children: ReactNode;
+};
+
+/**
+ * Standard shell layout for list sub-views (create, detail, …).
+ * Back control + title + body with consistent spacing.
+ */
+export function ListsSectionLayout({
+  title,
+  description,
+  onBack,
+  children,
+}: ListsSectionLayoutProps) {
+  return (
+    <div className="grid gap-4 pb-4">
+      <ListsSubViewHeader title={title} description={description} onBack={onBack} />
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/features/lists/constants/lists.constants.ts
+++ b/apps/web/src/features/lists/constants/lists.constants.ts
@@ -1,0 +1,11 @@
+/** Field limits for list create/update — mirrors POST/PUT /list validation. */
+export const listConstraints = {
+  name: { min: 1, max: 255 },
+  description: { max: 1000 },
+} as const;
+
+export const LIST_VISIBILITY_VALUES = ["PRIVATE", "SHARED", "PUBLIC"] as const;
+
+export type ListVisibility = (typeof LIST_VISIBILITY_VALUES)[number];
+
+export const DEFAULT_LIST_VISIBILITY: ListVisibility = "PRIVATE";

--- a/apps/web/src/features/lists/forms/create-list-form.tsx
+++ b/apps/web/src/features/lists/forms/create-list-form.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import { standardSchemaResolver } from "@hookform/resolvers/standard-schema";
+import { useTranslations } from "next-intl";
+import { useMemo } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+
+import {
+  Button,
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  Input,
+  Separator,
+  Textarea,
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui";
+import {
+  DEFAULT_LIST_VISIBILITY,
+  LIST_VISIBILITY_VALUES,
+  listConstraints,
+  useCreateList,
+} from "@/features/lists";
+import type { ListVisibility } from "@/features/lists/constants/lists.constants";
+import {
+  createListFormSchema,
+  type CreateListFormData,
+} from "@/features/lists/schemas/lists.schema";
+import { useErrorMessage } from "@/hooks/use-error-message";
+import { cn } from "@/lib/utils";
+
+export type CreateListFormProps = {
+  /** Closes the dialog after a successful create. */
+  closeDialog?: () => void;
+  /** Called with the new list id (e.g. navigate to detail). */
+  onCreated?: (listId: string) => void;
+  embedded?: boolean;
+};
+
+export function CreateListForm({ closeDialog, onCreated, embedded = false }: CreateListFormProps) {
+  const tLists = useTranslations("lists");
+  const t = useTranslations();
+  const getErrorMessage = useErrorMessage();
+  const { mutateAsync: createList, isPending } = useCreateList();
+
+  const listFormSchema = useMemo(
+    () =>
+      createListFormSchema({
+        requiredName: tLists("validation.requiredName"),
+        nameTooLong: tLists("validation.nameTooLong"),
+        descriptionTooLong: tLists("validation.descriptionTooLong"),
+      }),
+    [tLists]
+  );
+
+  const form = useForm<CreateListFormData>({
+    resolver: standardSchemaResolver(listFormSchema),
+    defaultValues: {
+      name: "",
+      description: "",
+      visibility: DEFAULT_LIST_VISIBILITY,
+    },
+  });
+
+  async function onSubmit(values: CreateListFormData) {
+    try {
+      const { list } = await createList({
+        name: values.name,
+        description: values.description?.trim() || undefined,
+        visibility: values.visibility,
+      });
+
+      toast.success(tLists("createList.success"));
+      form.reset();
+      closeDialog?.();
+      onCreated?.(list.id);
+    } catch (error) {
+      toast.error(tLists("createList.error"), {
+        description: getErrorMessage(error),
+      });
+    }
+  }
+
+  return (
+    <div className={cn(!embedded && "pt-4")}>
+      <div
+        className={cn(
+          "grid gap-6",
+          !embedded && "py-4 md:py-0 mb-[env(safe-area-inset-bottom,0.5rem)]"
+        )}
+      >
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="grid gap-4">
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel className="text-md lg:text-sm">{tLists("fields.name")}</FormLabel>
+                  <FormControl>
+                    <Input {...field} maxLength={listConstraints.name.max} autoComplete="off" />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel className="text-md lg:text-sm">
+                    {tLists("fields.description")}
+                  </FormLabel>
+                  <FormControl>
+                    <Textarea
+                      {...field}
+                      rows={3}
+                      maxLength={listConstraints.description.max}
+                      className="min-h-22 resize-y"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="visibility"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel className="text-md lg:text-sm">
+                    {tLists("fields.visibility")}
+                  </FormLabel>
+                  <Select
+                    value={field.value}
+                    onValueChange={(value) => field.onChange(value as ListVisibility)}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent className="z-10000">
+                      {LIST_VISIBILITY_VALUES.map((value) => (
+                        <SelectItem key={value} value={value}>
+                          {tLists(`visibility.${value}.label`)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <div
+              className={cn(
+                "flex gap-2 mt-2",
+                embedded ? "flex-col" : "flex-col md:flex-row justify-end"
+              )}
+            >
+              {!embedded && closeDialog && (
+                <Button variant="outline" type="button" onClick={closeDialog}>
+                  {t("common.buttons.cancel")}
+                </Button>
+              )}
+              <Button
+                type="submit"
+                disabled={isPending}
+                loading={isPending}
+                className={cn(embedded && "w-full")}
+              >
+                {tLists("create.submit")}
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/lists/index.ts
+++ b/apps/web/src/features/lists/index.ts
@@ -3,7 +3,17 @@ export { useList } from "./hooks/use-list";
 export { useCreateList } from "./hooks/use-create-list";
 export { useUpdateList } from "./hooks/use-update-list";
 export { useDeleteList } from "./hooks/use-delete-list";
+export { createListFormSchema } from "./schemas/lists.schema";
+export {
+  listConstraints,
+  LIST_VISIBILITY_VALUES,
+  DEFAULT_LIST_VISIBILITY,
+} from "./constants/lists.constants";
+export { ListsShellView } from "./navigation/lists-shell-view";
+export { CreateListForm } from "./forms/create-list-form";
 
 export type { ListFilters } from "./hooks/use-lists";
 export type { CreateListInput } from "./hooks/use-create-list";
 export type { UpdateListInput } from "./hooks/use-update-list";
+export type { CreateListFormMessages, CreateListFormData } from "./schemas/lists.schema";
+export type { ListVisibility } from "./constants/lists.constants";

--- a/apps/web/src/features/lists/navigation/lists-shell-view.tsx
+++ b/apps/web/src/features/lists/navigation/lists-shell-view.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useState } from "react";
+
+import type { ListsSection } from "../types/lists-section.types";
+import { DEFAULT_LISTS_SECTION } from "../types/lists-section.types";
+import { ListsCreateView } from "../views/lists-create-view";
+import { ListsIndexView } from "../views/lists-index-view";
+
+export function ListsShellView() {
+  const [section, setSection] = useState<ListsSection>(DEFAULT_LISTS_SECTION);
+
+  const goIndex = () => setSection("index");
+  const goCreate = () => setSection("create");
+
+  switch (section) {
+    case "create":
+      return <ListsCreateView onBack={goIndex} />;
+    case "index":
+    default:
+      return <ListsIndexView onCreate={goCreate} />;
+  }
+}

--- a/apps/web/src/features/lists/schemas/lists.schema.test.ts
+++ b/apps/web/src/features/lists/schemas/lists.schema.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+
+import { listConstraints } from "../constants/lists.constants";
+
+import { createListFormSchema } from "./lists.schema";
+
+const messages = {
+  requiredName: "required",
+  nameTooLong: "too long",
+  descriptionTooLong: "desc too long",
+};
+
+function schema() {
+  return createListFormSchema(messages);
+}
+
+describe("createListFormSchema", () => {
+  it("accepts valid input", () => {
+    const result = schema().safeParse({
+      name: "My list",
+      description: "Optional",
+      visibility: "PRIVATE",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects empty name", () => {
+    const result = schema().safeParse({
+      name: "",
+      visibility: "PRIVATE",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects name longer than max", () => {
+    const result = schema().safeParse({
+      name: "a".repeat(listConstraints.name.max + 1),
+      visibility: "PRIVATE",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects description longer than max", () => {
+    const result = schema().safeParse({
+      name: "OK",
+      description: "a".repeat(listConstraints.description.max + 1),
+      visibility: "PRIVATE",
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/web/src/features/lists/schemas/lists.schema.ts
+++ b/apps/web/src/features/lists/schemas/lists.schema.ts
@@ -1,0 +1,34 @@
+import * as z from "zod";
+
+import {
+  DEFAULT_LIST_VISIBILITY,
+  LIST_VISIBILITY_VALUES,
+  listConstraints,
+} from "../constants/lists.constants";
+
+const listVisibility = z.enum(LIST_VISIBILITY_VALUES);
+
+export interface CreateListFormMessages {
+  requiredName: string;
+  nameTooLong: string;
+  descriptionTooLong: string;
+}
+
+export function createListFormSchema(messages: CreateListFormMessages) {
+  const { name, description } = listConstraints;
+
+  return z.object({
+    name: z
+      .string()
+      .trim()
+      .min(name.min, { message: messages.requiredName })
+      .max(name.max, { message: messages.nameTooLong }),
+    description: z
+      .string()
+      .max(description.max, { message: messages.descriptionTooLong })
+      .optional(),
+    visibility: listVisibility,
+  });
+}
+
+export type CreateListFormData = z.infer<ReturnType<typeof createListFormSchema>>;

--- a/apps/web/src/features/lists/types/lists-section.types.ts
+++ b/apps/web/src/features/lists/types/lists-section.types.ts
@@ -1,0 +1,3 @@
+export type ListsSection = "index" | "create";
+
+export const DEFAULT_LISTS_SECTION: ListsSection = "index";

--- a/apps/web/src/features/lists/views/lists-create-view.tsx
+++ b/apps/web/src/features/lists/views/lists-create-view.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+
+import { ListsSectionLayout } from "../components/lists-section-layout";
+import { CreateListForm } from "../forms/create-list-form";
+
+type ListsCreateViewProps = {
+  onBack: () => void;
+};
+
+export function ListsCreateView({ onBack }: ListsCreateViewProps) {
+  const tLists = useTranslations("lists");
+
+  return (
+    <ListsSectionLayout title={tLists("create.title")} onBack={onBack}>
+      <CreateListForm embedded closeDialog={onBack} onCreated={() => onBack()} />
+    </ListsSectionLayout>
+  );
+}

--- a/apps/web/src/features/lists/views/lists-index-view.tsx
+++ b/apps/web/src/features/lists/views/lists-index-view.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+
+import { Button } from "@/components/ui";
+
+type ListsIndexViewProps = {
+  onCreate: () => void;
+};
+
+export function ListsIndexView({ onCreate }: ListsIndexViewProps) {
+  const tLists = useTranslations("lists");
+
+  return (
+    <div className="grid gap-4 pb-4">
+      <header className="flex items-center justify-between gap-3">
+        <h2 className="font-display text-lg font-semibold tracking-tight">
+          {tLists("index.title")}
+        </h2>
+        <Button type="button" size="sm" onClick={onCreate}>
+          {tLists("index.create")}
+        </Button>
+      </header>
+
+      {/* Temporaire jusqu’à NIR-55 : empty state ou liste useLists() */}
+      <p className="text-sm text-muted-foreground">{tLists("index.empty.title")}</p>
+    </div>
+  );
+}

--- a/apps/web/src/lib/i18n/locales/en/errors.json
+++ b/apps/web/src/lib/i18n/locales/en/errors.json
@@ -39,7 +39,7 @@
     "LIST_NOT_FOUND": "List not found",
     "LIST_NAME_REQUIRED": "List name is required",
     "LIST_NAME_TOO_LONG": "List name cannot contain more than 255 characters",
-    "LIST_DESCRIPTION_TOO_LONG": "List description cannot contain more than 255 characters",
+    "LIST_DESCRIPTION_TOO_LONG": "List description cannot contain more than 1000 characters",
     "LIST_ACCESS_DENIED": "You are not authorized to access this list",
     "LIST_EDIT_TOKEN_INVALID": "List edit token is invalid",
     "LIST_EDIT_TOKEN_EXPIRED": "List edit token has expired",

--- a/apps/web/src/lib/i18n/locales/en/lists.json
+++ b/apps/web/src/lib/i18n/locales/en/lists.json
@@ -48,8 +48,8 @@
     "ADMIN": "Admin"
   },
   "createList": {
-    "success": "",
-    "error": ""
+    "success": "List created successfully",
+    "error": "Could not create the list"
   },
   "updateList": {
     "success": "",
@@ -58,5 +58,10 @@
   "deleteList": {
     "success": "",
     "error": ""
+  },
+  "validation": {
+    "requiredName": "List name is required",
+    "nameTooLong": "List name cannot be longer than 255 characters",
+    "descriptionTooLong": "Description cannot be longer than 1000 characters"
   }
 }

--- a/apps/web/src/lib/i18n/locales/fr/errors.json
+++ b/apps/web/src/lib/i18n/locales/fr/errors.json
@@ -38,7 +38,7 @@
     "LIST_NOT_FOUND": "La liste n'a pas été trouvée",
     "LIST_NAME_REQUIRED": "Le nom de la liste est requis",
     "LIST_NAME_TOO_LONG": "Le nom de la liste ne peut pas contenir plus de 255 caractères",
-    "LIST_DESCRIPTION_TOO_LONG": "La description de la liste ne peut pas contenir plus de 255 caractères",
+    "LIST_DESCRIPTION_TOO_LONG": "La description de la liste ne peut pas contenir plus de 1000 caractères",
     "LIST_ACCESS_DENIED": "Vous n'avez pas accès à cette liste",
     "LIST_EDIT_TOKEN_INVALID": "Le token d'édition de la liste est invalide",
     "LIST_EDIT_TOKEN_EXPIRED": "Le token d'édition de la liste a expiré",

--- a/apps/web/src/lib/i18n/locales/fr/lists.json
+++ b/apps/web/src/lib/i18n/locales/fr/lists.json
@@ -48,8 +48,8 @@
     "ADMIN": "Administrateur"
   },
   "createList": {
-    "success": "",
-    "error": ""
+    "success": "Liste créée avec succès",
+    "error": "Impossible de créer la liste"
   },
   "updateList": {
     "success": "",
@@ -58,5 +58,10 @@
   "deleteList": {
     "success": "",
     "error": ""
+  },
+  "validation": {
+    "requiredName": "Le nom de la liste est requis",
+    "nameTooLong": "Le nom ne peut pas dépasser 255 caractères",
+    "descriptionTooLong": "La description ne peut pas dépasser 1000 caractères"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9295,6 +9295,7 @@ packages:
       {
         integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==,
       }
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   valibot@1.2.0:
@@ -12702,7 +12703,7 @@ snapshots:
       magicast: 0.5.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.13(@types/node@22.19.1)(@vitest/ui@4.0.13)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.1)
+      vitest: 4.0.13(@types/node@20.19.29)(@vitest/ui@4.0.13)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -12757,7 +12758,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vitest: 4.0.13(@types/node@22.19.1)(@vitest/ui@4.0.13)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.1)
+      vitest: 4.0.13(@types/node@20.19.29)(@vitest/ui@4.0.13)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.1)
 
   "@vitest/utils@4.0.13":
     dependencies:
@@ -13539,7 +13540,7 @@ snapshots:
       "@next/eslint-plugin-next": 16.1.2
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.1(jiti@2.6.1))
@@ -13566,7 +13567,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       "@nolyfill/is-core-module": 1.0.39
       debug: 4.4.3
@@ -13581,14 +13582,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       "@typescript-eslint/parser": 8.46.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -13603,7 +13604,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
## 📝 Description

Implémentation du flux de **création de liste** côté web (NIR-54) : validation Zod alignée sur l’API, formulaire react-hook-form, soumission via `useCreateList`, toasts succès/erreur, et navigation index → sous-vue création dans l’onglet Listes du shell.

## 🎯 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI update (no functional changes)
- [ ] ♻️ Code refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [x] ✅ Test update

## 🔗 Related Issues

- NIR-54 — Listes — Création d'une liste
- Dépend de la couche data (NIR-52 / #82) et i18n listes (NIR-53 / #83), déjà présentes sur la branche

## 🚀 Changes Made

- Ajout du schéma Zod `createListFormSchema` et des constantes (`listConstraints`, visibilités)
- Création de `CreateListForm` (nom, description, visibilité, `useCreateList`, toasts)
- Navigation shell : `ListsShellView` (index avec bouton création → sous-vue `ListsCreateView`)
- Layout sous-vue `ListsSectionLayout` (retour + titre)
- Intégration dans `shell-view.tsx` à la place du placeholder Listes
- Composant UI `Select` (shadcn) pour le champ visibilité
- Tests unitaires `lists.schema.test.ts`
- i18n : clés `validation` et toasts `createList` ; correction `LIST_DESCRIPTION_TOO_LONG` (1000 car.)

## 🧪 Testing

- [x] Tested locally with `pnpm dev`
- [x] All quality checks pass (`pnpm lint`)
- [x] Unit tests pass (`pnpm test` — `lists.schema`)
- [ ] Database migrations applied if needed

## 📸 Screenshots/Videos

Recommandé : capture de l’onglet Listes (index + bouton création) et de la sous-vue « Nouvelle liste » avec le formulaire soumis avec succès (toast).

N/A si non fourni.

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated if needed
- [x] No console errors or warnings
- [x] Removed any debug code
- [x] Translations added for any new text

---

## 🔗 Preview

Preview-URL: (will be added automatically by deploy:preview job)