### PR TITLE
feat(lists): implement lists index view with infinite scroll

### DIFF
--- a/apps/api/src/list/routes.ts
+++ b/apps/api/src/list/routes.ts
@@ -269,6 +269,12 @@ listRouter.get("/", requireAuth, async (req, res) => {
             where: { userId },
             select: { role: true },
           },
+          _count: {
+            select: {
+              savedPois: true,
+              collaborators: true,
+            },
+          },
         },
         orderBy: { createdAt: "desc" },
         skip,
@@ -286,11 +292,13 @@ listRouter.get("/", requireAuth, async (req, res) => {
     ]);
 
     const listsWithRole = lists.map((list) => {
-      const { collaborators, ...rest } = list;
+      const { collaborators, _count, ...rest } = list;
 
       return {
         ...rest,
         role: list.createdBy === userId ? "OWNER" : collaborators[0]?.role,
+        poiCount: _count.savedPois,
+        collaboratorCount: _count.collaborators,
       };
     });
 

--- a/apps/api/src/swagger/schemas/list.schema.ts
+++ b/apps/api/src/swagger/schemas/list.schema.ts
@@ -24,6 +24,8 @@ export const listSchemas = {
         nullable: true,
         description: "The date and time the edit token expires",
       },
+      poiCount: { type: "number" },
+      collaboratorCount: { type: "number" },
     },
     required: [
       "id",

--- a/apps/web/src/components/ui/item.tsx
+++ b/apps/web/src/components/ui/item.tsx
@@ -28,7 +28,7 @@ function ItemSeparator({ className, ...props }: React.ComponentProps<typeof Sepa
 }
 
 const itemVariants = cva(
-  "group/item flex items-center border border-transparent text-sm rounded-md transition-colors [a]:hover:bg-accent/50 [a]:transition-colors duration-100 flex-wrap outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+  "group/item flex flex-wrap items-center rounded-md border border-transparent text-sm transition-colors duration-100 outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 [a]:transition-colors [a]:hover:bg-accent/50",
   {
     variants: {
       variant: {
@@ -37,8 +37,8 @@ const itemVariants = cva(
         muted: "bg-muted/50",
       },
       size: {
-        default: "p-4 gap-4 ",
-        sm: "py-3 px-4 gap-2.5",
+        default: "gap-4 p-4",
+        sm: "gap-2.5 px-4 py-3",
       },
     },
     defaultVariants: {
@@ -68,13 +68,13 @@ function Item({
 }
 
 const itemMediaVariants = cva(
-  "flex shrink-0 items-center justify-center gap-2 group-has-[[data-slot=item-description]]/item:self-start [&_svg]:pointer-events-none group-has-[[data-slot=item-description]]/item:translate-y-0.5",
+  "flex shrink-0 items-center justify-center gap-2 group-has-[[data-slot=item-description]]/item:translate-y-0.5 group-has-[[data-slot=item-description]]/item:self-start [&_svg]:pointer-events-none",
   {
     variants: {
       variant: {
         default: "bg-transparent",
-        icon: "size-8 border rounded-sm bg-muted [&_svg:not([class*='size-'])]:size-4",
-        image: "size-10 rounded-sm overflow-hidden [&_img]:size-full [&_img]:object-cover",
+        icon: "size-8 rounded-sm border bg-muted [&_svg:not([class*='size-'])]:size-4",
+        image: "size-10 overflow-hidden rounded-sm [&_img]:size-full [&_img]:object-cover",
       },
     },
     defaultVariants: {
@@ -123,8 +123,8 @@ function ItemDescription({ className, ...props }: React.ComponentProps<"p">) {
     <p
       data-slot="item-description"
       className={cn(
-        "text-muted-foreground line-clamp-2 text-sm leading-normal font-normal text-balance",
-        "[&>a:hover]:text-primary [&>a]:underline [&>a]:underline-offset-4",
+        "line-clamp-2 text-sm leading-normal font-normal text-balance text-muted-foreground",
+        "[&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
         className
       )}
       {...props}

--- a/apps/web/src/features/auth/provider.tsx
+++ b/apps/web/src/features/auth/provider.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useQueryClient } from "@tanstack/react-query";
 import { useState, useEffect, useCallback } from "react";
 
 import { AuthContext, type AuthContextType } from "@/features/auth";
@@ -21,6 +22,7 @@ import { setAccessToken, setRefreshTokenFn } from "@/lib/api/client";
 import type { User } from "@/lib/api/generated";
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const queryClient = useQueryClient();
   const [user, setUser] = useState<User | null>(null);
   const [accessToken, setAccessTokenState] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -209,8 +211,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     } finally {
       updateToken(null);
       setUser(null);
+      queryClient.clear();
     }
-  }, [updateToken]);
+  }, [updateToken, queryClient]);
 
   useEffect(() => {
     const init = async () => {

--- a/apps/web/src/features/lists/components/list-row.tsx
+++ b/apps/web/src/features/lists/components/list-row.tsx
@@ -1,0 +1,65 @@
+import { GlobeIcon, LockIcon, MapPinIcon, UsersIcon } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+import { Badge } from "@/components";
+import { ListWithRole } from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+type ListRowProps = {
+  list: ListWithRole;
+  onClick: () => void;
+};
+
+export function ListRow({ list, onClick }: ListRowProps) {
+  const tRow = useTranslations("lists.row");
+  const tLists = useTranslations("lists");
+
+  const poiCount = list.poiCount ?? 0;
+  const collaboratorCount = list.collaboratorCount ?? 0;
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "group w-full min-w-0 rounded-md border border-border text-left",
+        "cursor-pointer transition-[box-shadow,transform,border-color,scale] duration-200",
+        "hover:border-foreground/15 hover:shadow-md hover:shadow-black/5 hover:scale-[1.03]",
+        "active:scale-[0.99] active:shadow-sm",
+        "focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
+      )}
+    >
+      <div className="rounded-t-md p-4 bg-linear-to-br from-[#EA580C] via-primary to-amber-500 transition-[filter] duration-200 group-hover:brightness-105">
+        <h3 className="line-clamp-1 min-w-0 wrap-break-words text-md font-bold text-white font-display">
+          {list.name}
+        </h3>
+
+        <p className="line-clamp-2 min-w-0 wrap-break-words text-sm text-white/80 font-semibold font-display">
+          {list.description}
+        </p>
+      </div>
+      <div className="px-4 py-2 flex items-center justify-between gap-2 transition-colors group-hover:bg-muted/30">
+        <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-4 gap-y-1">
+          <span className="flex items-center gap-1">
+            <MapPinIcon className="size-3 shrink-0 text-muted-foreground" />
+            <p className="text-xs text-muted-foreground">{tRow("poiCount", { count: poiCount })}</p>
+          </span>
+          {collaboratorCount > 0 && (
+            <span className="flex items-center gap-1">
+              <UsersIcon className="size-3 shrink-0 text-muted-foreground" />
+              <p className="text-xs text-muted-foreground">
+                {tRow("collaboratorCount", { count: collaboratorCount })}
+              </p>
+            </span>
+          )}
+        </div>
+        <Badge variant="outline" className="shrink-0 text-muted-foreground">
+          {list.visibility === "PRIVATE" && <LockIcon />}
+          {list.visibility === "SHARED" && <UsersIcon />}
+          {list.visibility === "PUBLIC" && <GlobeIcon />}
+          {tLists(`visibility.${list.visibility}.label`)}
+        </Badge>
+      </div>
+    </button>
+  );
+}

--- a/apps/web/src/features/lists/components/lists-index-empty.tsx
+++ b/apps/web/src/features/lists/components/lists-index-empty.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { ListPlusIcon, PlusIcon } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+import { Button } from "@/components/ui";
+
+type ListsIndexEmptyProps = {
+  onCreate: () => void;
+};
+
+export function ListsIndexEmpty({ onCreate }: ListsIndexEmptyProps) {
+  const tLists = useTranslations("lists");
+  const description = tLists("index.empty.description");
+
+  return (
+    <div className="flex flex-col items-center gap-4 py-10 text-center">
+      <span className="grid size-12 place-items-center rounded-full bg-primary/10 text-primary">
+        <ListPlusIcon className="size-6" aria-hidden />
+      </span>
+      <div className="grid max-w-sm gap-1">
+        <h3 className="font-display text-base font-semibold tracking-tight">
+          {tLists("index.empty.title")}
+        </h3>
+        {description ? <p className="text-sm text-muted-foreground">{description}</p> : null}
+      </div>
+      <Button type="button" size="sm" onClick={onCreate}>
+        <PlusIcon />
+        {tLists("index.empty.cta")}
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/features/lists/components/lists-index-error.tsx
+++ b/apps/web/src/features/lists/components/lists-index-error.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { OctagonXIcon } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+import { Button } from "@/components/ui";
+
+type ListsIndexErrorProps = {
+  message: string;
+  onRetry: () => void;
+};
+
+export function ListsIndexError({ message, onRetry }: ListsIndexErrorProps) {
+  const tLists = useTranslations("lists");
+
+  return (
+    <div className="flex flex-col items-center gap-4 py-10 text-center" role="alert">
+      <span className="grid size-12 place-items-center rounded-full bg-destructive/10 text-destructive">
+        <OctagonXIcon className="size-6" aria-hidden />
+      </span>
+      <div className="grid max-w-sm gap-1">
+        <h3 className="font-display text-base font-semibold tracking-tight">
+          {tLists("index.error.title")}
+        </h3>
+        <p className="text-sm text-muted-foreground">{message}</p>
+      </div>
+      <Button type="button" variant="outline" size="sm" onClick={onRetry}>
+        {tLists("index.error.retry")}
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/features/lists/components/lists-index-skeleton.tsx
+++ b/apps/web/src/features/lists/components/lists-index-skeleton.tsx
@@ -1,0 +1,17 @@
+import { Skeleton } from "@/components/ui";
+
+export function ListsIndexSkeleton() {
+  return (
+    <div className="flex flex-col gap-3" aria-busy="true" aria-label="Loading lists">
+      {Array.from({ length: 3 }).map((_, i) => (
+        <div key={i} className="rounded-md border border-border overflow-hidden">
+          <Skeleton className="h-20 w-full rounded-none" />
+          <div className="flex gap-4 px-4 py-2">
+            <Skeleton className="h-3 w-24" />
+            <Skeleton className="h-3 w-20" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/features/lists/hooks/use-infinite-scroll.ts
+++ b/apps/web/src/features/lists/hooks/use-infinite-scroll.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+type UseInfiniteScrollOptions = {
+  enabled?: boolean;
+  rootMargin?: string;
+};
+
+export function useInfiniteScroll(
+  onLoadMore: () => void,
+  { enabled = true, rootMargin = "200px" }: UseInfiniteScrollOptions = {}
+) {
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  const onLoadMoreRef = useRef(onLoadMore);
+
+  useEffect(() => {
+    onLoadMoreRef.current = onLoadMore;
+  });
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const el = sentinelRef.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) {
+          onLoadMoreRef.current();
+        }
+      },
+      { rootMargin }
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [enabled, rootMargin]);
+
+  return sentinelRef;
+}

--- a/apps/web/src/features/lists/hooks/use-list.ts
+++ b/apps/web/src/features/lists/hooks/use-list.ts
@@ -2,6 +2,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 
+import { useAuth } from "@/features/auth";
 import { getListById } from "@/lib/api";
 import { queryKeys } from "@/lib/api/query-keys";
 
@@ -12,9 +13,11 @@ import { queryKeys } from "@/lib/api/query-keys";
  * API errors are thrown so they can be handled with {@link useErrorMessage}.
  */
 export function useList(listId: string | undefined) {
+  const { user } = useAuth();
+
   return useQuery({
     queryKey: queryKeys.lists.detail(listId ?? ""),
-    enabled: Boolean(listId),
+    enabled: Boolean(listId && user),
     queryFn: async () => {
       if (!listId) {
         throw new Error("listID is required");

--- a/apps/web/src/features/lists/hooks/use-lists-infinite.ts
+++ b/apps/web/src/features/lists/hooks/use-lists-infinite.ts
@@ -1,0 +1,47 @@
+"use client";
+
+import { useInfiniteQuery } from "@tanstack/react-query";
+
+import { useAuth } from "@/features/auth";
+import type { GetListsData } from "@/lib/api";
+import { getLists } from "@/lib/api";
+import { queryKeys } from "@/lib/api/query-keys";
+
+export type ListsInfiniteFilters = Omit<NonNullable<GetListsData["query"]>, "page">;
+
+export const LISTS_PAGE_SIZE = 20;
+
+async function fetchListsPage(filters: ListsInfiniteFilters | undefined, page: number) {
+  const response = await getLists({
+    query: {
+      ...filters,
+      page,
+      limit: filters?.limit ?? LISTS_PAGE_SIZE,
+    },
+  });
+
+  if (response.data) {
+    return response.data;
+  }
+
+  throw response.error;
+}
+
+/**
+ * Paginated lists for infinite scroll (GET /list).
+ * API errors are thrown for {@link useErrorMessage}.
+ */
+export function useListsInfinite(filters?: ListsInfiniteFilters) {
+  const { user } = useAuth();
+
+  return useInfiniteQuery({
+    queryKey: queryKeys.lists.infinite(filters),
+    enabled: Boolean(user),
+    initialPageParam: 1,
+    queryFn: ({ pageParam }) => fetchListsPage(filters, pageParam),
+    getNextPageParam: (lastPage) => {
+      const { page, totalPages } = lastPage.pagination;
+      return page < totalPages ? page + 1 : undefined;
+    },
+  });
+}

--- a/apps/web/src/features/lists/hooks/use-lists.ts
+++ b/apps/web/src/features/lists/hooks/use-lists.ts
@@ -2,6 +2,7 @@
 
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 
+import { useAuth } from "@/features/auth";
 import { getLists } from "@/lib/api";
 import type { GetListsData } from "@/lib/api";
 import { queryKeys } from "@/lib/api/query-keys";
@@ -16,8 +17,11 @@ export type ListFilters = GetListsData["query"];
  * Uses `keepPreviousData` to avoid empty UI flashes when paginating.
  */
 export function useLists(filters?: ListFilters) {
+  const { user } = useAuth();
+
   return useQuery({
     queryKey: queryKeys.lists.list(filters),
+    enabled: Boolean(user),
     queryFn: async () => {
       const response = await getLists({ query: filters });
 

--- a/apps/web/src/features/lists/index.ts
+++ b/apps/web/src/features/lists/index.ts
@@ -1,4 +1,5 @@
 export { useLists } from "./hooks/use-lists";
+export { useListsInfinite, LISTS_PAGE_SIZE } from "./hooks/use-lists-infinite";
 export { useList } from "./hooks/use-list";
 export { useCreateList } from "./hooks/use-create-list";
 export { useUpdateList } from "./hooks/use-update-list";
@@ -13,6 +14,7 @@ export { ListsShellView } from "./navigation/lists-shell-view";
 export { CreateListForm } from "./forms/create-list-form";
 
 export type { ListFilters } from "./hooks/use-lists";
+export type { ListsInfiniteFilters } from "./hooks/use-lists-infinite";
 export type { CreateListInput } from "./hooks/use-create-list";
 export type { UpdateListInput } from "./hooks/use-update-list";
 export type { CreateListFormMessages, CreateListFormData } from "./schemas/lists.schema";

--- a/apps/web/src/features/lists/navigation/lists-shell-view.tsx
+++ b/apps/web/src/features/lists/navigation/lists-shell-view.tsx
@@ -5,19 +5,33 @@ import { useState } from "react";
 import type { ListsSection } from "../types/lists-section.types";
 import { DEFAULT_LISTS_SECTION } from "../types/lists-section.types";
 import { ListsCreateView } from "../views/lists-create-view";
+import { ListsDetailView } from "../views/lists-detail-view";
 import { ListsIndexView } from "../views/lists-index-view";
 
 export function ListsShellView() {
   const [section, setSection] = useState<ListsSection>(DEFAULT_LISTS_SECTION);
+  const [selectedListId, setSelectedListId] = useState<string | null>(null);
 
-  const goIndex = () => setSection("index");
+  const goIndex = () => {
+    setSelectedListId(null);
+    setSection("index");
+  };
+
   const goCreate = () => setSection("create");
 
+  const goDetail = (listId: string) => {
+    setSelectedListId(listId);
+    setSection("detail");
+  };
+
   switch (section) {
+    case "detail":
+      if (!selectedListId) return <ListsIndexView onCreate={goCreate} onSelectList={goDetail} />;
+      return <ListsDetailView listId={selectedListId} onBack={goIndex} />;
     case "create":
       return <ListsCreateView onBack={goIndex} />;
     case "index":
     default:
-      return <ListsIndexView onCreate={goCreate} />;
+      return <ListsIndexView onCreate={goCreate} onSelectList={goDetail} />;
   }
 }

--- a/apps/web/src/features/lists/types/lists-section.types.ts
+++ b/apps/web/src/features/lists/types/lists-section.types.ts
@@ -1,3 +1,3 @@
-export type ListsSection = "index" | "create";
+export type ListsSection = "index" | "create" | "detail";
 
 export const DEFAULT_LISTS_SECTION: ListsSection = "index";

--- a/apps/web/src/features/lists/views/lists-detail-view.tsx
+++ b/apps/web/src/features/lists/views/lists-detail-view.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+
+import { ListsSectionLayout } from "../components/lists-section-layout";
+import { useList } from "../hooks/use-list";
+
+type ListsDetailViewProps = {
+  listId: string;
+  onBack: () => void;
+};
+
+export function ListsDetailView({ listId, onBack }: ListsDetailViewProps) {
+  const tLists = useTranslations("lists");
+  const { data, isPending } = useList(listId);
+
+  return (
+    <ListsSectionLayout title={data?.list.name ?? tLists("detail.title")} onBack={onBack}>
+      {isPending ? (
+        <p className="text-sm text-muted-foreground">{tLists("detail.loading")}</p>
+      ) : (
+        <p className="text-sm text-muted-foreground"> {tLists("detail.poisComingSoon")}</p>
+      )}
+    </ListsSectionLayout>
+  );
+}

--- a/apps/web/src/features/lists/views/lists-index-view.test.tsx
+++ b/apps/web/src/features/lists/views/lists-index-view.test.tsx
@@ -1,0 +1,171 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useListsInfinite } from "../hooks/use-lists-infinite";
+
+import { ListsIndexView } from "./lists-index-view";
+
+import type { ListWithRole } from "@/lib/api";
+
+vi.mock("../hooks/use-lists-infinite", () => ({
+  useListsInfinite: vi.fn(),
+}));
+
+vi.mock("../hooks/use-infinite-scroll", () => ({
+  useInfiniteScroll: () => ({ current: null }),
+}));
+
+vi.mock("@/hooks/use-error-message", () => ({
+  useErrorMessage: () => () => "API error message",
+}));
+
+const mockList: ListWithRole = {
+  id: "list-1",
+  name: "Paris spots",
+  description: "My favorite places",
+  visibility: "PRIVATE",
+  role: "OWNER",
+  createdAt: "2024-01-01T00:00:00.000Z",
+  updatedAt: "2024-01-01T00:00:00.000Z",
+  createdBy: "user-1",
+  imageUrl: null,
+  shareToken: null,
+  shareTokenExpiresAt: null,
+  editToken: null,
+  editTokenExpiresAt: null,
+  poiCount: 3,
+  collaboratorCount: 0,
+};
+
+const mockList2: ListWithRole = {
+  ...mockList,
+  id: "list-2",
+  name: "Lyon food",
+  description: "Restaurants",
+};
+
+function mockInfiniteQuery(overrides: Partial<ReturnType<typeof useListsInfinite>> = {}) {
+  vi.mocked(useListsInfinite).mockReturnValue({
+    data: {
+      pages: [
+        {
+          lists: [],
+          pagination: { page: 1, limit: 20, total: 0, totalPages: 0 },
+        },
+      ],
+    },
+    isPending: false,
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+    isFetching: false,
+    isFetchingNextPage: false,
+    hasNextPage: false,
+    fetchNextPage: vi.fn(),
+    ...overrides,
+  } as ReturnType<typeof useListsInfinite>);
+}
+
+describe("ListsIndexView", () => {
+  const onCreate = vi.fn();
+  const onSelectList = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows loading skeleton on initial load", () => {
+    mockInfiniteQuery({
+      data: undefined,
+      isPending: true,
+      isLoading: true,
+    });
+
+    render(<ListsIndexView onCreate={onCreate} onSelectList={onSelectList} />);
+
+    expect(screen.getByLabelText("Loading lists")).toBeInTheDocument();
+  });
+
+  it("shows empty state when there are no lists", () => {
+    mockInfiniteQuery();
+
+    render(<ListsIndexView onCreate={onCreate} onSelectList={onSelectList} />);
+
+    expect(screen.getByText("index.empty.title")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /index\.empty\.cta/i })).toBeInTheDocument();
+  });
+
+  it("calls onCreate from empty state CTA", async () => {
+    const user = userEvent.setup();
+    mockInfiniteQuery();
+
+    render(<ListsIndexView onCreate={onCreate} onSelectList={onSelectList} />);
+
+    await user.click(screen.getByRole("button", { name: /index\.empty\.cta/i }));
+
+    expect(onCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows error state with retry", async () => {
+    const user = userEvent.setup();
+    const refetch = vi.fn();
+    mockInfiniteQuery({
+      data: undefined,
+      isError: true,
+      error: new Error("fail"),
+      refetch,
+    });
+
+    render(<ListsIndexView onCreate={onCreate} onSelectList={onSelectList} />);
+
+    expect(screen.getByText("index.error.title")).toBeInTheDocument();
+    expect(screen.getByText("API error message")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "index.error.retry" }));
+
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders list rows when data is available", () => {
+    mockInfiniteQuery({
+      data: {
+        pageParams: [1],
+        pages: [
+          {
+            lists: [mockList, mockList2],
+            pagination: { page: 1, limit: 20, total: 2, totalPages: 1 },
+          },
+        ],
+      },
+    });
+
+    render(<ListsIndexView onCreate={onCreate} onSelectList={onSelectList} />);
+
+    expect(screen.getByText("Paris spots")).toBeInTheDocument();
+    expect(screen.getByText("Lyon food")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /index\.create/i })).toBeInTheDocument();
+  });
+
+  it("calls onSelectList when a row is clicked", async () => {
+    const user = userEvent.setup();
+    mockInfiniteQuery({
+      data: {
+        pageParams: [1],
+        pages: [
+          {
+            lists: [mockList],
+            pagination: { page: 1, limit: 20, total: 1, totalPages: 1 },
+          },
+        ],
+      },
+    });
+
+    render(<ListsIndexView onCreate={onCreate} onSelectList={onSelectList} />);
+
+    await user.click(screen.getByRole("button", { name: /Paris spots/i }));
+
+    expect(onSelectList).toHaveBeenCalledWith("list-1");
+  });
+});

--- a/apps/web/src/features/lists/views/lists-index-view.tsx
+++ b/apps/web/src/features/lists/views/lists-index-view.tsx
@@ -1,29 +1,115 @@
 "use client";
 
+import { Loader2Icon, PlusIcon } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { useCallback } from "react";
+
+import { ListRow } from "../components/list-row";
+import { ListsIndexEmpty } from "../components/lists-index-empty";
+import { ListsIndexError } from "../components/lists-index-error";
+import { ListsIndexSkeleton } from "../components/lists-index-skeleton";
 
 import { Button } from "@/components/ui";
+import { useInfiniteScroll } from "@/features/lists/hooks/use-infinite-scroll";
+import { useListsInfinite } from "@/features/lists/hooks/use-lists-infinite";
+import { useErrorMessage } from "@/hooks/use-error-message";
+import type { ListWithRole } from "@/lib/api";
 
 type ListsIndexViewProps = {
   onCreate: () => void;
+  onSelectList: (listId: string) => void;
 };
 
-export function ListsIndexView({ onCreate }: ListsIndexViewProps) {
+export function ListsIndexView({ onCreate, onSelectList }: ListsIndexViewProps) {
   const tLists = useTranslations("lists");
+  const getErrorMessage = useErrorMessage();
+
+  const {
+    data,
+    isPending,
+    isLoading,
+    isError,
+    error,
+    refetch,
+    isFetching,
+    isFetchingNextPage,
+    hasNextPage,
+    fetchNextPage,
+  } = useListsInfinite();
+
+  const items = data?.pages.flatMap((page) => page.lists) ?? [];
+  const total = data?.pages[0]?.pagination.total;
+  const isInitialLoading = (isPending || isLoading) && items.length === 0;
+  const isRefreshing = isFetching && !isFetchingNextPage && items.length > 0;
+
+  const loadMore = useCallback(() => {
+    if (hasNextPage && !isFetchingNextPage) {
+      void fetchNextPage();
+    }
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  const sentinelRef = useInfiniteScroll(loadMore, {
+    enabled: hasNextPage === true && !isError && items.length > 0,
+  });
 
   return (
-    <div className="grid gap-4 pb-4">
+    <div className="grid w-full min-w-0 gap-4 pb-4">
       <header className="flex items-center justify-between gap-3">
-        <h2 className="font-display text-lg font-semibold tracking-tight">
-          {tLists("index.title")}
-        </h2>
-        <Button type="button" size="sm" onClick={onCreate}>
-          {tLists("index.create")}
-        </Button>
+        <div>
+          <h2 className="font-display text-lg font-semibold tracking-tight">
+            {tLists("index.title")}
+          </h2>
+          <p className="text-sm text-muted-foreground">{tLists("index.total", { total })}</p>
+        </div>
+        {items.length > 0 && (
+          <Button type="button" variant="outline" size="sm" onClick={onCreate}>
+            <PlusIcon />
+            {tLists("index.create")}
+          </Button>
+        )}
       </header>
 
-      {/* Temporaire jusqu’à NIR-55 : empty state ou liste useLists() */}
-      <p className="text-sm text-muted-foreground">{tLists("index.empty.title")}</p>
+      {isInitialLoading && <ListsIndexSkeleton />}
+
+      {!isInitialLoading && isError && (
+        <ListsIndexError message={getErrorMessage(error)} onRetry={() => refetch()} />
+      )}
+
+      {!isInitialLoading && !isError && items.length === 0 && (
+        <ListsIndexEmpty onCreate={onCreate} />
+      )}
+
+      {!isInitialLoading && !isError && items.length > 0 && (
+        <>
+          {isRefreshing && (
+            <p className="text-xs text-muted-foreground" aria-live="polite">
+              {tLists("index.refreshing")}
+            </p>
+          )}
+
+          <ul className="flex w-full min-w-0 flex-col gap-3">
+            {items.map((list: ListWithRole) => (
+              <li key={list.id}>
+                <ListRow list={list} onClick={() => onSelectList(list.id)} />
+              </li>
+            ))}
+          </ul>
+
+          {/* Sentinel : déclenche fetchNextPage au scroll */}
+          <div ref={sentinelRef} className="h-1 w-full" aria-hidden />
+
+          {isFetchingNextPage && (
+            <div
+              className="flex items-center justify-center gap-2 py-4 text-sm text-muted-foreground"
+              aria-busy="true"
+              aria-live="polite"
+            >
+              <Loader2Icon className="size-4 animate-spin" />
+              {tLists("index.loadingMore")}
+            </div>
+          )}
+        </>
+      )}
     </div>
   );
 }

--- a/apps/web/src/lib/api/generated/types.gen.ts
+++ b/apps/web/src/lib/api/generated/types.gen.ts
@@ -249,6 +249,8 @@ export type List = {
    * The date and time the edit token expires
    */
   editTokenExpiresAt: string | null;
+  poiCount?: number;
+  collaboratorCount?: number;
 };
 
 export type ListWithRole = List & {

--- a/apps/web/src/lib/api/query-keys.ts
+++ b/apps/web/src/lib/api/query-keys.ts
@@ -1,9 +1,13 @@
 import { GetListsData } from "./generated/types.gen";
 
+import type { ListsInfiniteFilters } from "@/features/lists/hooks/use-lists-infinite";
+
 export const queryKeys = {
   lists: {
     all: ["lists"] as const,
     list: (filters?: GetListsData["query"]) => [...queryKeys.lists.all, "list", filters] as const,
+    infinite: (filters?: ListsInfiniteFilters) =>
+      [...queryKeys.lists.all, "infinite", filters] as const,
     detail: (listId: string) => [...queryKeys.lists.all, "detail", listId] as const,
   },
 };

--- a/apps/web/src/lib/i18n/locales/en/lists.json
+++ b/apps/web/src/lib/i18n/locales/en/lists.json
@@ -1,7 +1,8 @@
 {
   "index": {
     "title": "Lists",
-    "create": "Create a list",
+    "total": "{total, plural, =0 {No lists} one {# list} other {# lists}}",
+    "create": "New list",
     "empty": {
       "title": "No lists yet",
       "description": "",
@@ -10,7 +11,13 @@
     "search": {
       "placeholder": "Search lists…",
       "minLengthHint": ""
-    }
+    },
+    "error": {
+      "title": "Could not load lists",
+      "retry": "Retry"
+    },
+    "refreshing": "Refreshing…",
+    "loadingMore": "Loading more…"
   },
   "create": {
     "title": "New list",
@@ -63,5 +70,9 @@
     "requiredName": "List name is required",
     "nameTooLong": "List name cannot be longer than 255 characters",
     "descriptionTooLong": "Description cannot be longer than 1000 characters"
+  },
+  "row": {
+    "poiCount": "{count, plural, =0 {No places saved} one {# place saved} other {# places saved}}",
+    "collaboratorCount": "{count, plural, one {# collaborator} other {# collaborators}}"
   }
 }

--- a/apps/web/src/lib/i18n/locales/en/lists.json
+++ b/apps/web/src/lib/i18n/locales/en/lists.json
@@ -26,7 +26,8 @@
   "detail": {
     "title": "List",
     "back": "Back to lists",
-    "poisComingSoon": "Places coming soon"
+    "poisComingSoon": "Places coming soon",
+    "loading": "Loading list…"
   },
   "edit": {
     "title": "Edit list",

--- a/apps/web/src/lib/i18n/locales/fr/lists.json
+++ b/apps/web/src/lib/i18n/locales/fr/lists.json
@@ -1,7 +1,8 @@
 {
   "index": {
     "title": "Listes",
-    "create": "Créer une liste",
+    "total": "{total, plural, =0 {Aucune liste} one {# liste} other {# listes}}",
+    "create": "Nouvelle liste",
     "empty": {
       "title": "Aucune liste pour l'instant",
       "description": "",
@@ -10,7 +11,13 @@
     "search": {
       "placeholder": "Rechercher une liste…",
       "minLengthHint": ""
-    }
+    },
+    "error": {
+      "title": "Impossible de charger les listes",
+      "retry": "Réessayer"
+    },
+    "refreshing": "Mise à jour…",
+    "loadingMore": "Chargement…"
   },
   "create": {
     "title": "Nouvelle liste",
@@ -63,5 +70,9 @@
     "requiredName": "Le nom de la liste est requis",
     "nameTooLong": "Le nom ne peut pas dépasser 255 caractères",
     "descriptionTooLong": "La description ne peut pas dépasser 1000 caractères"
+  },
+  "row": {
+    "poiCount": "{count, plural, =0 {Aucun lieu enregistré} one {# lieu enregistré} other {# lieux enregistrés}}",
+    "collaboratorCount": "{count, plural, one {# collaborateur} other {# collaborateurs}}"
   }
 }

--- a/apps/web/src/lib/i18n/locales/fr/lists.json
+++ b/apps/web/src/lib/i18n/locales/fr/lists.json
@@ -26,7 +26,8 @@
   "detail": {
     "title": "Liste",
     "back": "Retour aux listes",
-    "poisComingSoon": "Lieux à venir"
+    "poisComingSoon": "Lieux à venir",
+    "loading": "Chargement de la liste…"
   },
   "edit": {
     "title": "Modifier la liste",


### PR DESCRIPTION
## 📝 Description

Implémentation de la vue index de l’onglet Listes (NIR-55) : affichage paginé des listes de l’utilisateur avec infinite scroll, gestion des états loading / vide / erreur, navigation vers une vue détail (stub), et correction du cache React Query au logout.

La recherche et la synchro URL (`?listId=`) sont volontairement hors scope (tickets suivants).

## 🎯 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI update (no functional changes)
- [ ] ♻️ Code refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [x] ✅ Test update

## 🔗 Related Issues

Closes NIR-55

## 🚀 Changes Made

- API `GET /list` : ajout de `poiCount` et `collaboratorCount` dans la réponse
- Nouveaux composants `ListRow`, `ListsIndexEmpty`, `ListsIndexError`, `ListsIndexSkeleton`
- `ListsIndexView` branchée sur `useListsInfinite` avec infinite scroll et compteur total
- Navigation index → détail (stub `ListsDetailView`) via `ListsShellView`
- Fix auth : `queryClient.clear()` au logout + `enabled: Boolean(user)` sur les hooks lists
- Tests unitaires `lists-index-view.test.tsx` (loading, vide, erreur, données, clic)
- i18n en/fr : clés `index.total`, `row.*`, états index

## 🧪 Testing

- [x] Tested locally with `pnpm dev`
- [x] All quality checks pass (`pnpm lint`)
- [x] Unit tests pass (`pnpm test`)
- [ ] Database migrations applied if needed

## 📸 Screenshots/Videos

N/A — captures recommandées : état vide, liste avec cartes, vue détail stub.

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated if needed
- [x] No console errors or warnings
- [x] Removed any debug code