### PR TITLE
feat(i18n): add en/fr translations for list pois and explore

### DIFF
--- a/apps/web/src/features/lists/views/lists-detail-view.test.tsx
+++ b/apps/web/src/features/lists/views/lists-detail-view.test.tsx
@@ -129,7 +129,7 @@ describe("ListsDetailView", () => {
     expect(screen.getByText("My favorite places")).toBeInTheDocument();
     expect(screen.getByText("role.OWNER")).toBeInTheDocument();
     expect(screen.getByText("detail.createdAt")).toBeInTheDocument();
-    expect(screen.getByText("detail.poisComingSoon")).toBeInTheDocument();
+    expect(screen.getByText("pois.section.title")).toBeInTheDocument();
   });
 
   it("shows edit button for OWNER and calls onEdit", async () => {

--- a/apps/web/src/features/lists/views/lists-detail-view.tsx
+++ b/apps/web/src/features/lists/views/lists-detail-view.tsx
@@ -66,7 +66,7 @@ export function ListsDetailView({ listId, onBack, onEdit, onDelete }: ListsDetai
               />
             )}
             <div className="border-t border-border pt-6">
-              <p className="text-sm text-muted-foreground">{tLists("detail.poisComingSoon")}</p>
+              <p className="text-sm text-muted-foreground">{tLists("pois.section.title")}</p>
             </div>
           </div>
         )}

--- a/apps/web/src/lib/i18n/locales-parity.test.tsx
+++ b/apps/web/src/lib/i18n/locales-parity.test.tsx
@@ -1,0 +1,114 @@
+import { renderHook } from "@testing-library/react";
+import { createTranslator, NextIntlClientProvider } from "next-intl";
+import { useTranslations } from "next-intl";
+import type { ReactNode } from "react";
+import { describe, expect, it } from "vitest";
+
+import enExplore from "./locales/en/explore.json";
+import enLists from "./locales/en/lists.json";
+import frExplore from "./locales/fr/explore.json";
+import frLists from "./locales/fr/lists.json";
+
+type JsonObject = Record<string, unknown>;
+
+function collectKeys(obj: JsonObject, prefix = ""): string[] {
+  return Object.entries(obj).flatMap(([key, value]) => {
+    const path = prefix ? `${prefix}.${key}` : key;
+
+    if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+      return collectKeys(value as JsonObject, path);
+    }
+
+    return [path];
+  });
+}
+
+function getValue(obj: JsonObject, path: string): unknown {
+  return path.split(".").reduce<unknown>((current, key) => {
+    if (current && typeof current === "object" && key in (current as JsonObject)) {
+      return (current as JsonObject)[key];
+    }
+    return undefined;
+  }, obj);
+}
+
+function expectLocaleParity(en: JsonObject, fr: JsonObject, namespace: string) {
+  const enKeys = collectKeys(en).sort();
+  const frKeys = collectKeys(fr).sort();
+
+  expect(frKeys, `${namespace}: fr keys should match en`).toEqual(enKeys);
+}
+
+const NEW_LISTS_KEYS = [
+  "pois.section.title",
+  "pois.empty.title",
+  "pois.error.retry",
+  "poi.source.custom",
+  "removePoi.success",
+] as const;
+
+const NEW_EXPLORE_KEYS = [
+  "idle.title",
+  "search.placeholder",
+  "results.empty.title",
+  "addToList.picker.title",
+  "addToList.alreadySaved",
+] as const;
+
+function expectNonEmptyStrings(obj: JsonObject, keys: readonly string[], locale: string) {
+  for (const key of keys) {
+    const value = getValue(obj, key);
+    expect(value, `${locale}.${key}`).toEqual(expect.any(String));
+    expect(String(value).length, `${locale}.${key} should not be empty`).toBeGreaterThan(0);
+  }
+}
+
+function createIntlWrapper(messages: Record<string, unknown>) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <NextIntlClientProvider locale="en" messages={messages}>
+        {children}
+      </NextIntlClientProvider>
+    );
+  };
+}
+
+describe("locales parity", () => {
+  it("lists.json has the same keys in en and fr", () => {
+    expectLocaleParity(enLists, frLists, "lists");
+  });
+
+  it("explore.json has the same keys in en and fr", () => {
+    expectLocaleParity(enExplore, frExplore, "explore");
+  });
+
+  it("new lists keys are non-empty strings in both locales", () => {
+    expectNonEmptyStrings(enLists, NEW_LISTS_KEYS, "en");
+    expectNonEmptyStrings(frLists, NEW_LISTS_KEYS, "fr");
+  });
+
+  it("new explore keys are non-empty strings in both locales", () => {
+    expectNonEmptyStrings(enExplore, NEW_EXPLORE_KEYS, "en");
+    expectNonEmptyStrings(frExplore, NEW_EXPLORE_KEYS, "fr");
+  });
+
+  it("does not keep the removed detail.poisComingSoon key", () => {
+    expect(collectKeys(enLists)).not.toContain("detail.poisComingSoon");
+    expect(collectKeys(frLists)).not.toContain("detail.poisComingSoon");
+  });
+});
+
+describe("message resolution", () => {
+  it("resolves lists and explore namespaces", () => {
+    const messages = { lists: enLists, explore: enExplore };
+
+    const tLists = createTranslator({ locale: "en", messages, namespace: "lists" });
+    const tExplore = createTranslator({ locale: "en", messages, namespace: "explore" });
+
+    expect(tLists("pois.section.title")).toBe("Places");
+    expect(tExplore("search.placeholder")).toBe("Search for a place…");
+    expect(tExplore("addToList.picker.description", { placeName: "Tour Eiffel" })).toBe(
+      'Choose a list for "Tour Eiffel"'
+    );
+  });
+});

