### PR TITLE
feat(lists): sync list detail navigation with url params

### DIFF
--- a/apps/web/src/features/app-shell/constants/shell.constants.ts
+++ b/apps/web/src/features/app-shell/constants/shell.constants.ts
@@ -3,6 +3,7 @@ import { Compass, ListChecks, User } from "lucide-react";
 import type { ShellView, ShellViewConfig } from "../types/shell.types";
 
 import {
+  LIST_ID_PARAM,
   PROFILE_SECTION_PARAM,
   SHELL_MAP_MODE_PARAM,
   SHELL_VIEW_PARAM,
@@ -62,6 +63,10 @@ export function buildShellViewSearchParams(current: URLSearchParams, view: Shell
 
   if (view !== "profile") {
     next.delete(PROFILE_SECTION_PARAM);
+  }
+
+  if (view !== "lists") {
+    next.delete(LIST_ID_PARAM);
   }
 
   next.delete(SHELL_MAP_MODE_PARAM);

--- a/apps/web/src/features/lists/constants/lists.constants.test.ts
+++ b/apps/web/src/features/lists/constants/lists.constants.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { canDeleteList, canEditList } from "./lists.constants";
+import {
+  buildListsNavigationSearchParams,
+  canDeleteList,
+  canEditList,
+  parseListId,
+} from "./lists.constants";
 
 describe("canEditList", () => {
   it("allows OWNER, ADMIN, EDITOR", () => {
@@ -24,5 +29,30 @@ describe("canDeleteList", () => {
     expect(canDeleteList("EDITOR")).toBe(false);
     expect(canDeleteList("VIEWER")).toBe(false);
     expect(canDeleteList(undefined)).toBe(false);
+  });
+});
+
+describe("parseListId", () => {
+  it("returns null when param is absent or empty", () => {
+    expect(parseListId(null)).toBe(null);
+    expect(parseListId("")).toBe(null);
+  });
+  it("returns the raw id", () => {
+    expect(parseListId("abc-123")).toBe("abc-123");
+  });
+});
+describe("buildListsNavigationSearchParams", () => {
+  it("builds index URL without listId", () => {
+    const qs = buildListsNavigationSearchParams(new URLSearchParams(), null);
+    expect(qs).toBe("?view=lists");
+  });
+  it("builds detail URL with listId", () => {
+    const qs = buildListsNavigationSearchParams(new URLSearchParams(), "abc-123");
+    expect(qs).toBe("?view=lists&listId=abc-123");
+  });
+  it("removes mapMode and replaces listId when going back to index", () => {
+    const current = new URLSearchParams("view=lists&listId=abc&mapMode=1");
+    const qs = buildListsNavigationSearchParams(current, null);
+    expect(qs).toBe("?view=lists");
   });
 });

--- a/apps/web/src/features/lists/constants/lists.constants.ts
+++ b/apps/web/src/features/lists/constants/lists.constants.ts
@@ -1,3 +1,48 @@
+import { ListsSection } from "../types/lists-section.types";
+
+import {
+  LIST_ID_PARAM,
+  SHELL_MAP_MODE_PARAM,
+  SHELL_VIEW_PARAM,
+} from "@/lib/navigation/search-params";
+
+/** Re-export for hooks/views that import from lists.constants. */
+export { LIST_ID_PARAM } from "@/lib/navigation/search-params";
+
+export const DEFAULT_LISTS_SECTION: ListsSection = "index";
+/**
+ * Parses `listId` from the URL.
+ * Index is represented by `null` (param absent or empty).
+ */
+export function parseListId(raw: string | null): string | null {
+  if (raw === null || raw === "") {
+    return null;
+  }
+  return raw;
+}
+/**
+ * Builds the query string when navigating within the lists shell.
+ *
+ * - Always sets `view=lists`
+ * - Sets `listId` for detail, removes it for index
+ * - Clears `mapMode` (same as profile navigation)
+ */
+export function buildListsNavigationSearchParams(
+  current: URLSearchParams,
+  listId: string | null
+): string {
+  const next = new URLSearchParams(current.toString());
+  next.set(SHELL_VIEW_PARAM, "lists");
+  if (listId === null) {
+    next.delete(LIST_ID_PARAM);
+  } else {
+    next.set(LIST_ID_PARAM, listId);
+  }
+  next.delete(SHELL_MAP_MODE_PARAM);
+  const qs = next.toString();
+  return qs ? `?${qs}` : "";
+}
+
 /** Field limits for list create/update — mirrors POST/PUT /list validation. */
 export const listConstraints = {
   name: { min: 1, max: 255 },

--- a/apps/web/src/features/lists/hooks/use-list-section-url.test.ts
+++ b/apps/web/src/features/lists/hooks/use-list-section-url.test.ts
@@ -1,0 +1,101 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useState } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const push = vi.fn();
+let searchParams = new URLSearchParams();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push,
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+    back: vi.fn(),
+  }),
+  usePathname: () => "/",
+  useSearchParams: () => searchParams,
+}));
+
+import { useListSectionUrl } from "./use-list-section-url";
+
+function useTestHarness(initialListId: string | null = null) {
+  const [listId, setListIdState] = useState(initialListId);
+  const { setListId } = useListSectionUrl(listId, setListIdState);
+  return { listId, setListId };
+}
+
+describe("useListSectionUrl", () => {
+  beforeEach(() => {
+    push.mockClear();
+    push.mockImplementation((href: string) => {
+      const query = href.includes("?") ? href.split("?")[1] : "";
+      searchParams = new URLSearchParams(query);
+    });
+    searchParams = new URLSearchParams();
+  });
+
+  it("pushes detail URL when setListId is called with an id", async () => {
+    const { result } = renderHook(() => useTestHarness(null));
+
+    act(() => {
+      result.current.setListId("abc-123");
+    });
+
+    expect(push).toHaveBeenCalledWith("/?view=lists&listId=abc-123", { scroll: false });
+    await waitFor(() => {
+      expect(result.current.listId).toBe("abc-123");
+    });
+  });
+
+  it("pushes index URL when setListId is called with null", async () => {
+    searchParams = new URLSearchParams("view=lists&listId=abc-123");
+    const { result } = renderHook(() => useTestHarness("abc-123"));
+
+    act(() => {
+      result.current.setListId(null);
+    });
+
+    expect(push).toHaveBeenCalledWith("/?view=lists", { scroll: false });
+    await waitFor(() => {
+      expect(result.current.listId).toBe(null);
+    });
+  });
+
+  it("does not push when setListId is called with the same value", async () => {
+    searchParams = new URLSearchParams("view=lists&listId=abc-123");
+    const { result } = renderHook(() => useTestHarness("abc-123"));
+
+    await waitFor(() => {
+      expect(result.current.listId).toBe("abc-123");
+    });
+
+    act(() => {
+      result.current.setListId("abc-123");
+    });
+
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("syncs listId from URL on mount (deep-link)", async () => {
+    searchParams = new URLSearchParams("view=lists&listId=deep-link-id");
+    const { result } = renderHook(() => useTestHarness(null));
+
+    await waitFor(() => {
+      expect(result.current.listId).toBe("deep-link-id");
+    });
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("syncs listId to null when listId param is removed from URL", async () => {
+    searchParams = new URLSearchParams("view=lists&listId=abc-123");
+    const { result, rerender } = renderHook(() => useTestHarness("abc-123"));
+
+    searchParams = new URLSearchParams("view=lists");
+    rerender();
+
+    await waitFor(() => {
+      expect(result.current.listId).toBe(null);
+    });
+    expect(push).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/features/lists/hooks/use-list-section-url.ts
+++ b/apps/web/src/features/lists/hooks/use-list-section-url.ts
@@ -1,0 +1,22 @@
+import {
+  buildListsNavigationSearchParams,
+  LIST_ID_PARAM,
+  parseListId,
+} from "../constants/lists.constants";
+
+import { useUrlParamState } from "@/lib/navigation";
+
+export function useListSectionUrl(
+  listId: string | null,
+  setListIdState: (listId: string | null) => void
+) {
+  const { setValueAndPush: setListId } = useUrlParamState({
+    param: LIST_ID_PARAM,
+    value: listId,
+    setValue: setListIdState,
+    parse: parseListId,
+    buildHref: (current, next) => buildListsNavigationSearchParams(current, next),
+  });
+
+  return { setListId };
+}

--- a/apps/web/src/features/lists/index.ts
+++ b/apps/web/src/features/lists/index.ts
@@ -4,6 +4,7 @@ export { useList } from "./hooks/use-list";
 export { useCreateList } from "./hooks/use-create-list";
 export { useUpdateList } from "./hooks/use-update-list";
 export { useDeleteList } from "./hooks/use-delete-list";
+export { useListSectionUrl } from "./hooks/use-list-section-url";
 export { createListFormSchema } from "./schemas/lists.schema";
 export {
   listConstraints,
@@ -24,3 +25,4 @@ export type { CreateListInput } from "./hooks/use-create-list";
 export type { UpdateListInput } from "./hooks/use-update-list";
 export type { CreateListFormMessages, CreateListFormData } from "./schemas/lists.schema";
 export type { ListVisibility, ListRole } from "./constants/lists.constants";
+export type { ListsSection } from "./types/lists-section.types";

--- a/apps/web/src/features/lists/navigation/lists-shell-view.tsx
+++ b/apps/web/src/features/lists/navigation/lists-shell-view.tsx
@@ -2,46 +2,52 @@
 
 import { useState } from "react";
 
+import { useListSectionUrl } from "../hooks/use-list-section-url";
 import type { ListsSection } from "../types/lists-section.types";
-import { DEFAULT_LISTS_SECTION } from "../types/lists-section.types";
 import { ListsCreateView } from "../views/lists-create-view";
 import { ListsDetailView } from "../views/lists-detail-view";
 import { ListsEditView } from "../views/lists-edit-view";
 import { ListsIndexView } from "../views/lists-index-view";
 
+type ListsOverlaySection = "create" | "edit" | null;
+
+function resolveSection(listId: string | null, overlay: ListsOverlaySection): ListsSection {
+  if (overlay === "create") return "create";
+  if (overlay === "edit" && listId) return "edit";
+  if (listId) return "detail";
+  return "index";
+}
+
 export function ListsShellView() {
-  const [section, setSection] = useState<ListsSection>(DEFAULT_LISTS_SECTION);
-  const [selectedListId, setSelectedListId] = useState<string | null>(null);
+  const [overlaySection, setOverlaySection] = useState<ListsOverlaySection>(null);
+  const [listId, setListIdState] = useState<string | null>(null);
+  const { setListId } = useListSectionUrl(listId, setListIdState);
+  const section = resolveSection(listId, overlaySection);
 
   const goIndex = () => {
-    setSelectedListId(null);
-    setSection("index");
+    setListId(null);
+    setOverlaySection(null);
   };
 
-  const goCreate = () => setSection("create");
-  const goEdit = () => setSection("edit");
+  const goCreate = () => setOverlaySection("create");
+  const goEdit = () => setOverlaySection("edit");
 
-  const goDetail = (listId: string) => {
-    setSelectedListId(listId);
-    setSection("detail");
+  const goDetail = (id: string) => {
+    setListId(id);
+    setOverlaySection(null);
   };
 
   switch (section) {
     case "detail":
-      if (!selectedListId) return <ListsIndexView onCreate={goCreate} onSelectList={goDetail} />;
+      if (!listId) return <ListsIndexView onCreate={goCreate} onSelectList={goDetail} />;
       return (
-        <ListsDetailView
-          listId={selectedListId}
-          onBack={goIndex}
-          onEdit={goEdit}
-          onDelete={goIndex}
-        />
+        <ListsDetailView listId={listId} onBack={goIndex} onEdit={goEdit} onDelete={goIndex} />
       );
     case "edit":
-      if (!selectedListId) {
+      if (!listId) {
         return <ListsIndexView onCreate={goCreate} onSelectList={goDetail} />;
       }
-      return <ListsEditView listId={selectedListId} onBack={() => setSection("detail")} />;
+      return <ListsEditView listId={listId} onBack={() => setOverlaySection(null)} />;
     case "create":
       return <ListsCreateView onBack={goIndex} />;
     case "index":

--- a/apps/web/src/features/lists/types/lists-section.types.ts
+++ b/apps/web/src/features/lists/types/lists-section.types.ts
@@ -1,3 +1,1 @@
 export type ListsSection = "index" | "create" | "detail" | "edit";
-
-export const DEFAULT_LISTS_SECTION: ListsSection = "index";

--- a/apps/web/src/features/profile/constants/profile.constants.ts
+++ b/apps/web/src/features/profile/constants/profile.constants.ts
@@ -1,6 +1,7 @@
 import type { ProfileSection } from "../types/profile-section.types";
 
 import {
+  LIST_ID_PARAM,
   PROFILE_SECTION_PARAM,
   SHELL_MAP_MODE_PARAM,
   SHELL_VIEW_PARAM,
@@ -42,6 +43,7 @@ export function buildProfileSectionSearchParams(
     next.set(PROFILE_SECTION_PARAM, section);
   }
 
+  next.delete(LIST_ID_PARAM);
   next.delete(SHELL_MAP_MODE_PARAM);
 
   const qs = next.toString();

--- a/apps/web/src/lib/navigation/search-params.ts
+++ b/apps/web/src/lib/navigation/search-params.ts
@@ -1,19 +1,24 @@
 /**
- * Shared query-string keys for app-shell and profile navigation.
+ * Shared query-string keys for app-shell, profile, and lists navigation.
  *
  * Keep param names here so features do not duplicate literals or create
- * circular imports between `app-shell` and `profile`. Builders such as
- * `buildShellViewSearchParams` and `buildProfileSectionSearchParams` should
- * import these constants rather than defining their own.
+ * circular imports between `app-shell`, `profile`, and `lists`. Builders such as
+ * `buildShellViewSearchParams`, `buildProfileSectionSearchParams`, and
+ * `buildListsNavigationSearchParams` should import these constants rather than
+ * defining their own.
  *
  * @example
  * // Shell tab: default view omits the param
- * // /map → explore
- * // /map?view=profile → profile
+ * // / → explore
+ * // /?view=profile → profile
  *
  * @example
  * // Profile subsection (only meaningful when shell view is profile)
- * // /map?view=profile&section=info
+ * // /?view=profile&section=info
+ *
+ * @example
+ * // Lists detail deep-link (only meaningful when shell view is lists)
+ * // /?view=lists&listId=abc123
  */
 export const SHELL_VIEW_PARAM = "view";
 
@@ -24,6 +29,14 @@ export const SHELL_VIEW_PARAM = "view";
  * from the URL (see `buildShellViewSearchParams`).
  */
 export const PROFILE_SECTION_PARAM = "section";
+
+/**
+ * Lists detail key (index is represented by omitting this param).
+ *
+ * When the shell leaves the lists view, builders should remove this param
+ * from the URL (see `buildShellViewSearchParams`).
+ */
+export const LIST_ID_PARAM = "listId";
 
 /** Mobile shell map-focus mode (`?mapMode=1` when the bottom sheet is collapsed). */
 export const SHELL_MAP_MODE_PARAM = "mapMode";


### PR DESCRIPTION
## 📝 Description

Synchronisation de la navigation index ↔ détail des listes avec l’URL du shell (`?view=lists&listId=xxx`), sur le modèle déjà utilisé pour le profil. Permet le deep-linking et le retour navigateur sans rechargement.

## 🎯 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI update (no functional changes)
- [ ] ♻️ Code refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [x] ✅ Test update

## 🔗 Related Issues

Closes NIR-58

## 🚀 Changes Made

- Ajout du paramètre URL partagé `listId` et des builders `parseListId` / `buildListsNavigationSearchParams`
- Création du hook `useListSectionUrl` (wrapper `useUrlParamState`) pour synchroniser l’état avec le router Next.js
- Refactor de `ListsShellView` : section dérivée via `resolveSection` (index/détail via URL, create/edit en overlay local)
- Nettoyage de `listId` lors du changement d’onglet shell ou navigation vers le profil
- Export public de `useListSectionUrl` et du type `ListsSection`
- Tests unitaires des builders et du hook URL (deep-link, push, retour navigateur simulé)

## 🧪 Testing

- [x] Tested locally with `pnpm dev`
- [ ] All quality checks pass (`pnpm lint`)
- [x] Unit tests pass (`pnpm test`)
- [ ] Database migrations applied if needed

## 📸 Screenshots/Videos

N/A

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated if needed
- [x] No console errors or warnings
- [x] Removed any debug code