### PR TITLE
feat(lists): add list detail view and edit flow

### DIFF
--- a/apps/api/__test__/list/routes.test.ts
+++ b/apps/api/__test__/list/routes.test.ts
@@ -118,6 +118,32 @@ describe("List Routes", () => {
 
       expect(res.status).toBe(200);
       expect(res.body.list.name).toBe("Test List");
+      expect(res.body.list.role).toBe("OWNER"); // ← ajouter
+    });
+
+    it("should return role VIEWER for a viewer collaborator", async () => {
+      const owner = await prisma.user.create({
+        data: {
+          email: "owner-get-detail@example.com",
+          passwordHash: await hashPassword("password123"),
+          emailVerified: true,
+        },
+      });
+
+      const list = await prisma.poiList.create({
+        data: { name: "Shared List", createdBy: owner.id },
+      });
+
+      await prisma.listCollaborator.create({
+        data: { listId: list.id, userId, role: "VIEWER" },
+      });
+
+      const res = await request(app)
+        .get(`/list/${list.id}`)
+        .set("Authorization", `Bearer ${accessToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.list.role).toBe("VIEWER");
     });
 
     it("should return 404 for non-existent list", async () => {

--- a/apps/api/src/list/routes.ts
+++ b/apps/api/src/list/routes.ts
@@ -384,7 +384,7 @@ listRouter.get("/:listId", requireAuth, async (req, res) => {
       return res.status(404).json(formatError(ErrorCodes.LIST_NOT_FOUND, "List not found"));
     }
 
-    res.json({ list });
+    res.json({ list: { ...list, role } });
   } catch (err) {
     req.log?.error({ err }, "Failed to get list");
     return res.status(500).json(formatError(ErrorCodes.INTERNAL_ERROR, "Internal server error"));

--- a/apps/api/src/swagger/schemas/list.schema.ts
+++ b/apps/api/src/swagger/schemas/list.schema.ts
@@ -86,7 +86,7 @@ export const listSchemas = {
   GetListResponse: {
     type: "object",
     properties: {
-      list: { $ref: "#/components/schemas/List" },
+      list: { $ref: "#/components/schemas/ListWithRole" },
     },
     required: ["list"],
   },

--- a/apps/web/src/features/lists/components/list-row.tsx
+++ b/apps/web/src/features/lists/components/list-row.tsx
@@ -1,7 +1,8 @@
-import { GlobeIcon, LockIcon, MapPinIcon, UsersIcon } from "lucide-react";
+import { MapPinIcon, UsersIcon } from "lucide-react";
 import { useTranslations } from "next-intl";
 
-import { Badge } from "@/components";
+import { ListVisibilityBadge } from "./list-visibility-badge";
+
 import { ListWithRole } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
@@ -12,7 +13,6 @@ type ListRowProps = {
 
 export function ListRow({ list, onClick }: ListRowProps) {
   const tRow = useTranslations("lists.row");
-  const tLists = useTranslations("lists");
 
   const poiCount = list.poiCount ?? 0;
   const collaboratorCount = list.collaboratorCount ?? 0;
@@ -53,12 +53,7 @@ export function ListRow({ list, onClick }: ListRowProps) {
             </span>
           )}
         </div>
-        <Badge variant="outline" className="shrink-0 text-muted-foreground">
-          {list.visibility === "PRIVATE" && <LockIcon />}
-          {list.visibility === "SHARED" && <UsersIcon />}
-          {list.visibility === "PUBLIC" && <GlobeIcon />}
-          {tLists(`visibility.${list.visibility}.label`)}
-        </Badge>
+        <ListVisibilityBadge visibility={list.visibility} />
       </div>
     </button>
   );

--- a/apps/web/src/features/lists/components/list-visibility-badge.tsx
+++ b/apps/web/src/features/lists/components/list-visibility-badge.tsx
@@ -1,0 +1,19 @@
+import { LockIcon, UsersIcon, GlobeIcon } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+import type { ListVisibility } from "../constants/lists.constants";
+
+import { Badge } from "@/components/ui";
+
+export function ListVisibilityBadge({ visibility }: { visibility: ListVisibility }) {
+  const tLists = useTranslations("lists");
+
+  return (
+    <Badge variant="outline" className="text-muted-foreground">
+      {visibility === "PRIVATE" && <LockIcon />}
+      {visibility === "SHARED" && <UsersIcon />}
+      {visibility === "PUBLIC" && <GlobeIcon />}
+      {tLists(`visibility.${visibility}.label`)}
+    </Badge>
+  );
+}

--- a/apps/web/src/features/lists/components/lists-detail-metadata.tsx
+++ b/apps/web/src/features/lists/components/lists-detail-metadata.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useLocale, useTranslations } from "next-intl";
+import { useMemo } from "react";
+
+import { ListVisibilityBadge } from "./list-visibility-badge";
+
+import { Badge } from "@/components/ui";
+import type { ListWithRole } from "@/lib/api";
+
+type ListsDetailMetadataProps = {
+  list: Pick<ListWithRole, "role" | "visibility" | "createdAt" | "updatedAt">;
+};
+
+export function ListsDetailMetadata({ list }: ListsDetailMetadataProps) {
+  const tLists = useTranslations("lists");
+  const locale = useLocale();
+
+  const dateFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat(locale, {
+        dateStyle: "medium",
+      }),
+    [locale]
+  );
+
+  const createdAtLabel = tLists("detail.createdAt", {
+    date: dateFormatter.format(new Date(list.createdAt)),
+  });
+
+  return (
+    <div className="grid gap-2">
+      <div className="flex flex-wrap items-center gap-2">
+        {list.role && <Badge variant="secondary">{tLists(`role.${list.role}`)}</Badge>}
+
+        <ListVisibilityBadge visibility={list.visibility} />
+      </div>
+
+      <div className="text-xs text-muted-foreground">
+        <p>{createdAtLabel}</p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/lists/components/lists-list-query-boundary.tsx
+++ b/apps/web/src/features/lists/components/lists-list-query-boundary.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import type { ReactNode } from "react";
+
+import { useList } from "../hooks/use-list";
+
+import { Button } from "@/components/ui";
+import { useErrorMessage } from "@/hooks/use-error-message";
+import type { ListWithRole } from "@/lib/api";
+import { getErrorCode } from "@/lib/api/errors";
+
+type ListsListQueryBoundaryProps = {
+  listId: string;
+  children: (list: ListWithRole) => ReactNode;
+};
+
+/**
+ * Loads a list by id and renders loading / error / success states shared by detail and edit views.
+ */
+export function ListsListQueryBoundary({ listId, children }: ListsListQueryBoundaryProps) {
+  const tLists = useTranslations("lists");
+  const getErrorMessage = useErrorMessage();
+  const { data, isPending, isError, error, refetch } = useList(listId);
+
+  const list = data?.list;
+  const isNotFound = isError && getErrorCode(error) === "LIST_NOT_FOUND";
+
+  if (isPending) {
+    return <p className="text-sm text-muted-foreground">{tLists("detail.loading")}</p>;
+  }
+
+  if (isError) {
+    return (
+      <div className="grid gap-3 py-4" role="alert">
+        <p className="text-sm text-muted-foreground">
+          {isNotFound ? tLists("detail.notFound") : getErrorMessage(error)}
+        </p>
+        {!isNotFound && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="w-fit"
+            onClick={() => refetch()}
+          >
+            {tLists("index.error.retry")}
+          </Button>
+        )}
+      </div>
+    );
+  }
+
+  if (!list) {
+    return null;
+  }
+
+  return <>{children(list)}</>;
+}

--- a/apps/web/src/features/lists/constants/lists.constants.test.ts
+++ b/apps/web/src/features/lists/constants/lists.constants.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { canEditList } from "./lists.constants";
+
+describe("canEditList", () => {
+  it("allows OWNER, ADMIN, EDITOR", () => {
+    expect(canEditList("OWNER")).toBe(true);
+    expect(canEditList("ADMIN")).toBe(true);
+    expect(canEditList("EDITOR")).toBe(true);
+  });
+
+  it("denies VIEWER and undefined", () => {
+    expect(canEditList("VIEWER")).toBe(false);
+    expect(canEditList(undefined)).toBe(false);
+  });
+});

--- a/apps/web/src/features/lists/constants/lists.constants.ts
+++ b/apps/web/src/features/lists/constants/lists.constants.ts
@@ -9,3 +9,18 @@ export const LIST_VISIBILITY_VALUES = ["PRIVATE", "SHARED", "PUBLIC"] as const;
 export type ListVisibility = (typeof LIST_VISIBILITY_VALUES)[number];
 
 export const DEFAULT_LIST_VISIBILITY: ListVisibility = "PRIVATE";
+
+/** Collaborator / owner roles that may edit list metadata (mirrors API `canUpdateList`). */
+export const EDITABLE_LIST_ROLES = ["OWNER", "ADMIN", "EDITOR"] as const;
+
+export type ListRole = (typeof EDITABLE_LIST_ROLES)[number] | "VIEWER";
+
+/**
+ * Whether the current user may edit list fields (name, description, visibility).
+ * VIEWER and missing role → read-only.
+ */
+export function canEditList(role?: ListRole): boolean {
+  return (
+    role !== undefined && EDITABLE_LIST_ROLES.includes(role as (typeof EDITABLE_LIST_ROLES)[number])
+  );
+}

--- a/apps/web/src/features/lists/forms/edit-list-form.tsx
+++ b/apps/web/src/features/lists/forms/edit-list-form.tsx
@@ -2,6 +2,7 @@
 
 import { standardSchemaResolver } from "@hookform/resolvers/standard-schema";
 import { useTranslations } from "next-intl";
+import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 
@@ -12,45 +13,49 @@ import { ListFormFields } from "./list-form-fields";
 import { ListFormLayout } from "./list-form-layout";
 
 import { Button, Form } from "@/components/ui";
-import { DEFAULT_LIST_VISIBILITY, useCreateList } from "@/features/lists";
+import { useUpdateList } from "@/features/lists";
 import type { CreateListFormData } from "@/features/lists/schemas/lists.schema";
 import { useErrorMessage } from "@/hooks/use-error-message";
 import { cn } from "@/lib/utils";
 
-export type CreateListFormProps = {
-  /** Closes the dialog after a successful create. */
-  closeDialog?: () => void;
-  /** Called with the new list id (e.g. navigate to detail). */
-  onCreated?: (listId: string) => void;
+export type EditListFormProps = {
+  listId: string;
+  defaultValues: CreateListFormData;
   embedded?: boolean;
+  onUpdated?: () => void;
 };
 
-export function CreateListForm({ closeDialog, onCreated, embedded = false }: CreateListFormProps) {
+export function EditListForm({
+  listId,
+  defaultValues,
+  embedded = true,
+  onUpdated,
+}: EditListFormProps) {
   const tLists = useTranslations("lists");
-  const t = useTranslations();
   const getErrorMessage = useErrorMessage();
-  const { mutateAsync: createList, isPending } = useCreateList();
+  const { mutateAsync: updateList, isPending } = useUpdateList();
   const listFormSchema = useListFormSchema();
 
   const form = useForm<CreateListFormData>({
     resolver: standardSchemaResolver(listFormSchema),
-    defaultValues: {
-      name: "",
-      description: "",
-      visibility: DEFAULT_LIST_VISIBILITY,
-    },
+    defaultValues,
   });
+
+  useEffect(() => {
+    form.reset(defaultValues);
+  }, [defaultValues, form]);
 
   async function onSubmit(values: CreateListFormData) {
     try {
-      const { list } = await createList(listFormValuesToBody(values));
+      await updateList({
+        listId,
+        body: listFormValuesToBody(values),
+      });
 
-      toast.success(tLists("createList.success"));
-      form.reset();
-      closeDialog?.();
-      onCreated?.(list.id);
+      toast.success(tLists("updateList.success"));
+      onUpdated?.();
     } catch (error) {
-      toast.error(tLists("createList.error"), {
+      toast.error(tLists("updateList.error"), {
         description: getErrorMessage(error),
       });
     }
@@ -62,24 +67,14 @@ export function CreateListForm({ closeDialog, onCreated, embedded = false }: Cre
         <form onSubmit={form.handleSubmit(onSubmit)} className="grid gap-4">
           <ListFormFields control={form.control} />
 
-          <div
-            className={cn(
-              "flex gap-2 mt-2",
-              embedded ? "flex-col" : "flex-col md:flex-row justify-end"
-            )}
-          >
-            {!embedded && closeDialog && (
-              <Button variant="outline" type="button" onClick={closeDialog}>
-                {t("common.buttons.cancel")}
-              </Button>
-            )}
+          <div className={cn("mt-2", embedded && "w-full")}>
             <Button
               type="submit"
               disabled={isPending}
               loading={isPending}
               className={cn(embedded && "w-full")}
             >
-              {tLists("create.submit")}
+              {tLists("edit.submit")}
             </Button>
           </div>
         </form>

--- a/apps/web/src/features/lists/forms/list-form-fields.tsx
+++ b/apps/web/src/features/lists/forms/list-form-fields.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import type { Control } from "react-hook-form";
+
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  Input,
+  Textarea,
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui";
+import {
+  LIST_VISIBILITY_VALUES,
+  listConstraints,
+} from "@/features/lists/constants/lists.constants";
+import type { ListVisibility } from "@/features/lists/constants/lists.constants";
+import type { CreateListFormData } from "@/features/lists/schemas/lists.schema";
+
+type ListFormFieldsProps = {
+  control: Control<CreateListFormData>;
+  disabled?: boolean;
+};
+
+/** Shared name, description, and visibility fields for list create/edit forms. */
+export function ListFormFields({ control, disabled = false }: ListFormFieldsProps) {
+  const tLists = useTranslations("lists");
+
+  return (
+    <>
+      <FormField
+        control={control}
+        name="name"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel className="text-md lg:text-sm">{tLists("fields.name")}</FormLabel>
+            <FormControl>
+              <Input
+                {...field}
+                disabled={disabled}
+                maxLength={listConstraints.name.max}
+                autoComplete="off"
+              />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={control}
+        name="description"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel className="text-md lg:text-sm">{tLists("fields.description")}</FormLabel>
+            <FormControl>
+              <Textarea
+                {...field}
+                disabled={disabled}
+                rows={3}
+                maxLength={listConstraints.description.max}
+                className="min-h-22 resize-y"
+              />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={control}
+        name="visibility"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel className="text-md lg:text-sm">{tLists("fields.visibility")}</FormLabel>
+            <Select
+              value={field.value}
+              onValueChange={(value) => field.onChange(value as ListVisibility)}
+              disabled={disabled}
+            >
+              <FormControl>
+                <SelectTrigger disabled={disabled}>
+                  <SelectValue />
+                </SelectTrigger>
+              </FormControl>
+              <SelectContent className="z-10000">
+                {LIST_VISIBILITY_VALUES.map((value) => (
+                  <SelectItem key={value} value={value}>
+                    {tLists(`visibility.${value}.label`)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    </>
+  );
+}

--- a/apps/web/src/features/lists/forms/list-form-layout.tsx
+++ b/apps/web/src/features/lists/forms/list-form-layout.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+type ListFormLayoutProps = {
+  embedded?: boolean;
+  children: ReactNode;
+};
+
+/** Outer shell spacing for embedded (shell) vs standalone list forms. */
+export function ListFormLayout({ embedded = false, children }: ListFormLayoutProps) {
+  return (
+    <div className={cn(!embedded && "pt-4")}>
+      <div
+        className={cn(
+          "grid gap-6",
+          !embedded && "py-4 md:py-0 mb-[env(safe-area-inset-bottom,0.5rem)]"
+        )}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/lists/hooks/use-list-form-schema.ts
+++ b/apps/web/src/features/lists/hooks/use-list-form-schema.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useMemo } from "react";
+
+import { createListFormSchema } from "../schemas/lists.schema";
+
+/** Zod schema for list create/edit forms with localized validation messages. */
+export function useListFormSchema() {
+  const tLists = useTranslations("lists");
+
+  return useMemo(
+    () =>
+      createListFormSchema({
+        requiredName: tLists("validation.requiredName"),
+        nameTooLong: tLists("validation.nameTooLong"),
+        descriptionTooLong: tLists("validation.descriptionTooLong"),
+      }),
+    [tLists]
+  );
+}

--- a/apps/web/src/features/lists/index.ts
+++ b/apps/web/src/features/lists/index.ts
@@ -9,13 +9,16 @@ export {
   listConstraints,
   LIST_VISIBILITY_VALUES,
   DEFAULT_LIST_VISIBILITY,
+  EDITABLE_LIST_ROLES,
+  canEditList,
 } from "./constants/lists.constants";
 export { ListsShellView } from "./navigation/lists-shell-view";
 export { CreateListForm } from "./forms/create-list-form";
+export { EditListForm } from "./forms/edit-list-form";
 
 export type { ListFilters } from "./hooks/use-lists";
 export type { ListsInfiniteFilters } from "./hooks/use-lists-infinite";
 export type { CreateListInput } from "./hooks/use-create-list";
 export type { UpdateListInput } from "./hooks/use-update-list";
 export type { CreateListFormMessages, CreateListFormData } from "./schemas/lists.schema";
-export type { ListVisibility } from "./constants/lists.constants";
+export type { ListVisibility, ListRole } from "./constants/lists.constants";

--- a/apps/web/src/features/lists/navigation/lists-shell-view.tsx
+++ b/apps/web/src/features/lists/navigation/lists-shell-view.tsx
@@ -6,6 +6,7 @@ import type { ListsSection } from "../types/lists-section.types";
 import { DEFAULT_LISTS_SECTION } from "../types/lists-section.types";
 import { ListsCreateView } from "../views/lists-create-view";
 import { ListsDetailView } from "../views/lists-detail-view";
+import { ListsEditView } from "../views/lists-edit-view";
 import { ListsIndexView } from "../views/lists-index-view";
 
 export function ListsShellView() {
@@ -18,6 +19,7 @@ export function ListsShellView() {
   };
 
   const goCreate = () => setSection("create");
+  const goEdit = () => setSection("edit");
 
   const goDetail = (listId: string) => {
     setSelectedListId(listId);
@@ -27,7 +29,12 @@ export function ListsShellView() {
   switch (section) {
     case "detail":
       if (!selectedListId) return <ListsIndexView onCreate={goCreate} onSelectList={goDetail} />;
-      return <ListsDetailView listId={selectedListId} onBack={goIndex} />;
+      return <ListsDetailView listId={selectedListId} onBack={goIndex} onEdit={goEdit} />;
+    case "edit":
+      if (!selectedListId) {
+        return <ListsIndexView onCreate={goCreate} onSelectList={goDetail} />;
+      }
+      return <ListsEditView listId={selectedListId} onBack={() => setSection("detail")} />;
     case "create":
       return <ListsCreateView onBack={goIndex} />;
     case "index":

--- a/apps/web/src/features/lists/types/lists-section.types.ts
+++ b/apps/web/src/features/lists/types/lists-section.types.ts
@@ -1,3 +1,3 @@
-export type ListsSection = "index" | "create" | "detail";
+export type ListsSection = "index" | "create" | "detail" | "edit";
 
 export const DEFAULT_LISTS_SECTION: ListsSection = "index";

--- a/apps/web/src/features/lists/utils/list-form.utils.test.ts
+++ b/apps/web/src/features/lists/utils/list-form.utils.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { listFormValuesToBody, listToFormValues } from "./list-form.utils";
+
+describe("listToFormValues", () => {
+  it("maps list fields to form defaults", () => {
+    expect(
+      listToFormValues({
+        name: "Paris",
+        description: null,
+        visibility: "PUBLIC",
+      })
+    ).toEqual({
+      name: "Paris",
+      description: "",
+      visibility: "PUBLIC",
+    });
+  });
+});
+
+describe("listFormValuesToBody", () => {
+  it("trims empty description to undefined", () => {
+    expect(
+      listFormValuesToBody({
+        name: "Paris",
+        description: "   ",
+        visibility: "PRIVATE",
+      })
+    ).toEqual({
+      name: "Paris",
+      description: undefined,
+      visibility: "PRIVATE",
+    });
+  });
+});

--- a/apps/web/src/features/lists/utils/list-form.utils.ts
+++ b/apps/web/src/features/lists/utils/list-form.utils.ts
@@ -1,0 +1,23 @@
+import type { CreateListFormData } from "../schemas/lists.schema";
+
+import type { List } from "@/lib/api";
+
+/** Maps API list fields to react-hook-form default values. */
+export function listToFormValues(
+  list: Pick<List, "name" | "description" | "visibility">
+): CreateListFormData {
+  return {
+    name: list.name,
+    description: list.description ?? "",
+    visibility: list.visibility,
+  };
+}
+
+/** Request body for POST /list and PUT /list/:listId. */
+export function listFormValuesToBody(values: CreateListFormData) {
+  return {
+    name: values.name,
+    description: values.description?.trim() || undefined,
+    visibility: values.visibility,
+  };
+}

--- a/apps/web/src/features/lists/views/lists-detail-view.test.tsx
+++ b/apps/web/src/features/lists/views/lists-detail-view.test.tsx
@@ -1,0 +1,139 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useList } from "../hooks/use-list";
+
+import { ListsDetailView } from "./lists-detail-view";
+
+import type { ListWithRole } from "@/lib/api";
+import { getErrorCode } from "@/lib/api/errors";
+
+vi.mock("../hooks/use-list", () => ({
+  useList: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-error-message", () => ({
+  useErrorMessage: () => () => "API error message",
+}));
+
+vi.mock("@/lib/api/errors", () => ({
+  getErrorCode: vi.fn(),
+}));
+
+const mockList: ListWithRole = {
+  id: "list-1",
+  name: "Paris spots",
+  description: "My favorite places",
+  visibility: "PRIVATE",
+  role: "OWNER",
+  createdAt: "2024-01-01T00:00:00.000Z",
+  updatedAt: "2024-06-01T00:00:00.000Z",
+  createdBy: "user-1",
+  imageUrl: null,
+  shareToken: null,
+  shareTokenExpiresAt: null,
+  editToken: null,
+  editTokenExpiresAt: null,
+  poiCount: 3,
+  collaboratorCount: 0,
+};
+
+function mockListQuery(overrides: Partial<ReturnType<typeof useList>> = {}) {
+  vi.mocked(useList).mockReturnValue({
+    data: { list: mockList },
+    isPending: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+    ...overrides,
+  } as ReturnType<typeof useList>);
+}
+
+describe("ListsDetailView", () => {
+  const onBack = vi.fn();
+  const onEdit = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getErrorCode).mockReturnValue(null);
+  });
+
+  it("shows loading state", () => {
+    mockListQuery({ data: undefined, isPending: true });
+
+    render(<ListsDetailView listId="list-1" onBack={onBack} onEdit={onEdit} />);
+
+    expect(screen.getByText("detail.loading")).toBeInTheDocument();
+  });
+
+  it("shows not found when API returns LIST_NOT_FOUND", () => {
+    vi.mocked(getErrorCode).mockReturnValue("LIST_NOT_FOUND");
+    mockListQuery({
+      data: undefined,
+      isError: true,
+      error: new Error("LIST_NOT_FOUND"),
+    });
+
+    render(<ListsDetailView listId="list-1" onBack={onBack} onEdit={onEdit} />);
+
+    expect(screen.getByText("detail.notFound")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "index.error.retry" })).not.toBeInTheDocument();
+  });
+
+  it("shows generic error with retry", async () => {
+    const user = userEvent.setup();
+    const refetch = vi.fn();
+    mockListQuery({
+      data: undefined,
+      isError: true,
+      error: new Error("fail"),
+      refetch,
+    });
+
+    render(<ListsDetailView listId="list-1" onBack={onBack} onEdit={onEdit} />);
+
+    expect(screen.getByText("API error message")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "index.error.retry" }));
+
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders list content and POI placeholder for OWNER", () => {
+    mockListQuery();
+
+    render(<ListsDetailView listId="list-1" onBack={onBack} onEdit={onEdit} />);
+
+    expect(screen.getByRole("heading", { name: "Paris spots" })).toBeInTheDocument();
+    expect(screen.getByText("My favorite places")).toBeInTheDocument();
+    expect(screen.getByText("role.OWNER")).toBeInTheDocument();
+    expect(screen.getByText("detail.createdAt")).toBeInTheDocument();
+    expect(screen.getByText("detail.poisComingSoon")).toBeInTheDocument();
+  });
+
+  it("shows edit button for OWNER and calls onEdit", async () => {
+    const user = userEvent.setup();
+    mockListQuery();
+
+    render(<ListsDetailView listId="list-1" onBack={onBack} onEdit={onEdit} />);
+
+    const editButton = screen.getByRole("button", { name: "edit.action" });
+    expect(editButton).toBeInTheDocument();
+
+    await user.click(editButton);
+
+    expect(onEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides edit button for VIEWER", () => {
+    mockListQuery({
+      data: { list: { ...mockList, role: "VIEWER" } },
+    });
+
+    render(<ListsDetailView listId="list-1" onBack={onBack} onEdit={onEdit} />);
+
+    expect(screen.queryByRole("button", { name: "edit.action" })).not.toBeInTheDocument();
+    expect(screen.queryByText("edit.readOnly")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/lists/views/lists-detail-view.tsx
+++ b/apps/web/src/features/lists/views/lists-detail-view.tsx
@@ -1,26 +1,51 @@
 "use client";
 
+import { PencilIcon } from "lucide-react";
 import { useTranslations } from "next-intl";
 
+import { ListsDetailMetadata } from "../components/lists-detail-metadata";
+import { ListsListQueryBoundary } from "../components/lists-list-query-boundary";
 import { ListsSectionLayout } from "../components/lists-section-layout";
+import { canEditList } from "../constants/lists.constants";
 import { useList } from "../hooks/use-list";
+
+import { Button } from "@/components/ui";
 
 type ListsDetailViewProps = {
   listId: string;
   onBack: () => void;
+  onEdit: () => void;
 };
 
-export function ListsDetailView({ listId, onBack }: ListsDetailViewProps) {
+export function ListsDetailView({ listId, onBack, onEdit }: ListsDetailViewProps) {
   const tLists = useTranslations("lists");
-  const { data, isPending } = useList(listId);
+  const { data } = useList(listId);
+  const list = data?.list;
 
   return (
-    <ListsSectionLayout title={data?.list.name ?? tLists("detail.title")} onBack={onBack}>
-      {isPending ? (
-        <p className="text-sm text-muted-foreground">{tLists("detail.loading")}</p>
-      ) : (
-        <p className="text-sm text-muted-foreground"> {tLists("detail.poisComingSoon")}</p>
-      )}
+    <ListsSectionLayout
+      title={list?.name ?? tLists("detail.title")}
+      description={list?.description ?? undefined}
+      onBack={onBack}
+    >
+      <ListsListQueryBoundary listId={listId}>
+        {(loadedList) => (
+          <div className="grid gap-6">
+            <ListsDetailMetadata list={loadedList} />
+
+            {canEditList(loadedList.role) && (
+              <Button type="button" variant="outline" size="sm" className="w-fit" onClick={onEdit}>
+                <PencilIcon className="size-4" />
+                {tLists("edit.action")}
+              </Button>
+            )}
+
+            <div className="border-t border-border pt-6">
+              <p className="text-sm text-muted-foreground">{tLists("detail.poisComingSoon")}</p>
+            </div>
+          </div>
+        )}
+      </ListsListQueryBoundary>
     </ListsSectionLayout>
   );
 }

--- a/apps/web/src/features/lists/views/lists-edit-view.test.tsx
+++ b/apps/web/src/features/lists/views/lists-edit-view.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useList } from "../hooks/use-list";
+import { useUpdateList } from "../hooks/use-update-list";
+
+import { ListsEditView } from "./lists-edit-view";
+
+import type { ListWithRole } from "@/lib/api";
+
+vi.mock("../hooks/use-list", () => ({
+  useList: vi.fn(),
+}));
+
+vi.mock("../hooks/use-update-list", () => ({
+  useUpdateList: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-error-message", () => ({
+  useErrorMessage: () => () => "API error message",
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const mockList: ListWithRole = {
+  id: "list-1",
+  name: "Paris spots",
+  description: "My favorite places",
+  visibility: "PRIVATE",
+  role: "OWNER",
+  createdAt: "2024-01-01T00:00:00.000Z",
+  updatedAt: "2024-06-01T00:00:00.000Z",
+  createdBy: "user-1",
+  imageUrl: null,
+  shareToken: null,
+  shareTokenExpiresAt: null,
+  editToken: null,
+  editTokenExpiresAt: null,
+};
+
+function mockListQuery(overrides: Partial<ReturnType<typeof useList>> = {}) {
+  vi.mocked(useList).mockReturnValue({
+    data: { list: mockList },
+    isPending: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+    ...overrides,
+  } as ReturnType<typeof useList>);
+}
+
+describe("ListsEditView", () => {
+  const onBack = vi.fn();
+  const mutateAsync = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mutateAsync.mockResolvedValue({ list: mockList });
+    vi.mocked(useUpdateList).mockReturnValue({
+      mutateAsync,
+      isPending: false,
+    } as unknown as ReturnType<typeof useUpdateList>);
+  });
+
+  it("shows loading state", () => {
+    mockListQuery({ data: undefined, isPending: true });
+
+    render(<ListsEditView listId="list-1" onBack={onBack} />);
+
+    expect(screen.getByText("detail.loading")).toBeInTheDocument();
+  });
+
+  it("shows read-only message for VIEWER", () => {
+    mockListQuery({
+      data: { list: { ...mockList, role: "VIEWER" } },
+    });
+
+    render(<ListsEditView listId="list-1" onBack={onBack} />);
+
+    expect(screen.getByText("edit.readOnly")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "edit.submit" })).not.toBeInTheDocument();
+  });
+
+  it("renders edit form for OWNER", () => {
+    mockListQuery();
+
+    render(<ListsEditView listId="list-1" onBack={onBack} />);
+
+    expect(screen.getByRole("heading", { name: "edit.title" })).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Paris spots")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "edit.submit" })).toBeInTheDocument();
+  });
+
+  it("submits update and returns to detail via onBack", async () => {
+    const user = userEvent.setup();
+    mockListQuery();
+
+    render(<ListsEditView listId="list-1" onBack={onBack} />);
+
+    const nameInput = screen.getByDisplayValue("Paris spots");
+    await user.clear(nameInput);
+    await user.type(nameInput, "Updated name");
+
+    await user.click(screen.getByRole("button", { name: "edit.submit" }));
+
+    expect(mutateAsync).toHaveBeenCalledWith({
+      listId: "list-1",
+      body: {
+        name: "Updated name",
+        description: "My favorite places",
+        visibility: "PRIVATE",
+      },
+    });
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/features/lists/views/lists-edit-view.tsx
+++ b/apps/web/src/features/lists/views/lists-edit-view.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+
+import { ListsListQueryBoundary } from "../components/lists-list-query-boundary";
+import { ListsSectionLayout } from "../components/lists-section-layout";
+import { canEditList } from "../constants/lists.constants";
+import { EditListForm } from "../forms/edit-list-form";
+import { listToFormValues } from "../utils/list-form.utils";
+
+type ListsEditViewProps = {
+  listId: string;
+  onBack: () => void;
+};
+
+export function ListsEditView({ listId, onBack }: ListsEditViewProps) {
+  const tLists = useTranslations("lists");
+
+  return (
+    <ListsSectionLayout title={tLists("edit.title")} onBack={onBack}>
+      <ListsListQueryBoundary listId={listId}>
+        {(list) =>
+          canEditList(list.role) ? (
+            <EditListForm
+              listId={listId}
+              embedded
+              defaultValues={listToFormValues(list)}
+              onUpdated={onBack}
+            />
+          ) : (
+            <p className="text-sm text-muted-foreground">{tLists("edit.readOnly")}</p>
+          )
+        }
+      </ListsListQueryBoundary>
+    </ListsSectionLayout>
+  );
+}

--- a/apps/web/src/lib/api/generated/types.gen.ts
+++ b/apps/web/src/lib/api/generated/types.gen.ts
@@ -267,7 +267,7 @@ export type CreateListResponse = {
 };
 
 export type GetListResponse = {
-  list: List;
+  list: ListWithRole;
 };
 
 export type UpdateListResponse = {

--- a/apps/web/src/lib/i18n/locales/en/lists.json
+++ b/apps/web/src/lib/i18n/locales/en/lists.json
@@ -26,11 +26,14 @@
   "detail": {
     "title": "List",
     "back": "Back to lists",
-    "poisComingSoon": "Places coming soon",
-    "loading": "Loading list…"
+    "loading": "Loading list…",
+    "notFound": "List not found",
+    "createdAt": "Created at {date}",
+    "poisComingSoon": "Places coming soon"
   },
   "edit": {
     "title": "Edit list",
+    "action": "Edit",
     "readOnly": "You can only view this list",
     "submit": "Save"
   },
@@ -60,8 +63,8 @@
     "error": "Could not create the list"
   },
   "updateList": {
-    "success": "",
-    "error": ""
+    "success": "List updated successfully",
+    "error": "Could not update the list"
   },
   "deleteList": {
     "success": "",

--- a/apps/web/src/lib/i18n/locales/fr/lists.json
+++ b/apps/web/src/lib/i18n/locales/fr/lists.json
@@ -26,11 +26,14 @@
   "detail": {
     "title": "Liste",
     "back": "Retour aux listes",
-    "poisComingSoon": "Lieux à venir",
-    "loading": "Chargement de la liste…"
+    "loading": "Chargement de la liste…",
+    "notFound": "Liste introuvable",
+    "createdAt": "Créée le {date}",
+    "poisComingSoon": "Lieux à venir"
   },
   "edit": {
     "title": "Modifier la liste",
+    "action": "Modifier",
     "readOnly": "Tu peux seulement consulter cette liste",
     "submit": "Enregistrer"
   },
@@ -60,8 +63,8 @@
     "error": "Impossible de créer la liste"
   },
   "updateList": {
-    "success": "",
-    "error": ""
+    "success": "Liste mise à jour avec succès",
+    "error": "Impossible de mettre à jour la liste"
   },
   "deleteList": {
     "success": "",


### PR DESCRIPTION
## 📝 Description

Implémentation de la vue détail d'une liste et du parcours d'édition (NIR-56) : affichage des métadonnées, gestion des rôles (OWNER/ADMIN/EDITOR vs VIEWER), formulaire de mise à jour avec retours toast, et navigation shell détail → édition → détail.

> **Note :** si la MR cible `main` et que l'index listes n'y est pas encore mergé, cette branche inclut aussi les commits liés à l'index (hooks, `ListsIndexView`, scroll infini — NIR-55 / #85).

## 🎯 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI update (no functional changes)
- [x] ♻️ Code refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [x] ✅ Test update

## 🔗 Related Issues

Closes NIR-56

## 🚀 Changes Made

- **API** : `GET /list/:listId` renvoie désormais `role` sur la liste ; schéma OpenAPI `ListWithRole` ; tests OWNER / VIEWER
- **Vue détail** : métadonnées (nom, description, rôle, visibilité, date de création), placeholder POI, bouton « Modifier » réservé aux rôles éditables, gestion 404 / erreur avec retry
- **Vue édition** : sous-vue shell `edit` calquée sur `create`, formulaire pré-rempli via `useUpdateList`, retour au détail après sauvegarde
- **Formulaires** : extraction de `ListFormFields`, `ListFormLayout`, `useListFormSchema` et utils `listToFormValues` / `listFormValuesToBody` ; refactor de `CreateListForm`
- **Partagé** : `ListsListQueryBoundary` pour loading/erreur entre détail et édition ; helper `canEditList`
- **i18n** : clés `detail.*`, `edit.*`, `updateList.*` (en/fr)
- **Tests** : `lists-detail-view.test.tsx`, `lists-edit-view.test.tsx`, `lists.constants.test.ts`, `list-form.utils.test.ts`

## 🧪 Testing

- [x] Tested locally with `pnpm dev`
- [x] All quality checks pass (`pnpm lint`)
- [x] Unit tests pass (`pnpm test`)
- [ ] Database migrations applied if needed

## 📸 Screenshots/Videos

Recommandé : capture de la vue détail (OWNER avec bouton Modifier) et de la vue édition après sauvegarde (toast + retour détail).

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated if needed
- [x] No console errors or warnings
- [x] Removed any debug code
- [x] Translations added for any new text