--- a/apps/web/src/lib/i18n/locales/en/explore.json
+++ b/apps/web/src/lib/i18n/locales/en/explore.json
@@ -1,0 +1,36 @@
+{
+  "idle": {
+    "title": "Find places",
+    "description": "Search for cafés, museums, restaurants and more."
+  },
+  "search": {
+    "placeholder": "Search for a place…",
+    "hint": "Cafés, museums, restaurants",
+    "minLengthHint": "Type at least 2 characters to search",
+    "loading": "Searching…"
+  },
+  "results": {
+    "title": "Results",
+    "empty": {
+      "title": "No places found",
+      "description": "Try a different name or address."
+    },
+    "error": {
+      "title": "Search failed",
+      "retry": "Retry"
+    }
+  },
+  "addToList": {
+    "action": "Add to list",
+    "picker": {
+      "title": "Add to a list",
+      "description": "Choose a list for \"{placeName}\"",
+      "empty": "No lists you can edit",
+      "submit": "Add"
+    },
+    "success": "Added to {listName}",
+    "error": "Could not add the place",
+    "alreadySaved": "This place is already in the list",
+    "viewList": "View list"
+  }
+}

--- a/apps/web/src/lib/i18n/locales/en/lists.json
+++ b/apps/web/src/lib/i18n/locales/en/lists.json
@@ -28,8 +28,7 @@
     "back": "Back to lists",
     "loading": "Loading list…",
     "notFound": "List not found",
-    "createdAt": "Created at {date}",
-    "poisComingSoon": "Places coming soon"
+    "createdAt": "Created at {date}"
   },
   "edit": {
     "title": "Edit list",
@@ -79,5 +78,37 @@
   "row": {
     "poiCount": "{count, plural, =0 {No places saved} one {# place saved} other {# places saved}}",
     "collaboratorCount": "{count, plural, one {# collaborator} other {# collaborators}}"
+  },
+  "pois": {
+    "section": {
+      "title": "Places",
+      "total": "{total, plural, =0 {No places} one {# place} other {# places}}"
+    },
+    "empty": {
+      "title": "No places yet",
+      "description": "Search for places in Explore to add them here."
+    },
+    "loading": "Loading places…",
+    "loadingMore": "Loading more…",
+    "error": {
+      "title": "Could not load places",
+      "retry": "Retry"
+    }
+  },
+  "poi": {
+    "source": {
+      "custom": "Custom place",
+      "google": "Google"
+    },
+    "addressUnknown": "No address",
+    "categoryUnknown": "Place"
+  },
+  "removePoi": {
+    "action": "Remove",
+    "title": "Remove place",
+    "description": "\"{placeName}\" will be removed from this list.",
+    "confirmSubmit": "Remove",
+    "success": "Place removed from list",
+    "error": "Could not remove the place"
   }
 }

