### PR TITLE
test(lists): add unit tests for schema, query keys and hooks

### DIFF
--- a/apps/web/src/features/lists/hooks/use-create-list.test.tsx
+++ b/apps/web/src/features/lists/hooks/use-create-list.test.tsx
@@ -1,0 +1,83 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useCreateList } from "./use-create-list";
+
+import { createList } from "@/lib/api";
+import { queryKeys } from "@/lib/api/query-keys";
+
+vi.mock("@/lib/api", () => ({
+  createList: vi.fn(),
+}));
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe("useCreateList", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+  });
+
+  it("calls createList and returns data on success", async () => {
+    const input = { name: "Paris", visibility: "PRIVATE" as const };
+    const data = { id: "list-1", name: "Paris", visibility: "PRIVATE" };
+    vi.mocked(createList).mockResolvedValue({ data, error: undefined });
+
+    const { result } = renderHook(() => useCreateList(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    let resolved: typeof data | undefined;
+    await act(async () => {
+      resolved = await result.current.mutateAsync(input);
+    });
+
+    expect(createList).toHaveBeenCalledWith({ body: input });
+    expect(resolved).toEqual(data);
+  });
+
+  it("invalidates lists cache on success", async () => {
+    vi.mocked(createList).mockResolvedValue({
+      data: { id: "list-1", name: "Paris", visibility: "PRIVATE" },
+      error: undefined,
+    });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useCreateList(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ name: "Paris", visibility: "PRIVATE" });
+    });
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.lists.all });
+    });
+  });
+
+  it("throws API error when response has no data", async () => {
+    const apiError = { message: "Forbidden" };
+    vi.mocked(createList).mockResolvedValue({ data: undefined, error: apiError });
+
+    const { result } = renderHook(() => useCreateList(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await expect(
+      act(async () => {
+        await result.current.mutateAsync({ name: "Paris", visibility: "PRIVATE" });
+      })
+    ).rejects.toEqual(apiError);
+  });
+});

--- a/apps/web/src/features/lists/hooks/use-delete-list.test.tsx
+++ b/apps/web/src/features/lists/hooks/use-delete-list.test.tsx
@@ -1,0 +1,86 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useDeleteList } from "./use-delete-list";
+
+import { deleteList } from "@/lib/api";
+import { queryKeys } from "@/lib/api/query-keys";
+
+vi.mock("@/lib/api", () => ({
+  deleteList: vi.fn(),
+}));
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe("useDeleteList", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+  });
+
+  it("calls deleteList and returns data on success", async () => {
+    const listId = "list-1";
+    const data = { success: true };
+    vi.mocked(deleteList).mockResolvedValue({ data, error: undefined });
+
+    const { result } = renderHook(() => useDeleteList(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    let resolved: typeof data | undefined;
+    await act(async () => {
+      resolved = await result.current.mutateAsync(listId);
+    });
+
+    expect(deleteList).toHaveBeenCalledWith({ path: { listId } });
+    expect(resolved).toEqual(data);
+  });
+
+  it("invalidates lists and removes detail cache on success", async () => {
+    const listId = "list-1";
+    vi.mocked(deleteList).mockResolvedValue({
+      data: { success: true },
+      error: undefined,
+    });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const removeSpy = vi.spyOn(queryClient, "removeQueries");
+
+    const { result } = renderHook(() => useDeleteList(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync(listId);
+    });
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.lists.all });
+      expect(removeSpy).toHaveBeenCalledWith({ queryKey: queryKeys.lists.detail(listId) });
+    });
+  });
+
+  it("throws API error when response has no data", async () => {
+    const apiError = { message: "Not found" };
+    vi.mocked(deleteList).mockResolvedValue({ data: undefined, error: apiError });
+
+    const { result } = renderHook(() => useDeleteList(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await expect(
+      act(async () => {
+        await result.current.mutateAsync("list-1");
+      })
+    ).rejects.toEqual(apiError);
+  });
+});

--- a/apps/web/src/features/lists/schemas/lists.schema.test.ts
+++ b/apps/web/src/features/lists/schemas/lists.schema.test.ts
@@ -24,12 +24,52 @@ describe("createListFormSchema", () => {
     expect(result.success).toBe(true);
   });
 
