### PR TITLE
feat(lists): add delete list flow from detail view

### DIFF
--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -30,7 +30,7 @@ function DialogOverlay({
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-10001 bg-black/50",
         className
       )}
       {...props}
@@ -52,7 +52,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 outline-none sm:max-w-lg",
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-10001 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 outline-none sm:max-w-lg",
           className
         )}
         {...props}

--- a/apps/web/src/features/lists/components/delete-list-dialog.tsx
+++ b/apps/web/src/features/lists/components/delete-list-dialog.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { toast } from "sonner";
+
+import { useDeleteList } from "../hooks/use-delete-list";
+
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui";
+import { useErrorMessage } from "@/hooks/use-error-message";
+import { getErrorCode } from "@/lib/api/errors";
+
+export type DeleteListDialogProps = {
+  listId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onDeleted: () => void;
+};
+
+export function DeleteListDialog({ listId, open, onOpenChange, onDeleted }: DeleteListDialogProps) {
+  const tLists = useTranslations("lists");
+  const tCommon = useTranslations("common");
+  const getErrorMessage = useErrorMessage();
+  const { mutateAsync: deleteList, isPending } = useDeleteList();
+
+  async function handleDelete() {
+    if (isPending) return;
+
+    try {
+      await deleteList(listId);
+      toast.success(tLists("deleteList.success"));
+      onOpenChange(false);
+      onDeleted();
+    } catch (error) {
+      if (getErrorCode(error) === "LIST_NOT_FOUND") {
+        onOpenChange(false);
+        onDeleted();
+        return;
+      }
+
+      toast.error(tLists("deleteList.error"), {
+        description: getErrorMessage(error),
+      });
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{tLists("delete.title")}</DialogTitle>
+          <DialogDescription>{tLists("delete.description")}</DialogDescription>
+        </DialogHeader>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isPending}
+          >
+            {tCommon("buttons.cancel")}
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            disabled={isPending}
+            loading={isPending}
+            onClick={handleDelete}
+          >
+            {tLists("delete.confirmSubmit")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/features/lists/constants/lists.constants.test.ts
+++ b/apps/web/src/features/lists/constants/lists.constants.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { canEditList } from "./lists.constants";
+import { canDeleteList, canEditList } from "./lists.constants";
 
 describe("canEditList", () => {
   it("allows OWNER, ADMIN, EDITOR", () => {
@@ -12,5 +12,17 @@ describe("canEditList", () => {
   it("denies VIEWER and undefined", () => {
     expect(canEditList("VIEWER")).toBe(false);
     expect(canEditList(undefined)).toBe(false);
+  });
+});
+
+describe("canDeleteList", () => {
+  it("allows OWNER and ADMIN", () => {
+    expect(canDeleteList("OWNER")).toBe(true);
+    expect(canDeleteList("ADMIN")).toBe(true);
+  });
+  it("denies EDITOR, VIEWER and undefined", () => {
+    expect(canDeleteList("EDITOR")).toBe(false);
+    expect(canDeleteList("VIEWER")).toBe(false);
+    expect(canDeleteList(undefined)).toBe(false);
   });
 });

--- a/apps/web/src/features/lists/constants/lists.constants.ts
+++ b/apps/web/src/features/lists/constants/lists.constants.ts
@@ -13,7 +13,21 @@ export const DEFAULT_LIST_VISIBILITY: ListVisibility = "PRIVATE";
 /** Collaborator / owner roles that may edit list metadata (mirrors API `canUpdateList`). */
 export const EDITABLE_LIST_ROLES = ["OWNER", "ADMIN", "EDITOR"] as const;
 
+/** Collaborator / owner roles that may delete a list (mirrors API `canDeleteList`). */
+export const DELETABLE_LIST_ROLES = ["OWNER", "ADMIN"] as const;
+
 export type ListRole = (typeof EDITABLE_LIST_ROLES)[number] | "VIEWER";
+
+/**
+ * Whether the current user may delete the list.
+ * EDITOR, VIEWER and missing role → no delete.
+ */
+export function canDeleteList(role?: ListRole): boolean {
+  return (
+    role !== undefined &&
+    DELETABLE_LIST_ROLES.includes(role as (typeof DELETABLE_LIST_ROLES)[number])
+  );
+}
 
 /**
  * Whether the current user may edit list fields (name, description, visibility).

--- a/apps/web/src/features/lists/index.ts
+++ b/apps/web/src/features/lists/index.ts
@@ -10,7 +10,9 @@ export {
   LIST_VISIBILITY_VALUES,
   DEFAULT_LIST_VISIBILITY,
   EDITABLE_LIST_ROLES,
+  DELETABLE_LIST_ROLES,
   canEditList,
+  canDeleteList,
 } from "./constants/lists.constants";
 export { ListsShellView } from "./navigation/lists-shell-view";
 export { CreateListForm } from "./forms/create-list-form";

--- a/apps/web/src/features/lists/navigation/lists-shell-view.tsx
+++ b/apps/web/src/features/lists/navigation/lists-shell-view.tsx
@@ -29,7 +29,14 @@ export function ListsShellView() {
   switch (section) {
     case "detail":
       if (!selectedListId) return <ListsIndexView onCreate={goCreate} onSelectList={goDetail} />;
-      return <ListsDetailView listId={selectedListId} onBack={goIndex} onEdit={goEdit} />;
+      return (
+        <ListsDetailView
+          listId={selectedListId}
+          onBack={goIndex}
+          onEdit={goEdit}
+          onDelete={goIndex}
+        />
+      );
     case "edit":
       if (!selectedListId) {
         return <ListsIndexView onCreate={goCreate} onSelectList={goDetail} />;

--- a/apps/web/src/features/lists/views/lists-detail-view.test.tsx
+++ b/apps/web/src/features/lists/views/lists-detail-view.test.tsx
@@ -1,7 +1,9 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { toast } from "sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { useDeleteList } from "../hooks/use-delete-list";
 import { useList } from "../hooks/use-list";
 
 import { ListsDetailView } from "./lists-detail-view";
@@ -19,6 +21,17 @@ vi.mock("@/hooks/use-error-message", () => ({
 
 vi.mock("@/lib/api/errors", () => ({
   getErrorCode: vi.fn(),
+}));
+
+vi.mock("../hooks/use-delete-list", () => ({
+  useDeleteList: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
 }));
 
 const mockList: ListWithRole = {
@@ -53,16 +66,23 @@ function mockListQuery(overrides: Partial<ReturnType<typeof useList>> = {}) {
 describe("ListsDetailView", () => {
   const onBack = vi.fn();
   const onEdit = vi.fn();
+  const onDelete = vi.fn();
+  const mutateAsync = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(getErrorCode).mockReturnValue(null);
+    mutateAsync.mockResolvedValue({ message: "List deleted successfully" });
+    vi.mocked(useDeleteList).mockReturnValue({
+      mutateAsync,
+      isPending: false,
+    } as unknown as ReturnType<typeof useDeleteList>);
   });
 
   it("shows loading state", () => {
     mockListQuery({ data: undefined, isPending: true });
 
-    render(<ListsDetailView listId="list-1" onBack={onBack} onEdit={onEdit} />);
+    render(<ListsDetailView listId="list-1" onBack={onBack} onEdit={onEdit} onDelete={onDelete} />);
 
     expect(screen.getByText("detail.loading")).toBeInTheDocument();
   });
@@ -75,7 +95,7 @@ describe("ListsDetailView", () => {
       error: new Error("LIST_NOT_FOUND"),
     });
 
-    render(<ListsDetailView listId="list-1" onBack={onBack} onEdit={onEdit} />);
+    render(<ListsDetailView listId="list-1" onBack={onBack} onEdit={onEdit} onDelete={onDelete} />);
 
     expect(screen.getByText("detail.notFound")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "index.error.retry" })).not.toBeInTheDocument();
@@ -91,7 +111,7 @@ describe("ListsDetailView", () => {
       refetch,
     });
 
-    render(<ListsDetailView listId="list-1" onBack={onBack} onEdit={onEdit} />);
+    render(<ListsDetailView listId="list-1" onBack={onBack} onEdit={onEdit} onDelete={onDelete} />);
 
     expect(screen.getByText("API error message")).toBeInTheDocument();
 
@@ -103,7 +123,7 @@ describe("ListsDetailView", () => {
   it("renders list content and POI placeholder for OWNER", () => {
     mockListQuery();
 
-    render(<ListsDetailView listId="list-1" onBack={onBack} onEdit={onEdit} />);
+    render(<ListsDetailView listId="list-1" onBack={onBack} onEdit={onEdit} onDelete={onDelete} />);
 
     expect(screen.getByRole("heading", { name: "Paris spots" })).toBeInTheDocument();
     expect(screen.getByText("My favorite places")).toBeInTheDocument();
@@ -116,7 +136,7 @@ describe("ListsDetailView", () => {
     const user = userEvent.setup();
     mockListQuery();
 
-    render(<ListsDetailView listId="list-1" onBack={onBack} onEdit={onEdit} />);
+    render(<ListsDetailView listId="list-1" onBack={onBack} onEdit={onEdit} onDelete={onDelete} />);
 
     const editButton = screen.getByRole("button", { name: "edit.action" });
     expect(editButton).toBeInTheDocument();
@@ -131,9 +151,52 @@ describe("ListsDetailView", () => {
       data: { list: { ...mockList, role: "VIEWER" } },
     });
 
-    render(<ListsDetailView listId="list-1" onBack={onBack} onEdit={onEdit} />);
+    render(<ListsDetailView listId="list-1" onBack={onBack} onEdit={onEdit} onDelete={onDelete} />);
 
     expect(screen.queryByRole("button", { name: "edit.action" })).not.toBeInTheDocument();
     expect(screen.queryByText("edit.readOnly")).not.toBeInTheDocument();
+  });
+
+  it("hides delete button for VIEWER", () => {
+    mockListQuery({
+      data: { list: { ...mockList, role: "VIEWER" } },
+    });
+
+    render(<ListsDetailView listId="list-1" onBack={onBack} onEdit={onEdit} onDelete={onDelete} />);
+
+    expect(screen.queryByRole("button", { name: "delete.submit" })).not.toBeInTheDocument();
+  });
+
+  it("hides delete button for EDITOR", () => {
+    mockListQuery({
+      data: { list: { ...mockList, role: "EDITOR" } },
+    });
+
+    render(<ListsDetailView listId="list-1" onBack={onBack} onEdit={onEdit} onDelete={onDelete} />);
+
+    expect(screen.getByRole("button", { name: "edit.action" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "delete.submit" })).not.toBeInTheDocument();
+  });
+
+  it("shows delete button for OWNER", () => {
+    mockListQuery();
+
+    render(<ListsDetailView listId="list-1" onBack={onBack} onEdit={onEdit} onDelete={onDelete} />);
+
+    expect(screen.getByRole("button", { name: "delete.submit" })).toBeInTheDocument();
+  });
+
+  it("confirms deletion and calls onDelete", async () => {
+    const user = userEvent.setup();
+    mockListQuery();
+
+    render(<ListsDetailView listId="list-1" onBack={onBack} onEdit={onEdit} onDelete={onDelete} />);
+
+    await user.click(screen.getByRole("button", { name: "delete.submit" }));
+    await user.click(screen.getByRole("button", { name: "delete.confirmSubmit" }));
+
+    expect(mutateAsync).toHaveBeenCalledWith("list-1");
+    expect(toast.success).toHaveBeenCalledWith("deleteList.success");
+    expect(onDelete).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/features/lists/views/lists-detail-view.tsx
+++ b/apps/web/src/features/lists/views/lists-detail-view.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { PencilIcon } from "lucide-react";
+import { PencilIcon, Trash2Icon } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { useState } from "react";
 
+import { DeleteListDialog } from "../components/delete-list-dialog";
 import { ListsDetailMetadata } from "../components/lists-detail-metadata";
 import { ListsListQueryBoundary } from "../components/lists-list-query-boundary";
 import { ListsSectionLayout } from "../components/lists-section-layout";
-import { canEditList } from "../constants/lists.constants";
+import { canDeleteList, canEditList } from "../constants/lists.constants";
 import { useList } from "../hooks/use-list";
 
 import { Button } from "@/components/ui";
@@ -15,11 +17,13 @@ type ListsDetailViewProps = {
   listId: string;
   onBack: () => void;
   onEdit: () => void;
+  onDelete: () => void;
 };
 
-export function ListsDetailView({ listId, onBack, onEdit }: ListsDetailViewProps) {
+export function ListsDetailView({ listId, onBack, onEdit, onDelete }: ListsDetailViewProps) {
   const tLists = useTranslations("lists");
   const { data } = useList(listId);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const list = data?.list;
 
   return (
@@ -32,14 +36,35 @@ export function ListsDetailView({ listId, onBack, onEdit }: ListsDetailViewProps
         {(loadedList) => (
           <div className="grid gap-6">
             <ListsDetailMetadata list={loadedList} />
-
-            {canEditList(loadedList.role) && (
-              <Button type="button" variant="outline" size="sm" className="w-fit" onClick={onEdit}>
-                <PencilIcon className="size-4" />
-                {tLists("edit.action")}
-              </Button>
+            {(canEditList(loadedList.role) || canDeleteList(loadedList.role)) && (
+              <div className="flex flex-wrap gap-2">
+                {canEditList(loadedList.role) && (
+                  <Button type="button" variant="outline" size="sm" onClick={onEdit}>
+                    <PencilIcon className="size-4" />
+                    {tLists("edit.action")}
+                  </Button>
+                )}
+                {canDeleteList(loadedList.role) && (
+                  <Button
+                    type="button"
+                    variant="destructive"
+                    size="sm"
+                    onClick={() => setDeleteDialogOpen(true)}
+                  >
+                    <Trash2Icon className="size-4" />
+                    {tLists("delete.submit")}
+                  </Button>
+                )}
+              </div>
             )}
-
+            {canDeleteList(loadedList.role) && (
+              <DeleteListDialog
+                listId={listId}
+                open={deleteDialogOpen}
+                onOpenChange={setDeleteDialogOpen}
+                onDeleted={onDelete}
+              />
+            )}
             <div className="border-t border-border pt-6">
               <p className="text-sm text-muted-foreground">{tLists("detail.poisComingSoon")}</p>
             </div>

--- a/apps/web/src/lib/i18n/locales/en/lists.json
+++ b/apps/web/src/lib/i18n/locales/en/lists.json
@@ -39,8 +39,9 @@
   },
   "delete": {
     "title": "Delete list",
-    "confirm": "Delete this list?",
-    "submit": "Delete"
+    "description": "This action cannot be undone. All places in this list will be removed.",
+    "submit": "Delete",
+    "confirmSubmit": "Delete permanently"
   },
   "fields": {
     "name": "Name",
@@ -67,8 +68,8 @@
     "error": "Could not update the list"
   },
   "deleteList": {
-    "success": "",
-    "error": ""
+    "success": "List deleted successfully",
+    "error": "Could not delete the list"
   },
   "validation": {
     "requiredName": "List name is required",

--- a/apps/web/src/lib/i18n/locales/fr/lists.json
+++ b/apps/web/src/lib/i18n/locales/fr/lists.json
@@ -39,8 +39,9 @@
   },
   "delete": {
     "title": "Supprimer la liste",
-    "confirm": "Supprimer cette liste ?",
-    "submit": "Supprimer"
+    "description": "Cette action est irréversible. Tous les lieux de cette liste seront supprimés.",
+    "submit": "Supprimer",
+    "confirmSubmit": "Supprimer définitivement"
   },
   "fields": {
     "name": "Nom",
@@ -67,8 +68,8 @@
     "error": "Impossible de mettre à jour la liste"
   },
   "deleteList": {
-    "success": "",
-    "error": ""
+    "success": "Liste supprimée avec succès",
+    "error": "Impossible de supprimer la liste"
   },
   "validation": {
     "requiredName": "Le nom de la liste est requis",


### PR DESCRIPTION
## 📝 Description

Ajout de la suppression d'une liste depuis la vue détail : bouton réservé aux rôles OWNER/ADMIN, dialog de confirmation, appel à `useDeleteList`, toasts et retour automatique à l'index. Correction du z-index des dialogs pour qu'ils s'affichent au-dessus du shell applicatif.

## 🎯 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI update (no functional changes)
- [ ] ♻️ Code refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [x] ✅ Test update

## 🔗 Related Issues

Closes NIR-57

## 🚀 Changes Made

- Ajout de `canDeleteList` / `DELETABLE_LIST_ROLES` (miroir API : OWNER et ADMIN uniquement)
- Création du composant `DeleteListDialog` avec confirmation simple et gestion des erreurs 403/404
- Intégration dans `ListsDetailView` (bouton destructif + dialog) et navigation shell (`onDelete` → index)
- Traductions EN/FR pour la suppression (`delete.*`, `deleteList.success` / `error`)
- Augmentation du z-index du composant `Dialog` (`z-10001`) pour griser correctement le shell (`z-9999`)
- Tests unitaires : gating par rôle (VIEWER, EDITOR, OWNER) et flux de suppression mocké

## 🧪 Testing

- [x] Tested locally with `pnpm dev`
- [ ] All quality checks pass (`pnpm lint`)
- [x] Unit tests pass (`pnpm test`)
- [ ] Database migrations applied if needed

## 📸 Screenshots/Videos

N/A — capture recommandée du dialog de suppression sur desktop et mobile (overlay sur tout le shell).

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated if needed
- [x] No console errors or warnings
- [x] Removed any debug code
- [x] Translations added for any new text