--- a/apps/web/src/lib/i18n/locales/fr/explore.json
+++ b/apps/web/src/lib/i18n/locales/fr/explore.json
@@ -1,0 +1,36 @@
+{
+  "idle": {
+    "title": "Trouver des lieux",
+    "description": "Recherche des cafés, musées, restaurants et plus encore."
+  },
+  "search": {
+    "placeholder": "Rechercher un lieu…",
+    "hint": "Cafés, musées, restaurants",
+    "minLengthHint": "Saisis au moins 2 caractères pour lancer la recherche",
+    "loading": "Recherche en cours…"
+  },
+  "results": {
+    "title": "Résultats",
+    "empty": {
+      "title": "Aucun lieu trouvé",
+      "description": "Essaie un autre nom ou une autre adresse."
+    },
+    "error": {
+      "title": "La recherche a échoué",
+      "retry": "Réessayer"
+    }
+  },
+  "addToList": {
+    "action": "Ajouter à une liste",
+    "picker": {
+      "title": "Ajouter à une liste",
+      "description": "Choisis une liste pour « {placeName} »",
+      "empty": "Aucune liste que tu peux modifier",
+      "submit": "Ajouter"
+    },
+    "success": "Ajouté à {listName}",
+    "error": "Impossible d'ajouter le lieu",
+    "alreadySaved": "Ce lieu est déjà dans la liste",
+    "viewList": "Voir la liste"
+  }
+}

--- a/apps/web/src/lib/i18n/locales/fr/lists.json
+++ b/apps/web/src/lib/i18n/locales/fr/lists.json
@@ -28,8 +28,7 @@
     "back": "Retour aux listes",
     "loading": "Chargement de la liste…",
     "notFound": "Liste introuvable",
-    "createdAt": "Créée le {date}",
-    "poisComingSoon": "Lieux à venir"
+    "createdAt": "Créée le {date}"
   },
   "edit": {
     "title": "Modifier la liste",
@@ -79,5 +78,37 @@
   "row": {
     "poiCount": "{count, plural, =0 {Aucun lieu enregistré} one {# lieu enregistré} other {# lieux enregistrés}}",
     "collaboratorCount": "{count, plural, one {# collaborateur} other {# collaborateurs}}"
+  },
+  "pois": {
+    "section": {
+      "title": "Lieux",
+      "total": "{total, plural, =0 {Aucun lieu} one {# lieu} other {# lieux}}"
+    },
+    "empty": {
+      "title": "Aucun lieu pour l'instant",
+      "description": "Recherche des lieux dans Explorer pour les ajouter ici."
+    },
+    "loading": "Chargement des lieux…",
+    "loadingMore": "Chargement…",
+    "error": {
+      "title": "Impossible de charger les lieux",
+      "retry": "Réessayer"
+    }
+  },
+  "poi": {
+    "source": {
+      "custom": "Lieu personnalisé",
+      "google": "Google"
+    },
+    "addressUnknown": "Aucune adresse",
+    "categoryUnknown": "Lieu"
+  },
+  "removePoi": {
+    "action": "Retirer",
+    "title": "Retirer le lieu",
+    "description": "« {placeName} » sera retiré de cette liste.",
+    "confirmSubmit": "Retirer",
+    "success": "Lieu retiré de la liste",
+    "error": "Impossible de retirer le lieu"
   }
 }


### PR DESCRIPTION
## 📝 Description

Ajout des traductions en/fr pour les lieux sauvegardés dans une liste et la recherche Explore minimale. Prépare les clés i18n consommées par NIR-63 (affichage des POIs) et NIR-65 (recherche Google + ajout à une liste).

## 🎯 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI update (no functional changes)
- [ ] ♻️ Code refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [x] ✅ Test update

## 🔗 Related Issues

Closes NIR-62
Closes #93

## 🚀 Changes Made

- Extension de `lists.json` (en/fr) : sections `pois`, `poi`, `removePoi` pour l'affichage, les items et la suppression
- Création de `explore.json` (en/fr) : états idle, recherche, résultats et flux `addToList`
- Suppression de la clé obsolète `detail.poisComingSoon`
- Mise à jour de `ListsDetailView` et de son test pour utiliser `pois.section.title` en attendant NIR-63
- Ajout de `locales-parity.test.tsx` : parité des clés en/fr + résolution des messages via `createTranslator`

## 🧪 Testing

- [x] Tested locally with `pnpm dev`
- [ ] All quality checks pass (`pnpm lint`)
- [x] Unit tests pass (`pnpm test`)
- [ ] Database migrations applied if needed

## 📸 Screenshots/Videos

N/A

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated if needed
- [x] No console errors or warnings
- [x] Removed any debug code