-  it("rejects empty name", () => {
+  it("trims whitespace from name", () => {
+    const result = schema().safeParse({
+      name: "  My list  ",
+      visibility: "PRIVATE",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.name).toBe("My list");
+    }
+  });
+
+  it("accepts input without description", () => {
+    const result = schema().safeParse({
+      name: "My list",
+      visibility: "PRIVATE",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts SHARED and PUBLIC visibility", () => {
+    for (const visibility of ["SHARED", "PUBLIC"] as const) {
+      const result = schema().safeParse({
+        name: "My list",
+        visibility,
+      });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it("rejects invalid visibility", () => {
+    const result = schema().safeParse({
+      name: "My list",
+      visibility: "SECRET",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty name with required message", () => {
     const result = schema().safeParse({
       name: "",
       visibility: "PRIVATE",
     });
     expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe(messages.requiredName);
+    }
   });
 
   it("rejects name longer than max", () => {
@@ -38,6 +78,9 @@ describe("createListFormSchema", () => {
       visibility: "PRIVATE",
     });
     expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe(messages.nameTooLong);
+    }
   });
 
   it("rejects description longer than max", () => {
@@ -47,5 +90,26 @@ describe("createListFormSchema", () => {
       visibility: "PRIVATE",
     });
     expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe(messages.descriptionTooLong);
+    }
+  });
+});
+
+describe("createListFormSchema (edit flow)", () => {
+  it("accepts a typical edit payload", () => {
+    const result = schema().safeParse({
+      name: "Updated list",
+      description: "New description",
+      visibility: "PUBLIC",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual({
+        name: "Updated list",
+        description: "New description",
+        visibility: "PUBLIC",
+      });
+    }
   });
 });

--- a/apps/web/src/lib/api/query-keys.test.ts
+++ b/apps/web/src/lib/api/query-keys.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { queryKeys } from "./query-keys";
+
+describe("queryKeys.lists", () => {
+  it("all is stable root", () => {
+    expect(queryKeys.lists.all).toEqual(["lists"]);
+  });
+
+  it("list includes filters", () => {
+    const filters = { page: 1, limit: 10 };
+    expect(queryKeys.lists.list(filters)).toEqual(["lists", "list", filters]);
+    expect(queryKeys.lists.list()).toEqual(["lists", "list", undefined]);
+  });
+
+  it("infinite includes filters", () => {
+    const filters = { search: "paris", limit: 20 };
+    expect(queryKeys.lists.infinite(filters)).toEqual(["lists", "infinite", filters]);
+    expect(queryKeys.lists.infinite()).toEqual(["lists", "infinite", undefined]);
+  });
+
+  it("detail includes listId", () => {
+    expect(queryKeys.lists.detail("abc")).toEqual(["lists", "detail", "abc"]);
+  });
+
+  it("keys are prefixed by all", () => {
+    expect(queryKeys.lists.list()[0]).toBe(queryKeys.lists.all[0]);
+    expect(queryKeys.lists.infinite()[0]).toBe(queryKeys.lists.all[0]);
+    expect(queryKeys.lists.detail("id")[0]).toBe(queryKeys.lists.all[0]);
+  });
+});


### PR DESCRIPTION
## 📝 Description

Ajout et enrichissement des tests unitaires pour la feature listes (NIR-59) : schéma Zod, clés React Query et hooks de mutation `useCreateList` / `useDeleteList`.

## 🎯 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI update (no functional changes)
- [ ] ♻️ Code refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [x] ✅ Test update

## 🔗 Related Issues

Closes NIR-59

## 🚀 Changes Made

- Enrichissement de `lists.schema.test.ts` : trim du nom, visibilités, messages d’erreur i18n, flux édition
- Ajout de `query-keys.test.ts` pour la structure stable de `queryKeys.lists` (`all`, `list`, `infinite`, `detail`)
- Ajout de `use-create-list.test.tsx` : appel API mocké, invalidation du cache, propagation des erreurs
- Ajout de `use-delete-list.test.tsx` : appel API mocké, `invalidateQueries` + `removeQueries`, propagation des erreurs

## 🧪 Testing

- [x] Tested locally with `pnpm dev`
- [ ] All quality checks pass (`pnpm lint`)
- [x] Unit tests pass (`pnpm test`)
- [ ] Database migrations applied if needed

## 📸 Screenshots/Videos

N/A

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated if needed
- [x] No console errors or warnings
- [x] Removed any debug code