### PR TITLE
feat(google-place): enhance photo fetching with cache refresh and err…

### DIFF
--- a/apps/api/__test__/google-place/cache-utils.test.ts
+++ b/apps/api/__test__/google-place/cache-utils.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { prisma } from "../../src/db";
+import { hydrateExpiredGooglePlaceCaches } from "../../src/google-place/cache-utils";
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+describe("hydrateExpiredGooglePlaceCaches", () => {
+  beforeEach(async () => {
+    await prisma.savedPoi.deleteMany();
+    await prisma.poiList.deleteMany();
+    await prisma.googlePlaceCache.deleteMany();
+    await prisma.user.deleteMany();
+    mockFetch.mockReset();
+    vi.stubEnv("GOOGLE_PLACES_API_KEY", "test-api-key");
+  });
+
+  it("refreshes expired google place caches attached to saved pois", async () => {
+    const user = await prisma.user.create({
+      data: {
+        email: "cache-utils@test.com",
+        passwordHash: "hash",
+        emailVerified: true,
+      },
+    });
+
+    await prisma.googlePlaceCache.create({
+      data: {
+        placeId: "ChIJexpired-place",
+        name: "Expired Place",
+        latitude: 48.85,
+        longitude: 2.35,
+        photoReferences: ["places/ChIJexpired-place/photos/old"],
+        expiresAt: new Date(Date.now() - 1000),
+      },
+    });
+
+    const list = await prisma.poiList.create({
+      data: { name: "Test", createdBy: user.id },
+    });
+
+    const savedPoi = await prisma.savedPoi.create({
+      data: {
+        listId: list.id,
+        googlePlaceId: "ChIJexpired-place",
+      },
+      include: { poi: true, googlePlaceCache: true },
+    });
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        id: "ChIJexpired-place",
+        displayName: { text: "Updated Place", languageCode: "fr" },
+        location: { latitude: 48.85, longitude: 2.35 },
+        photos: [{ name: "places/ChIJexpired-place/photos/new", widthPx: 800, heightPx: 600 }],
+      }),
+    });
+
+    const [hydrated] = await hydrateExpiredGooglePlaceCaches([savedPoi], "fr");
+
+    expect(hydrated.googlePlaceCache?.name).toBe("Updated Place");
+    expect(hydrated.googlePlaceCache?.photoReferences).toEqual([
+      "places/ChIJexpired-place/photos/new",
+    ]);
+  });
+
+  it("leaves fresh caches untouched", async () => {
+    const user = await prisma.user.create({
+      data: {
+        email: "cache-utils-fresh@test.com",
+        passwordHash: "hash",
+        emailVerified: true,
+      },
+    });
+
+    await prisma.googlePlaceCache.create({
+      data: {
+        placeId: "ChIJfresh-place",
+        name: "Fresh Place",
+        latitude: 48.85,
+        longitude: 2.35,
+        photoReferences: ["places/ChIJfresh-place/photos/current"],
+        expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+      },
+    });
+
+    const list = await prisma.poiList.create({
+      data: { name: "Test", createdBy: user.id },
+    });
+
+    const savedPoi = await prisma.savedPoi.create({
+      data: {
+        listId: list.id,
+        googlePlaceId: "ChIJfresh-place",
+      },
+      include: { poi: true, googlePlaceCache: true },
+    });
+
+    const [hydrated] = await hydrateExpiredGooglePlaceCaches([savedPoi], "fr");
+
+    expect(hydrated.googlePlaceCache?.name).toBe("Fresh Place");
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/__test__/google-place/routes.test.ts
+++ b/apps/api/__test__/google-place/routes.test.ts
@@ -12,6 +12,22 @@ const app = createServer();
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
 
+function mockValidPhotoFetch() {
+  const buffer = Buffer.alloc(2000, 0);
+  buffer[0] = 0xff;
+  buffer[1] = 0xd8;
+  buffer[2] = 0xff;
+
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({ photoUri: "https://example.com/photo.jpg" }),
+  });
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    arrayBuffer: async () => buffer,
+  });
+}
+
 describe("Google Place Routes", () => {
   let accessToken: string;
   let userId: string;
@@ -444,12 +460,7 @@ describe("Google Place Routes", () => {
     });
 
     it("should return photo buffer with correct headers", async () => {
-      const mockPhotoBuffer = Buffer.from("fake-image-data");
-
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        arrayBuffer: async () => mockPhotoBuffer,
-      });
+      mockValidPhotoFetch();
 
       const response = await request(app)
         .get("/google-place/photo?ref=places/test/photos/abc123")
@@ -457,29 +468,25 @@ describe("Google Place Routes", () => {
 
       expect(response.status).toBe(200);
       expect(response.headers["content-type"]).toBe("image/jpeg");
-      expect(response.headers["cache-control"]).toBe("public, max-age=86400");
+      expect(response.headers["cache-control"]).toBe(
+        "private, no-cache, no-store, must-revalidate"
+      );
     });
 
     it("should pass maxWidth to Google API", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        arrayBuffer: async () => Buffer.from("fake-image"),
-      });
+      mockValidPhotoFetch();
 
       await request(app)
         .get("/google-place/photo?ref=places/test/photos/abc123&maxWidth=800")
         .set("Authorization", `Bearer ${accessToken}`);
 
-      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
       const url = mockFetch.mock.calls[0][0];
       expect(url).toContain("maxWidthPx=800");
     });
 
     it("should use default maxWidth of 400", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        arrayBuffer: async () => Buffer.from("fake-image"),
-      });
+      mockValidPhotoFetch();
 
       await request(app)
         .get("/google-place/photo?ref=places/test/photos/abc123")
@@ -489,7 +496,7 @@ describe("Google Place Routes", () => {
       expect(url).toContain("maxWidthPx=400");
     });
 
-    it("should return error when Google API fails", async () => {
+    it("should return error when Google API fails for a non-place photo ref", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: false,
         status: 404,
@@ -499,18 +506,38 @@ describe("Google Place Routes", () => {
         .get("/google-place/photo?ref=invalid-ref")
         .set("Authorization", `Bearer ${accessToken}`);
 
-      expect(response.status).toBe(404);
+      expect(response.status).toBe(400);
       expect(response.body.error.code).toBe("GOOGLE_PLACE_PHOTO_ERROR");
+    });
+
+    it("should refresh place cache when a place photo ref fails", async () => {
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 404 }).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: "test",
+          displayName: { text: "Test Place", languageCode: "en" },
+          location: { latitude: 0, longitude: 0 },
+          photos: [],
+        }),
+      });
+
+      const response = await request(app)
+        .get("/google-place/photo?ref=places/test/photos/abc123")
+        .set("Authorization", `Bearer ${accessToken}`);
+
+      expect(response.status).toBe(502);
+      expect(response.body.error.code).toBe("GOOGLE_PLACE_PHOTO_ERROR");
+      expect(mockFetch).toHaveBeenCalledTimes(2);
     });
 
     it("should handle network errors in photo fetch", async () => {
       mockFetch.mockRejectedValueOnce(new TypeError("fetch failed"));
 
       const response = await request(app)
-        .get("/google-place/photo?ref=places/test/photos/abc123")
+        .get("/google-place/photo?ref=invalid-ref")
         .set("Authorization", `Bearer ${accessToken}`);
 
-      expect(response.status).toBe(500);
+      expect(response.status).toBe(400);
       expect(response.body.error.code).toBe("GOOGLE_PLACE_PHOTO_ERROR");
     });
   });
@@ -583,10 +610,7 @@ describe("Google Place Routes", () => {
     });
 
     it("should include RateLimit headers in photo response", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        arrayBuffer: async () => Buffer.from("fake-image"),
-      });
+      mockValidPhotoFetch();
 
       const response = await request(app)
         .get("/google-place/photo?ref=places/test/photos/headers-test")

--- a/apps/api/__test__/google-place/service.test.ts
+++ b/apps/api/__test__/google-place/service.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { prisma } from "../../src/db";
+import {
+  extractPlaceIdFromPhotoRef,
+  getPhotoWithCacheRefresh,
+  refreshPlaceCache,
+} from "../../src/google-place/service";
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+function mockValidPhotoFetch() {
+  const buffer = Buffer.alloc(2000, 0);
+  buffer[0] = 0xff;
+  buffer[1] = 0xd8;
+  buffer[2] = 0xff;
+
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({ photoUri: "https://example.com/photo.jpg" }),
+  });
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    arrayBuffer: async () => buffer,
+  });
+}
+
+describe("Google Place service", () => {
+  beforeEach(async () => {
+    await prisma.googlePlaceCache.deleteMany();
+    mockFetch.mockReset();
+    vi.stubEnv("GOOGLE_PLACES_API_KEY", "test-api-key");
+  });
+
+  describe("extractPlaceIdFromPhotoRef", () => {
+    it("extracts place id from a photo resource name", () => {
+      expect(extractPlaceIdFromPhotoRef("places/ChIJabc123/photos/AcnlKN0test")).toBe("ChIJabc123");
+    });
+
+    it("returns null for invalid refs", () => {
+      expect(extractPlaceIdFromPhotoRef("invalid-ref")).toBeNull();
+    });
+  });
+
+  describe("getPhotoWithCacheRefresh", () => {
+    it("refreshes place cache and retries with fresh refs when photo fetch fails", async () => {
+      const staleRef = "places/ChIJrefresh-test/photos/stale-ref";
+      const freshRef = "places/ChIJrefresh-test/photos/fresh-ref";
+
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 404 }).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: "ChIJrefresh-test",
+          displayName: { text: "Refreshed Place", languageCode: "fr" },
+          location: { latitude: 48.85, longitude: 2.35 },
+          photos: [{ name: freshRef, widthPx: 800, heightPx: 600 }],
+        }),
+      });
+
+      mockValidPhotoFetch();
+
+      const buffer = await getPhotoWithCacheRefresh(staleRef, 400);
+
+      expect(buffer.length).toBeGreaterThan(1000);
+
+      const cached = await prisma.googlePlaceCache.findUnique({
+        where: { placeId: "ChIJrefresh-test" },
+      });
+      expect(cached?.photoReferences).toEqual([freshRef]);
+    });
+  });
+
+  describe("refreshPlaceCache", () => {
+    it("always fetches fresh data from Google", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: "ChIJforce-refresh",
+          displayName: { text: "Fresh Place", languageCode: "fr" },
+          location: { latitude: 48.85, longitude: 2.35 },
+          photos: [{ name: "places/ChIJforce-refresh/photos/new", widthPx: 800, heightPx: 600 }],
+        }),
+      });
+
+      await prisma.googlePlaceCache.create({
+        data: {
+          placeId: "ChIJforce-refresh",
+          name: "Stale Place",
+          latitude: 48.85,
+          longitude: 2.35,
+          photoReferences: ["places/ChIJforce-refresh/photos/old"],
+          expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+        },
+      });
+
+      const refreshed = await refreshPlaceCache("ChIJforce-refresh", "fr");
+
+      expect(refreshed.name).toBe("Fresh Place");
+      expect(refreshed.photoReferences).toEqual(["places/ChIJforce-refresh/photos/new"]);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/api/__test__/shared/routes.test.ts
+++ b/apps/api/__test__/shared/routes.test.ts
@@ -8,6 +8,8 @@ import { ErrorCodes } from "../../src/utils/error-codes";
 
 const app = createServer();
 
+const freshGooglePlaceCacheExpiresAt = () => new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+
 describe("Shared Routes", () => {
   let ownerId: string;
   let listId: string;
@@ -183,6 +185,7 @@ describe("Shared Routes", () => {
           name: "Google Place",
           latitude: 48.8566,
           longitude: 2.3522,
+          expiresAt: freshGooglePlaceCacheExpiresAt(),
         },
       });
 
@@ -217,6 +220,7 @@ describe("Shared Routes", () => {
           name: "Google Place",
           latitude: 48.8566,
           longitude: 2.3522,
+          expiresAt: freshGooglePlaceCacheExpiresAt(),
         },
       });
 

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -1,15 +1,39 @@
 import { PrismaPg } from "@prisma/adapter-pg";
-import { PrismaClient, PoiVisibility, CollaboratorRole } from "@prisma/client";
+import { PrismaClient, PoiVisibility, CollaboratorRole, GooglePlaceCache } from "@prisma/client";
 import { hashPassword } from "../src/auth/hash";
 import { env } from "../src/env";
+import { refreshPlaceCache } from "../src/google-place/service";
 
 const adapter = new PrismaPg({ connectionString: env.DATABASE_URL });
 const prisma = new PrismaClient({ adapter });
 
+const SEED_GOOGLE_PLACE_IDS = [
+  "ChIJxYJUC2lv5kcRlhdpWba_aGU", // Le Tout-Paris
+  "ChIJf-oe7Wdu5kcRRto099RQ9Fc", // Sacrée Fleur Montmartre
+  "ChIJ0Y7Uk_lv5kcRxQMuMKFtVmc", // Le Marais Restaurant Paris
+] as const;
+
+async function seedGooglePlaces() {
+  if (!env.GOOGLE_PLACES_API_KEY) {
+    console.warn("⚠️  GOOGLE_PLACES_API_KEY not set — skipping Google Places seed");
+    return [];
+  }
+
+  console.log("📍 Fetching Google Places from API...");
+  const places: GooglePlaceCache[] = [];
+
+  for (const placeId of SEED_GOOGLE_PLACE_IDS) {
+    const place = await refreshPlaceCache(placeId, "fr");
+    places.push(place);
+    console.log(`   ✓ ${place.name}`);
+  }
+
+  return places;
+}
+
 async function main() {
   console.log("🌱 Seeding database...");
 
-  // Create 3 users
   const user1 = await prisma.user.create({
     data: {
       email: "theobrissiaud@icloud.com",
@@ -28,7 +52,7 @@ async function main() {
     },
   });
 
-  const user3 = await prisma.user.create({
+  await prisma.user.create({
     data: {
       email: "bob@test.com",
       passwordHash: await hashPassword("password123"),
@@ -37,7 +61,6 @@ async function main() {
     },
   });
 
-  // Create POIs
   const poi1 = await prisma.poi.create({
     data: {
       name: "Fraktion",
@@ -51,336 +74,8 @@ async function main() {
     },
   });
 
-  // Create google places POIs
-  const googlePlace1 = await prisma.googlePlaceCache.create({
-    data: {
-      placeId: "ChIJxYJUC2lv5kcRlhdpWba_aGU", // Tour Eiffel
-      name: "Le Tout-Paris",
-      nameLang: "fr",
-      address: "8 Quai du Louvre, 75001 Paris, France",
-      latitude: 48.8587493,
-      longitude: 2.3422529,
-      category: "french_restaurant",
-      categoryDisplayName: "French Restaurant",
-      categoryDisplayNameLang: "en-US",
-      rating: 4.6,
-      userRatingCount: 1960,
-      openingHours: {
-        openNow: true,
-        periods: [
-          {
-            open: {
-              day: 0,
-              hour: 7,
-              minute: 0,
-            },
-            close: {
-              day: 1,
-              hour: 1,
-              minute: 0,
-            },
-          },
-          {
-            open: {
-              day: 1,
-              hour: 7,
-              minute: 0,
-            },
-            close: {
-              day: 2,
-              hour: 1,
-              minute: 0,
-            },
-          },
-          {
-            open: {
-              day: 2,
-              hour: 7,
-              minute: 0,
-            },
-            close: {
-              day: 3,
-              hour: 1,
-              minute: 0,
-            },
-          },
-          {
-            open: {
-              day: 3,
-              hour: 7,
-              minute: 0,
-            },
-            close: {
-              day: 4,
-              hour: 1,
-              minute: 0,
-            },
-          },
-          {
-            open: {
-              day: 4,
-              hour: 7,
-              minute: 0,
-            },
-            close: {
-              day: 5,
-              hour: 1,
-              minute: 0,
-            },
-          },
-          {
-            open: {
-              day: 5,
-              hour: 7,
-              minute: 0,
-            },
-            close: {
-              day: 6,
-              hour: 1,
-              minute: 0,
-            },
-          },
-          {
-            open: {
-              day: 6,
-              hour: 7,
-              minute: 0,
-            },
-            close: {
-              day: 0,
-              hour: 1,
-              minute: 0,
-            },
-          },
-        ],
-        nextCloseTime: "2026-01-16T00:00:00Z",
-        weekdayDescriptions: [
-          "Monday: 7:00 AM – 1:00 AM",
-          "Tuesday: 7:00 AM – 1:00 AM",
-          "Wednesday: 7:00 AM – 1:00 AM",
-          "Thursday: 7:00 AM – 1:00 AM",
-          "Friday: 7:00 AM – 1:00 AM",
-          "Saturday: 7:00 AM – 1:00 AM",
-          "Sunday: 7:00 AM – 1:00 AM",
-        ],
-      },
-      photoReferences: [
-        "places/ChIJxYJUC2lv5kcRlhdpWba_aGU/photos/AcnlKN2LPK5WqXz7EOANDm8PU6uv3VVn2sRjjnt1C85ubPGprM67MEZ12HkRgD_rt2ofWYUOrMZO74tWPoGEHyFtBr4WLoP-MZp-LVBJVkPZ1tPNqY7be3c9oPYBF08mc1UQbUNMAC_pTwdghdNA6fW9uMmDsmZpNWrzg1gzLq4Z7DpimKbYv3vnv_UhNECWKph7D-kvgS82J3VY2hp2RBWggRjPeAGpXYLloMnx1BIXHI3dE-2EJLEIc6C2otWHwF-L7wmZ3P2ZBcAmTZDJ7oFoYqwbwzoYvDl91zrPIHUUpdL_ew",
-        "places/ChIJxYJUC2lv5kcRlhdpWba_aGU/photos/AcnlKN0k4duGU9uT0p7jCPVYfnR-taUY1RV5FNTclLENUvh606NcfbACOYQ2iUKjM5q650sV9QReuUAK4xX2Xb1Y_jTjZrGSyMTFcIPoMt_7aFblJ8USfwm1eB31AcM0UJDhJ_1cdd-mxwJud4Ttmn-7dFQ7KXgNbL1UhM5vJgOyUFg4zHMqmw4ih9Hty0-9Qb0j6nUxy2QYYA7xCwqKdIKqMJ1s1mR-RMxzAh1G9ATPDMMzohiUUArs04A57il6G4Enn8u75prnO8-fngk1Q6Tk6MxR_Ak6m3RIHGY3Vu9achioMg",
-        "places/ChIJxYJUC2lv5kcRlhdpWba_aGU/photos/AcnlKN0MCZTL6WmyzY1jyv9lo78WXn0Y8QEUfgjpxElyi54CYXAQl2zXMRrzxx9-TbaBA-kyNGsCb2FTAOHTGH1AIXgQf6DnomvK819ALvNeOL2ju3f5PtapXxKDB7GKYcyN2gWZzUO_oVEr0Jn58OSB3rM1CPUD736ZmPxMNMTFN3eYr9-RhSmdIzaIh1ZGxdYCjDF4v_3MNXeWt6n6xpJ5_Hs6ocHtoGy8keRuCmO5x4zwTGVMABS5Vn6SdSt1KATUQzOFXdRZ0TL-5bnb0zfKpuNGuIhimBdDjaLsejyNhTzyijZAlRFT4x8kfSropWnw9kTrwp33PtrrF3zVcJ9q_csUUyPUk_c_HmRKKjsQvaLmBQ5AUCtOXkBLnBQM7AS2YRcUaSYjqJxs4YDxE59925dj619QWou3YGW_Cv8DjT7bMkLAtgIRePPWmNBHnejq",
-        "places/ChIJxYJUC2lv5kcRlhdpWba_aGU/photos/AcnlKN3WO8NwUd9kKXbksLtFpvMvDK4z63ALmsDRbfVSo1-Ie_1v3MNrGNqUZ72sSCgyCmhLONLYjDfsHrauvNFEGCJ7HG7Ee8TSNT27E72A3EXpQF3j0Ox_scEz6BaQ4F-48SYs9k5N_ZkN5WukIYMdz4nkz7EjkFzPR4bCOrVJG4nV1yrRJAuBHfX8JDfDaLr_bpnyPzxHWHHghUaL9NDgApiiDRvMyW79r8qZERs_0kEnPg0Ps0vGZkZ-YpYrcOayq8hGa1XlYzCGWODSgdSwZCLfKLmNJ5DrDsmng_hLpeaM_bGkwz9-fLiRDCQ_xP05Gt3xqVjz_c5iOkucG0dp-J_ffl_2xPZzMQDkFPCbiv1RmsQU9xEFvt91-Nw83yR6mV4KZmxGe2Dg-hbPJpccBlrFxuq8C2UI1dOZFOvv0r3BNQ",
-        "places/ChIJxYJUC2lv5kcRlhdpWba_aGU/photos/AcnlKN1c9F6GTPvjaF1J7RGNRbkdAdJiaP0Aoxs0prVEC0UCWmqIVChOwHcGRbnXdFATlXDfwQaiG9SRNvIF4azPI1nmRtsK90WFdFvZi97UfXJmcOqPn0wDd-Rc03zUDqxspNbsn1RJeO8TQ7BgyF9IsmOH6TiPXrrzAA8NworxgR79tsDmAGcpRWTgkJ6waRTUZi5sVdVIgXa7SVRdLnkP0u2H2AP5PreF_Qco4s5ug-WNoNv1GLVGM6R2oM96Ah1PdCPHoWzvhyjce0AmpanN1I0NQXBP99G488OoAEQC689vwJClmIScjKUS9trg9YDG3gqiglde9sbuFrRp0C51gg4wWx_AWZP8y2I_LPrbBBQONx8ZpC9vO6E4LCsDiR1RU0_MlfUM1R0e-cL9HzPESUaCU6NGCkHt8mt1dohy36F82lQpi2_vRTRpyIHjaA",
-        "places/ChIJxYJUC2lv5kcRlhdpWba_aGU/photos/AcnlKN0aC26CmG-J68Vei63nQQy78K36JR2uKTPl3hUV6gSNh19SvlQ52exH06ocSCLAOCZ_T2-rHaLsM154PdGezHBKJ20rS9CMR6fuvkb559lCmC44FEVewryFg9DgY66eElvJfbe6mxeCaYA2DZ73WpYDfZ4g205HDvIyV3Uw_Y_KQtDKL5rAwLRyGuuQGYhGbVhuuy1q9kRfc3qjXXQ3rzxC_41EoP5pFmAk8LbGSCZhr4DCNLbm9DZvfkOhJ9uZqdnz6JQWQwSmoAds1tjv-JmKoX7g-KaPnlW-Q0FEZs4_DwV_cXp2zo4PK6A3EmoJsbeQD2Y6KBDJHNtFXowbTQ_edkVD38_oZcFKJb03QOblC2Lm6Jmo5uf1De3Ze_P6LCaafA1rNVh66j9yzogLal1pWgz7bDKLDf8UPzUzvZj8U3EeDQQeLUgxhTJfjQ",
-        "places/ChIJxYJUC2lv5kcRlhdpWba_aGU/photos/AcnlKN1CjswHz3-r88poqAynWDMZpzSFVcW_OckwbQgOjSFmj-ONh6AyI_YLnK91cm3zwohvCSSTZts8w4M1jJ0cxLe7ehWPREEhTCBnUtrLOpnOicc296-zfYJNnoCOWc73iMEmEw16jlS417Fz2r2y422FLpcAIDhxEk7FFndY7e0E3_Rw28UIcSoo8Dnss-BN0TCR5bhNbc0ieMuvWawAmt-iNimA38j7-G-tCFX0wCVpSG2gkZtXmatUhg4Eksio2pgyJXVpkbyPW3KPeQU9KvhLZ_luOrBSVz-wz2iXqpvHBw",
-        "places/ChIJxYJUC2lv5kcRlhdpWba_aGU/photos/AcnlKN0wTWLZQwYkS8bgNm1dNIzAdYwS6ss4txdfeDqJ-_Bx90ATIDj9lkBBBjEurtX7ruJYwpCtmoKcLFWUsxp69CAfkjYSBbYVrKg73SmDE2g7HdF91qUyXut002B0mY0Wv7DPWwIRqKgp8Tz7VmbjrbN7tASubxbQ9JknDgwNDcXbDk8V31nUTmRtwWLabOUTix2amDr0bWbea9bd9XiIk7Q2GtElE2xr-2JNFwjpqq09ElgeeREqQ1c-eq2QhVDGVjbzhoTQrqr6L53rYxCkjIPdoDvJeUkpK9TapNT0YjSOuIwIUhSXtpPPHEiHeYoqyJ2s8bHWTB1LtT1ov_GhD7O0D-SAdjKF7GAXpZPkorupsY2AVDMuyqWXrMLTNVj59oQzy-OlDkoG9KPnrrc3mlSQ2qhnV0zMA3coLwWXrM2xM6IfRyUtpnVgQqUuQfeU",
-        "places/ChIJxYJUC2lv5kcRlhdpWba_aGU/photos/AcnlKN1TR0rDyW2LOG2rnj8UXa5Y-8Fu4f2-YKTd_Yr7QBw0hEyaLBybJ6EQkWjNIsB0LJfm_Ad5xb2-PLp-4-hNXYO5AHG_ORJYLmFzv9VJW0u9MKlhkuUCR36j9HxMeuF-MJc0-uJc4qKZ8_BcFU-gbmR2z_9ZVsI5Yt5ukRZoDv5KSIDz8V8lpxDF8B5al-LSKNpe2tLD7TcHg9J1MhhVr_z52cqL5uzYWyRPSmW2-uNEtwoREudotcqv0z0N32jLjDoLQQuJCLxk4D457uCPjZkDnnb1I9UqSHuGMtngrGA0OKB5CP1B9P7D6s9wqOXzVENRQlPWwgYxUYZNnrQKq9n93HtjeRpN70e99ToRVlfYw115gId_TweGZKjY9AI3rTgOq2HiIZIkhDNWc0le9u-UdImEyoe7VeEu0SvlznJyxTkKKgGk9ZyyeTj0kEP6",
-        "places/ChIJxYJUC2lv5kcRlhdpWba_aGU/photos/AcnlKN0LUE9nV87XORxhLbn2jTXGMjXn6AvbMABx_EMs8LyJYObOkRKcHd_564OkcaCIXvdtX6xbmw3A5d_kGhxxJengNp-sjCQLoQOWf2Eqyz3STlLyTNnNBqd2MLBe-PtsnDgMA3bPJxCatiuUFlbe0EF0uI3oGyEL1EdK7Qh6kB4JYaqIa1jFjIwrmSIBcBJ2zE9bQazcrsGB8z9E6g3tzQjRyDW-4ZtJhylkyIaJkMOL8CHCsCy387Rr5WdgdOxYC7vxb1ZqBO967mV8Mn_5ErxcID9rPgmlNhVyVnbrVGrtHiqg2n_8O4ve8DpCp3L_lcja8ST8YtlPd2o84ItklMPQKeHrAGT7oeNC5wAARBzof4BCsyhJ9bS8EZxbp6L2XdUMaThwp2s-SqKuqsmv_MKscfmCUGiib2O-CZZSXatBxj473M52u8CiN-hrrw",
-      ],
-      googleMapsUri:
-        "https://maps.google.com/?cid=7307301185313642390&g_mp=CiVnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLkdldFBsYWNlEAIYBCAA",
-      expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
-    },
-  });
+  const googlePlaces = await seedGooglePlaces();
 
-  const googlePlace2 = await prisma.googlePlaceCache.create({
-    data: {
-      placeId: "ChIJf-oe7Wdu5kcRRto099RQ9Fc",
-      name: "Sacrée Fleur Montmartre",
-      nameLang: "fr",
-      address: "50 Rue de Clignancourt, 75018 Paris, France",
-      latitude: 48.8876187,
-      longitude: 2.3479882,
-      category: "french_restaurant",
-      categoryDisplayName: "French Restaurant",
-      categoryDisplayNameLang: "en-US",
-      rating: 4.5,
-      userRatingCount: 1200,
-      openingHours: {
-        openNow: false,
-        periods: [
-          {
-            open: {
-              day: 1,
-              hour: 18,
-              minute: 0,
-            },
-            close: {
-              day: 1,
-              hour: 22,
-              minute: 0,
-            },
-          },
-          {
-            open: {
-              day: 2,
-              hour: 18,
-              minute: 0,
-            },
-            close: {
-              day: 2,
-              hour: 22,
-              minute: 0,
-            },
-          },
-          {
-            open: {
-              day: 3,
-              hour: 18,
-              minute: 0,
-            },
-            close: {
-              day: 3,
-              hour: 22,
-              minute: 0,
-            },
-          },
-          {
-            open: {
-              day: 4,
-              hour: 18,
-              minute: 0,
-            },
-            close: {
-              day: 4,
-              hour: 22,
-              minute: 0,
-            },
-          },
-          {
-            open: {
-              day: 5,
-              hour: 18,
-              minute: 0,
-            },
-            close: {
-              day: 5,
-              hour: 22,
-              minute: 0,
-            },
-          },
-          {
-            open: {
-              day: 6,
-              hour: 18,
-              minute: 0,
-            },
-            close: {
-              day: 6,
-              hour: 22,
-              minute: 0,
-            },
-          },
-        ],
-        nextOpenTime: "2026-01-15T17:00:00Z",
-        weekdayDescriptions: [
-          "Monday: 6:00 – 10:00 PM",
-          "Tuesday: 6:00 – 10:00 PM",
-          "Wednesday: 6:00 – 10:00 PM",
-          "Thursday: 6:00 – 10:00 PM",
-          "Friday: 6:00 – 10:00 PM",
-          "Saturday: 6:00 – 10:00 PM",
-          "Sunday: Closed",
-        ],
-      },
-      photoReferences: [
-        "places/ChIJf-oe7Wdu5kcRRto099RQ9Fc/photos/AcnlKN24yZUb2ZL3b3St6QrqtGdRK49fl2-tq8UNusb33u09zhm4fUYbtyV01BI9sfVWbETGCvONL4LcuNALRcSiJfGg94zHP-nzWn5uKtg8mIfyIcrm-MlY3TiSPr19Jjx5GCEeqyHHr7C66mk3ZHu_e9b1cRglYDvO1-zK4z737LXh9_ySpnA8RBF8i5aewdnafHc-PL0sNW1oufQByPGnEKy-Bw-0DSxUR20zrG4WCIWCqsXchqFoE-YN6r-GuXJaZhsPiaJWQ_voQrCOUXDeAqv5LGdWmvakeRkzXu-LLcnlMA",
-        "places/ChIJf-oe7Wdu5kcRRto099RQ9Fc/photos/AcnlKN0uCt_a45N_xM3EQaPCU5glEFH3SJtpPMbCPdNQP8z6kxqkKpbS0mjxZeccC9EwcRi7puELlha0_9Gif5stDEicjYxyr7CyV96vQSk7JBLj92ADnnkKnSVHEiHGf2d6ZfAO2w-9Xca_yQRiDJYG1lNdKhSFtdvS-1RdANEpBg3LcUIAgPRqE-AavfHmLeN3oWOEBR3pdjbbYkGZQQyWMfeqSwsffRDpzavkm-tuc-jHbgpXofnlZMKAxcVsaMZJozz4cqdrpynyyQI9JkKf4CXUWpAYVChfEvIJnqhifhuXKA",
-        "places/ChIJf-oe7Wdu5kcRRto099RQ9Fc/photos/AcnlKN23v1mWn8doF4RoJ56DYUoaYihMBiZjFCjuCR_4AHsU4d3jyRwEEX7d7G5nbfxVek_61V-0b6OzUqeieiy3rtaiwQaknOQnmedU_Qr8cgUOciuX-ZPXM-D0hBdIScRMXbfSFp3eGddzabJwmSEf4vFGdx1W2US0RWoXn0DZ7aPHeC7x6FrPeIi6Meiy1Q21e9kysIs8E15WrvnGzDxHiU0BMcRdI42FHAMg7uY2a5589wNoe-WSeXc52Jyje0RijFUNqT1A-lByot7wAKgoHdJ9fDZ9l9DnYmL-MBO_wmeaJ87x6F0LPuzJshBySFJ-VQPaKtLigxtYC1du2-ubQHa0CIpO_P7VtnB4K_39wfs7BleV0fS3LeJGynvfNDokxl2EGkkDcxazPYjAze-qpDuZOiNFs5-5LrRjks35vQiMNziiS_DUcpUSFrHUrKBm",
-        "places/ChIJf-oe7Wdu5kcRRto099RQ9Fc/photos/AcnlKN1ybQDQmsTHTw8UfMibM_wZVtXUM54DZslZiVkL3SxISfvAnoJ0B3qijmrh7pROEzFuvF7Rm-Q4GcrETsg8W-ozL9UrwC2iqyw5DRVLxHZEnCgknQ7u0UDXOgCKIRqYnyZWOIkFGP-cRMcungLLbnzLPGV_rG9aXSn2GxHHS0NmKY8HNRbM-XZTX0yAV_bfUJJJucrVv9nLdsnGh2rq3u_lA4J-ech1Mu1-Jgt2FlIc-hvucyiyIAjgGoZCrICgIlU-ONzU4MSeD6-uCXa_KkZ9o-eTVvIyT5Q611CG__pesVoufBia060Z-v875TB8I4Cz-ruKMnYVEuPR1V8BPHIzv9fhTucztVgzHhrpQKKr_T4uXRsKKBc2huqnxDIIQA5uml0T5hnftldR0FVsJ94WSbsJlEMFRHbw8oHRTy9NyVnGkIvSmlXCN3fIX89x",
-        "places/ChIJf-oe7Wdu5kcRRto099RQ9Fc/photos/AcnlKN1F8GwdWSgR_br79ec3bhcShGk0GjbOn6UFfQZNNK_nLD7-AyszTEatAg3_k_L8OdAE2B0WOGng3lNHh3gVeBuyKpu_F_aXwtCkD7cTdF4soT8_B8RYzwFb_DLJTZUlz8ynfNsWc6cucjsouDoZPT1IT38o7mR31yB1pR3RUWiR0ASvKi9SGa0qV2syOxIxf9Z5CrIXNPy_DoJq1kawmxQhF4SGFeSCcZRcQcvPjvgjpMbLePiF6uHwNGXNhrU5lIekr6nmRxvUjRq6aGbaGVDaR7Eh7LMGERlEEWhh1lz_4zAFcFBFR5O3wBhlgmfmlgZCxt5QBrjOM2l0_uuzdrTUnWUo6s1SyWDlWSC1zGkSfdSWBCNhH4aUL4xTcAClsqcxRZt6NyQS6XHsYtFzHsOPnelIf-V81vHdUpbo2Rq58Qm1",
-        "places/ChIJf-oe7Wdu5kcRRto099RQ9Fc/photos/AcnlKN3msZHNX2QpogSTnUflJ-ObpXIbcAMA3_bEQF8Gnvs7SfZfYk45rnWiz0yytNh3XigYgOQ8TkIBeAWOwiGmPMJea09Gj4-M_4hlQeIOpLQxOajGDXQcV8TjQHP7CsTFK2wuzfEG2rt64voPsll5EalbJP_oYx2aTDc7ToALRPA3qYXN0V-yJO7HSHYVbWZjdC0co4gE2SJYjcuT2oD_Zb61xm1X2LYK8Cf1a6fuNYOWUuzvccdeqrkxZe_Mm3K6mFsObKqqRfod14QlMgwJey9URPbWFMHyP_0TlRLjsYcP7I_wGPmKqQUkO52DJEosnfSARdMPgiMbqOEd_Ov4RdXxWXh76-NfSIXQ9dSNCZ2IDp5X8NKx3srerKOCxJHZnNvSfgEoddKwrvltmOvo9cZbEAQtw2fvf5PIRyoUfIJGhHCedFz1yJWpZcOJqis2",
-        "places/ChIJf-oe7Wdu5kcRRto099RQ9Fc/photos/AcnlKN1JMRHqb13bsTpzci6b_aysiU022nNx9xYtSOtcfs_DoXvN6xW09StUWj3Km6ApCWLKbcB6KPdHFgWqNHzRRe1NST1JChTFR2wcvJSWc7uZQWCt4JCfK-77jxSVRNVLE7Om6rSL5e7oRT1ai5fOE-zc-8I01bYfsKR6Xzi0_9Q48un-2wZJp9QioytRj4ILdf5C_KT14_K4JpkofS4KgO-XCoTiuT8IQIrdBMYsQjaeAR_IqZ7X1xW2H_-qSw5ZLPBRPlgKjYyNaS_4JKrSieR5zbBLL-4_YjMjiQDbmEg6bzAs0y4kzowUI4Zir37J6s0XRXSnAhtZasnoz41UL65CJoqOOnTPkkZpdnDIqiKA9yFLr_CDF4zX95S1S3kcgdOPkL8uAa4Im9X8uZoiZuhaL3vnw9lGVRk1y-CgJLOkFQ",
-        "places/ChIJf-oe7Wdu5kcRRto099RQ9Fc/photos/AcnlKN1k25TlwmTh10z2SnrL_n8FXdLfY42SVT83jqCMEGf2UkpURqcZrj3kAacC4SjgdlgLAmHN_IIEFNGywdGCn_uuu5NHbLOD_krbW0BwMQFg-S-UWjqlcSLMMKRAZB6hAE9FqK-cxhdBAv3cl2-Y37SMALuAy9TELlvwF3oo-ZsRDynV4NuyHIBSdFlwqahpNr0V67e6nGZn9qsRrnFlEpuzMlpHYSOKArpHWLyS5-yBoOaQjYOUgArCO_ZkZNrO3_dt2NgP6CTpg6957RI3FHdyCQdD8jpJ0_w79w8JQfgSuOmNjWPhWK5NjyJFdfZ4M1WklWSND5rrJyu6OhXU47ZjrrWD1nehKC0Firqx_PJoQ4JtnVCKEu1yt7Q6dWiIldW6lvhuRt_kcYYzbyonUe0dO61DfCsrt-XUfUoKQOnF9Zo",
-        "places/ChIJf-oe7Wdu5kcRRto099RQ9Fc/photos/AcnlKN0RojQcO8AmgO8RSPp8mrk2aM6RvlIWPmmQoZ9Y39iHeF0wIjh-XSamzhh7CMaKcf1GZcf8j0rRLExHRd1HoAFksjpVmBcvAH7PZkvw6u50hShFNQUqdVS7jn6FuG3gblOQlzcLJKbR1UD_k78HS5jHeHb1eYTB7dsw8bS_8Sa6-a8FUouTdkdC2iETHHXNxc72uapXHY1O0oBbY5hMGXz5s1BQG6p4tdegK0wlq0UvVlr50ivB7NDQtH_Ad_fmN2EOSx7gsplcYJjsbaBMq_myqv7uXIpjax1VUAJti25m4A",
-        "places/ChIJf-oe7Wdu5kcRRto099RQ9Fc/photos/AcnlKN2-lusA1ASUfBBJNLCejh62UcIkkASMT9lupSCdZmSmbP3rpNloOeCL6nsKVi54feCPSAfDG7S32gG01c-VxnKbqCPGjd4s2B8cJ00ShcJ8CcC2oz7LeEMaAYoYRhurqlnH7luTpV5SDUkovo7vY3hMgWDPMEfzUS_yrxpKtLO9KL0YgBo8-7DpcZQjgNTUCGagTuZzOCwcH3WC7GE-_mrtVrNS2bxONSKtt_qdb3bEAa7zpJAxhn6S11qfcXHvXdUU0IuLy5jXlZVp9urG_33mvl0RQuMRWJDGpJD7hdVeNEQboqPBd5U8Q1ejbdWBOL0FN77Aj2sIxKx_5GgOrA1vdIZBW1Pvbz3S7y2nq5Dt_BahOjTKuJ12NoVbq51f0UkB02L8V7Uv7fU7ctWRrBNqUmzlEVJNbUDoGJSzadCi1rcgU4gX-ZZK9VNtY5f5",
-      ],
-      googleMapsUri:
-        "https://maps.google.com/?cid=11554511042646742106&g_mp=CiVnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLkdldFBsYWNlEAIYBCAA",
-      expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
-    },
-  });
-
-  const googlePlace3 = await prisma.googlePlaceCache.create({
-    data: {
-      placeId: "ChIJ0Y7Uk_lv5kcRxQMuMKFtVmc",
-      name: "Le Marais Restaurant Paris",
-      nameLang: "fr",
-      description:
-        "Prime steaks, burgers, salads & desserts, plus beer & wine, in an easygoing venue with a courtyard.",
-      descriptionLang: "en",
-      address: "47 R. de Turbigo, 75003 Paris, France",
-      latitude: 48.86513799999999,
-      longitude: 2.3540023,
-      category: "mediterranean_restaurant",
-      categoryDisplayName: "Mediterranean Restaurant",
-      categoryDisplayNameLang: "en-US",
-      website: "https://www.privateaser.com/lieu/44897-le-marais-restaurant",
-      phone: "+33 9 87 36 09 13",
-      priceLevel: 2,
-      openingHours: {
-        openNow: true,
-        periods: [
-          {
-            open: { day: 0, hour: 9, minute: 0 },
-            close: { day: 1, hour: 0, minute: 0 },
-          },
-          {
-            open: { day: 1, hour: 9, minute: 0 },
-            close: { day: 2, hour: 0, minute: 0 },
-          },
-          {
-            open: { day: 2, hour: 9, minute: 0 },
-            close: { day: 3, hour: 0, minute: 0 },
-          },
-          {
-            open: { day: 3, hour: 9, minute: 0 },
-            close: { day: 4, hour: 0, minute: 0 },
-          },
-          {
-            open: { day: 4, hour: 9, minute: 0 },
-            close: { day: 5, hour: 0, minute: 0 },
-          },
-          {
-            open: { day: 5, hour: 9, minute: 0 },
-            close: { day: 6, hour: 0, minute: 0 },
-          },
-          {
-            open: { day: 6, hour: 9, minute: 0 },
-            close: { day: 0, hour: 0, minute: 0 },
-          },
-        ],
-        nextCloseTime: "2026-01-15T23:00:00Z",
-        weekdayDescriptions: [
-          "Monday: 9:00 AM – 12:00 AM",
-          "Tuesday: 9:00 AM – 12:00 AM",
-          "Wednesday: 9:00 AM – 12:00 AM",
-          "Thursday: 9:00 AM – 12:00 AM",
-          "Friday: 9:00 AM – 12:00 AM",
-          "Saturday: 9:00 AM – 1:00 AM",
-          "Sunday: 9:00 AM – 12:00 AM",
-        ],
-      },
-      rating: 4.6,
-      userRatingCount: 890,
-      photoReferences: [
-        "places/ChIJ0Y7Uk_lv5kcRxQMuMKFtVmc/photos/AcnlKN2hObi2Rd1GcAxI4ExSxQ3k7oeMTIxyA5vOrARj-ofp8I5cU8yL63NhxvtZk6crTDTZF-i-PAPh7ISOnOatsMguYSdP5ik1WkVRRHY2zDYeFiAfQqZD0AcpSg0ZT2oX4VycHhBOG9w8fVYH7NRx6GYSAuiecQM2BTrkGaaVrLOsiQRXH_Rs18VHoESFu1ufyre1NA5nsNZCN7R5sfZbGlZuYCstbnckBrJyeccQPzfDNGIDnle4FA05gp0Y2L8P3WX4d-lOmOLUqMHe3NvxJYahg6pM29RwOlOFowdaMwwTOA",
-        "places/ChIJ0Y7Uk_lv5kcRxQMuMKFtVmc/photos/AcnlKN0bBHWOqLk6jICPQpPzT13-emKipJH9igMJgPN3G0hgG-wdqqhgFkQNopGko1vt68qFw1c7B8kTuyRVNmK1HsD3W9PTCjREesrkZUSEKrAymRD0slvAZpKOdBMkz4lSBSWnO-ElArnfi0unzoy3SZPGpMrY4rVNubIyiyeStH2-9eYzSs5ga5uaeHgQELjT6uM9HVw2G8qGn78KfPcRvZmjRb5IHJZnZux7mBGcXUsjDMuHiU9T-hs1HX0MmJl9AoQLkyuVDy-10sCVmR3IRssSe8IZ-BIHHVcSo2BU_dg2gw",
-        "places/ChIJ0Y7Uk_lv5kcRxQMuMKFtVmc/photos/AcnlKN1AlD4R11GY8vZ-ZSHNrIxPa_WJ1I0KeP70AyJctJR9EAegQMSaITaMXbAMuAGZgp1761V0p0CVHzgzVuuc-4czLKHsUp4DRMn0ZozNLOUVKb8GHzR-oaNeEcH_szIEk0lCiMbwhvDaeclLX62Z2fgq8g-AMNqsu2ceEYiYl3IOpIt7c9mZyyA7q58yzjA3uZey5cSh7r-QzqVJN8qzpKLOGCnw96MkUL-qQz1_O2gUBso0UX2oxEYN1m1H07Mga-On5ewGPxb1W1JAFvIjA4JvVyDY8aKyzFB6NGIdHWojSbpj6_Ui0bBCnV99O_qePb3s4kBlrvgO4gRGDqNaFsSxooJiFan68DtS6kEgYw8fKGo6gLCKMobBmr0lSUv0B-BA4PrCPI2ol58WVH7vef3BrddV-FC1YrnguxMXaiunO3wm3dvyBmuu2KBz1m1H",
-        "places/ChIJ0Y7Uk_lv5kcRxQMuMKFtVmc/photos/AcnlKN1lOxrYXNkYpFExC0s7ZloQPfid73FPMpLCd2WzNcZ8_ph-W7RX7PlAO9p2atyoNBHWimtm3lgMLoygrjNRArVmlC8ThEUE1C6-zyrUFYUm6klG0Q7TvCjSlcgC0OUczJgq_t7C0BR5-Yr-VA0us9sTMOSTrtEFzDiQP0-ikBScvFFIUA4PPoCJipEhjWFzj3qbzZ6w6S68GLHUrh3Si0bKgHDoSvvEuze16t87XRDdpzUDg4k4xH6FQjbe1yUfXIa7-8Inzm8QT-nFH2L65S3aZiB3_gLRPvYTMaeZWfb9IlRaVsTRaQMghYGhWoM49ZW2yil01N7gfgVEcghknvzes-HQlT72SOIfF6tZetm-sjhaPYWKIoF7-Bv2KVmbwRqbSRPe0I4UQ8s74iIAFTsc8q749FH0-jCWgMjnv1Xa_QWtsEmLtWizszHtKlbG",
-        "places/ChIJ0Y7Uk_lv5kcRxQMuMKFtVmc/photos/AcnlKN08cV-DXMaVzuQK4c8P8VSrDOrkGVa-_SvNhGOukiazgjpAi6UrP2XvOzH7Un-gaf6K3c__sqDfF8kKOy1hheC314kEjM3k0nKuVPfxTfRaLu3CEf7ONxB6blGxJreqoDMkFtAParSvIqN2_KEKHZpNfvHtbji59iIy6zeKsEfUn5-tnHOXfF85t5m4g23_jFTNtR9VVv5vr5cTT9Nh7zAcj6L8VvlvCJGXx6lD5SGZuxy5cqsjulyack8m_Bn-LN0R9w0k72v-M2tDCeTEZ6kzwgaanCUto96vDpsuMVI32555_W0SB-Ywemzq1LrbKjFCUTA7jn4B7cMUuh6QecAlZ5pl5ZjzUqViGZrglxp-qDSOvI4xh6BE-1A5LifgBPZuAzIMTZzH-gn5slUfgVvvDU4rWRs4DBfFseQSNPyrCCvTFuViX6DLjV28-Q",
-        "places/ChIJ0Y7Uk_lv5kcRxQMuMKFtVmc/photos/AcnlKN18FLa-lH9FXnQ0MjFG8fnNbmNUueZPbq2X1e928fpG4D0oMzE_fpkUq_9dJyoes21XjFIvn2jMzWdBhh1ZLd-qq-kIzd2_8s5MPkeo30wY59DVPEY1fJQHQ4HcRo-Q4qOUMcSEfl7J0kTgohYZ3TrAkdQmemPC3-PUOe8YtJpGTYeWhq7RANqKQsXuIzctEHGkfqfOE4yzkjRwpTeAGheHMbLbCILLUhrhosDRktDDwyoQMzMCl7Cyx4b5njp2BRtTu50emlMSJA-brmVvYU_y7yI4Z9QR-j-exrYCrGj4oul3IXIi2XQIN1iN8QPrf4AtwO4KIHGWcO6jt93aSOcLVRLq1BgE1Fd1TSHIrYc_yPcqj2KIdF0do7qZp8hoTITPsLW2vTU0JKLWuh2tlqT2Olynxk2LaA7Tzs6Ab90Sgg",
-        "places/ChIJ0Y7Uk_lv5kcRxQMuMKFtVmc/photos/AcnlKN3zVWf4eBKIyF3mOEgzdpgfx_CuVmwcoCo37lKfQlMRzJ57a3sYkorDuH-F4J2XG4mS9PNuT-k6_X2NwX4n0ORdWvsKQNsjS7hiD4iKiYD0FO2b0xINuMQEqBECtrL1eXyRrOkXyhyPK0gKyjNunuqMx3zdiLk4SUYSSdh9fRR-b0Z_vGhLRcTtTOfZK3CpDhKSuvWsMDFXGDh3Odk7OaNBCVdtoRlI6tvFBuSgEfabl_DJsNgyac7T8ocQPpP_NxoJqofWJu8ciE5PUfAS7EdcbVjery2c4lUVu04_sjvJFISw-n1mQ9Sbq3_n236O_9DiA8ddo79Y73RU6N-J4Hx4OSKLd1TfHiRco-LGad7wkhipf4hoE3k8E0rB2C60aZpK8LqOPwx0792nhdhZSmrqe3Y8eRz3FwtoNcTK3vm8fd7N",
-        "places/ChIJ0Y7Uk_lv5kcRxQMuMKFtVmc/photos/AcnlKN34XSwSlk3EvDgBy06Y9jhu5a86AQ8b9RuCCQyKm9f7qCXvTaG2fwFO8HRz6Jcm1WFWiVg4qpyeMjsISHZEulrvji06NlSpAGVM9NzJx5II9a9vkmExV0el8QjLgMRyBMEOLGLDf9Pw9JaWx5X07CMxnDTbXj4GK-VaIxbz2CQ3Vw6YCxp84qVNmfjc0bHgG9rlC4rqZBQ5xuECyBagX91VR2rgN2Hek_1HIRWM2-nX1OPZjJMoPVxJEituta0Tr5wELmTUWn7D2z5xU6fPjj_bK83MXNtKMR3-JDGtEt5qK7MQXd9IHSmPxIF-AR_2ltuZuFto0sXw4Jm7SGNj214wzwwZwkOMxuZsjLIaG6LWRXt0Yl5Bc1irqJydSuGq7_GzYH4SvvD1BkBqFelg02CgDksqzhnV9nCteDcwCI_DOQ",
-        "places/ChIJ0Y7Uk_lv5kcRxQMuMKFtVmc/photos/AcnlKN1UACoHsARiXIjGFnzae2p6OQy3DbzTPEnulkmV-iW3b0AAEwFuZMf0VOuwzVlvxvhWdd5UOpzDCw9ChU-rK_5gZWLSlXn9e1lz2LYj9G25aPJlre7GWzXxz9jFdo2Xk5L8B8bcB2UnrlYCXiL4N5p6A-N736yCuC1FKpQfcBcndTPZKtLTsp1c7J-MC23RxEROl4tAJO8ZPZHwd19bgWVOr6dfKGdNpkD8ndGDFRFUJjEAB24Y5b8jvH8pQldXN0gbbJkr8Q4u2lPyuvHIKkk0FMw8SxZveJmqkdPR7MsADLVdwoZRmh0z8YFCjQSMNe5RhznzwoUXIkdE59SgxkCJiJZhviQ-9u8trDFSLCcCYPbNrhHldxtDtDyq-ydJBpw9-8VBBtrvG7O5OgXUbDkq52Qi-cLf_s5DO6vj_Hg",
-        "places/ChIJ0Y7Uk_lv5kcRxQMuMKFtVmc/photos/AcnlKN2PMs0I3NHJjSLbTSz7reUE5u2QjrFhk6pQNDdYVNvfRg9NoDSD9nDeTShMBIwllvxYf9XCtlb5C0sE4GuqrZY0J9xKphYhbkTnK3DpqVah-uWKbm2418SUQ4IKbGzKP9-58r4eK9EHd3610k4Yx0lbvBS_PDTTixWdQQdOtU5GdnZ7tL7HyZIdTnL1nsWfz0S-qarKLFRCTxPp3iZ-Wa_ZxzwGth6AtT6To2tuaZd0Ko19ZfSQfWgWWgv80nKB3JnvVUFJWfmM-3RBebQMiI-CIQqPgOrlw1LlJqnnrvP6TKzFTMVkGRyjzq-xmIuf7TP9MkxoIhZRRqHMTJEp823I7YtShb0pgnPHvyNIe48IGJpgQvTb7I05W-6kAgL7jHPv-XwVqkwA1ZT3bcClPeSCQX9gO4oOEPho2RxeUoQqMw",
-      ],
-      googleMapsUri:
-        "https://maps.google.com/?cid=1575247511252127996&g_mp=CiVnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLkdldFBsYWNlEAIYBCAA", // example CID, update as needed
-      expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
-    },
-  });
-
-  // Create lists
   const list1 = await prisma.poiList.create({
     data: {
       name: "Mes lieux favoris à Paris",
@@ -399,7 +94,6 @@ async function main() {
     },
   });
 
-  // Add POIs to lists
   await prisma.savedPoi.create({
     data: {
       listId: list1.id,
@@ -407,26 +101,14 @@ async function main() {
     },
   });
 
-  await prisma.savedPoi.create({
-    data: {
-      listId: list1.id,
-      googlePlaceId: googlePlace1.placeId,
-    },
-  });
-
-  await prisma.savedPoi.create({
-    data: {
-      listId: list1.id,
-      googlePlaceId: googlePlace2.placeId,
-    },
-  });
-
-  await prisma.savedPoi.create({
-    data: {
-      listId: list1.id,
-      googlePlaceId: googlePlace3.placeId,
-    },
-  });
+  for (const googlePlace of googlePlaces) {
+    await prisma.savedPoi.create({
+      data: {
+        listId: list1.id,
+        googlePlaceId: googlePlace.placeId,
+      },
+    });
+  }
 
   await prisma.savedPoi.create({
     data: {
@@ -435,14 +117,15 @@ async function main() {
     },
   });
 
-  await prisma.savedPoi.create({
-    data: {
-      listId: list2.id,
-      googlePlaceId: googlePlace1.placeId,
-    },
-  });
+  if (googlePlaces[0]) {
+    await prisma.savedPoi.create({
+      data: {
+        listId: list2.id,
+        googlePlaceId: googlePlaces[0].placeId,
+      },
+    });
+  }
 
-  // Add collaborator to list
   await prisma.listCollaborator.create({
     data: {
       listId: list1.id,
@@ -454,8 +137,8 @@ async function main() {
 
   console.log("✅ Seed completed!");
   console.log(`   - 3 users created`);
-  console.log(`   - 2 POIs created`);
-  console.log(`   - 3 Google Places cached`);
+  console.log(`   - 1 custom POI created`);
+  console.log(`   - ${googlePlaces.length} Google Places cached`);
   console.log(`   - 2 lists created`);
   console.log(`   - 1 collaborator added`);
   console.log("");

--- a/apps/api/src/google-place/cache-utils.ts
+++ b/apps/api/src/google-place/cache-utils.ts
@@ -1,0 +1,47 @@
+import type { GooglePlaceCache, Poi, SavedPoi } from "@prisma/client";
+
+import { getOrFetchPlace } from "./service";
+
+export type SavedPoiWithGoogleCache = SavedPoi & {
+  poi: Poi | null;
+  googlePlaceCache: GooglePlaceCache | null;
+};
+
+export async function hydrateExpiredGooglePlaceCaches<T extends SavedPoiWithGoogleCache>(
+  savedPois: T[],
+  language = "en-US"
+): Promise<T[]> {
+  const now = new Date();
+  const expiredPlaceIds = [
+    ...new Set(
+      savedPois
+        .filter(
+          (savedPoi) =>
+            savedPoi.googlePlaceCache &&
+            (!savedPoi.googlePlaceCache.expiresAt || savedPoi.googlePlaceCache.expiresAt <= now)
+        )
+        .map((savedPoi) => savedPoi.googlePlaceCache!.placeId)
+    ),
+  ];
+
+  if (expiredPlaceIds.length === 0) {
+    return savedPois;
+  }
+
+  const refreshedEntries = await Promise.all(
+    expiredPlaceIds.map(async (placeId) => {
+      const refreshed = await getOrFetchPlace(placeId, language);
+      return [placeId, refreshed] as const;
+    })
+  );
+  const refreshedByPlaceId = new Map(refreshedEntries);
+
+  return savedPois.map((savedPoi) => {
+    if (!savedPoi.googlePlaceCache) {
+      return savedPoi;
+    }
+
+    const refreshed = refreshedByPlaceId.get(savedPoi.googlePlaceCache.placeId);
+    return refreshed ? { ...savedPoi, googlePlaceCache: refreshed } : savedPoi;
+  });
+}

--- a/apps/api/src/google-place/routes.ts
+++ b/apps/api/src/google-place/routes.ts
@@ -7,7 +7,7 @@ import { SUPPORTED_LANGUAGES } from "../types";
 import { ErrorCode, ErrorCodes } from "../utils/error-codes";
 import { ApiError, formatError, handleZodError } from "../utils/errors";
 
-import { getOrFetchPlace, searchPlaces, getPhoto } from "./service";
+import { getOrFetchPlace, searchPlaces, getPhotoWithCacheRefresh } from "./service";
 
 export const googlePlaceRouter = Router();
 
@@ -190,10 +190,11 @@ googlePlaceRouter.get("/photo", requireAuth, photoRateLimiter, async (req, res) 
   try {
     const { ref, maxWidth } = getPhotoSchema.parse(req.query);
 
-    const photoBuffer = await getPhoto(ref, maxWidth);
+    const photoBuffer = await getPhotoWithCacheRefresh(ref, maxWidth);
 
     res.set("Content-Type", "image/jpeg");
-    res.set("Cache-Control", "public, max-age=86400");
+    res.set("Cache-Control", "private, no-cache, no-store, must-revalidate");
+    res.set("Pragma", "no-cache");
     res.send(photoBuffer);
   } catch (err) {
     if (err instanceof z.ZodError) {

--- a/apps/api/src/google-place/service.ts
+++ b/apps/api/src/google-place/service.ts
@@ -70,6 +70,27 @@ export function mapGooglePlaceToCache(place: GooglePlaceResponse, language: stri
   };
 }
 
+async function upsertPlaceCache(placeId: string, language: string) {
+  const googleData = await fetchPlaceDetails(placeId, language);
+  const cacheData = mapGooglePlaceToCache(googleData, language);
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { placeId: _unused, ...updateData } = cacheData;
+
+  return prisma.googlePlaceCache.upsert({
+    where: { placeId },
+    create: cacheData,
+    update: updateData,
+  });
+}
+
+/**
+ * Force-fetch place details from Google and update the cache.
+ */
+export async function refreshPlaceCache(placeId: string, language?: string) {
+  return upsertPlaceCache(placeId, language ?? "en-US");
+}
+
 /**
  * Get a place from cache, or fetch from Google API and cache it
  */
@@ -84,20 +105,12 @@ export async function getOrFetchPlace(placeId: string, language?: string) {
     return cached;
   }
 
-  const googleData = await fetchPlaceDetails(placeId, lang);
+  return upsertPlaceCache(placeId, lang);
+}
 
-  const cacheData = mapGooglePlaceToCache(googleData, lang);
-
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { placeId: _unused, ...updateData } = cacheData;
-
-  const upserted = await prisma.googlePlaceCache.upsert({
-    where: { placeId },
-    create: cacheData,
-    update: updateData,
-  });
-
-  return upserted;
+export function extractPlaceIdFromPhotoRef(photoReference: string): string | null {
+  const match = photoReference.match(/^places\/([^/]+)\/photos\//);
+  return match?.[1] ?? null;
 }
 
 /**
@@ -261,29 +274,109 @@ export async function getPhoto(photoReference: string, maxWidth: number = 400): 
   }
 
   try {
-    const response = await fetch(
-      `https://places.googleapis.com/v1/${photoReference}/media?maxWidthPx=${maxWidth}&skipHttpRedirect=true&key=${env.GOOGLE_PLACES_API_KEY}`,
-      { method: "GET" }
+    const metaResponse = await fetch(
+      `https://places.googleapis.com/v1/${photoReference}/media?maxWidthPx=${maxWidth}&skipHttpRedirect=true`,
+      {
+        method: "GET",
+        headers: { "X-Goog-Api-Key": env.GOOGLE_PLACES_API_KEY },
+      }
     );
 
-    if (!response.ok) {
+    if (!metaResponse.ok) {
       throw new ApiError(
-        response.status,
+        metaResponse.status,
         ErrorCodes.GOOGLE_PLACE_PHOTO_ERROR,
-        "Failed to fetch photo"
+        "Failed to fetch photo metadata"
       );
     }
 
-    return Buffer.from(await response.arrayBuffer());
-  } catch (error) {
-    if (error instanceof ApiError) {
-      throw error;
+    const meta = (await metaResponse.json()) as { photoUri?: string };
+    if (!meta.photoUri) {
+      throw new ApiError(502, ErrorCodes.GOOGLE_PLACE_PHOTO_ERROR, "Missing photoUri");
     }
 
+    const imageResponse = await fetch(meta.photoUri);
+    if (!imageResponse.ok) {
+      throw new ApiError(
+        imageResponse.status,
+        ErrorCodes.GOOGLE_PLACE_PHOTO_ERROR,
+        "Failed to download photo"
+      );
+    }
+
+    const buffer = Buffer.from(await imageResponse.arrayBuffer());
+    const isJpeg =
+      buffer.length >= 3 && buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff;
+
+    if (!isJpeg || buffer.length < 1000) {
+      throw new ApiError(
+        502,
+        ErrorCodes.GOOGLE_PLACE_PHOTO_ERROR,
+        "Invalid photo data received from Google"
+      );
+    }
+
+    return buffer;
+  } catch (error) {
+    if (error instanceof ApiError) throw error;
     throw new ApiError(
       500,
       ErrorCodes.GOOGLE_PLACE_PHOTO_ERROR,
       "Failed to fetch photo from Google Places API"
     );
   }
+}
+
+/**
+ * Fetch a photo, refreshing the place cache and trying alternate refs on failure.
+ */
+export async function getPhotoWithCacheRefresh(
+  photoReference: string,
+  maxWidth: number = 400
+): Promise<Buffer> {
+  try {
+    return await getPhoto(photoReference, maxWidth);
+  } catch (error) {
+    if (!(error instanceof ApiError) || error.code !== ErrorCodes.GOOGLE_PLACE_PHOTO_ERROR) {
+      throw error;
+    }
+  }
+
+  const placeId = extractPlaceIdFromPhotoRef(photoReference);
+  if (!placeId) {
+    throw new ApiError(400, ErrorCodes.GOOGLE_PLACE_PHOTO_ERROR, "Failed to fetch photo metadata");
+  }
+
+  const refreshed = await refreshPlaceCache(placeId);
+  const refsToTry = refreshed.photoReferences.filter(Boolean);
+
+  if (refsToTry.length === 0) {
+    throw new ApiError(
+      502,
+      ErrorCodes.GOOGLE_PLACE_PHOTO_ERROR,
+      "No photo references available for this place"
+    );
+  }
+
+  let lastError: ApiError | undefined;
+  for (const ref of refsToTry) {
+    try {
+      return await getPhoto(ref, maxWidth);
+    } catch (error) {
+      if (error instanceof ApiError && error.code === ErrorCodes.GOOGLE_PLACE_PHOTO_ERROR) {
+        lastError = error;
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  throw (
+    lastError ??
+    new ApiError(
+      502,
+      ErrorCodes.GOOGLE_PLACE_PHOTO_ERROR,
+      "Failed to fetch photo from Google Places API"
+    )
+  );
 }

--- a/apps/api/src/list/poi.routes.ts
+++ b/apps/api/src/list/poi.routes.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 import { requireAuth } from "../auth/middleware";
 import { prisma } from "../db";
+import { hydrateExpiredGooglePlaceCaches } from "../google-place/cache-utils";
 import { getOrFetchPlace } from "../google-place/service";
 import { ErrorCodes } from "../utils/error-codes";
 import { formatError, handleZodError } from "../utils/errors";
@@ -263,8 +264,10 @@ listPoiRouter.get("/:listId/pois", requireAuth, async (req, res) => {
       }),
     ]);
 
+    const savedPoisWithFreshGoogleCache = await hydrateExpiredGooglePlaceCaches(savedPois);
+
     res.json({
-      savedPois: savedPois,
+      savedPois: savedPoisWithFreshGoogleCache,
       pagination: {
         page,
         limit,

--- a/apps/api/src/shared/routes.ts
+++ b/apps/api/src/shared/routes.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 
 import { prisma } from "../db";
+import { hydrateExpiredGooglePlaceCaches } from "../google-place/cache-utils";
 import { ErrorCodes } from "../utils/error-codes";
 import { formatError } from "../utils/errors";
 
@@ -157,7 +158,9 @@ sharedRouter.get("/:shareToken/pois", async (req, res) => {
       }),
     ]);
 
-    const publicPois = savedPois
+    const savedPoisWithFreshGoogleCache = await hydrateExpiredGooglePlaceCaches(savedPois);
+
+    const publicPois = savedPoisWithFreshGoogleCache
       .map((savedPoi) => {
         if (savedPoi.googlePlaceCache) {
           return savedPoi.googlePlaceCache;

--- a/apps/web/src/features/lists/components/list-poi-row.tsx
+++ b/apps/web/src/features/lists/components/list-poi-row.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { PoiCard, getPoiDisplayDataFromSavedPoi, type SavedPoiListItem } from "@/features/pois";
+
+type ListPoiRowProps = {
+  savedPoi: SavedPoiListItem;
+};
+
+export function ListPoiRow({ savedPoi }: ListPoiRowProps) {
+  const display = getPoiDisplayDataFromSavedPoi(savedPoi);
+
+  if (!display) {
+    return null;
+  }
+
+  return <PoiCard poi={display} />;
+}

--- a/apps/web/src/features/lists/components/list-pois-section.test.tsx
+++ b/apps/web/src/features/lists/components/list-pois-section.test.tsx
@@ -1,0 +1,155 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useListPoisInfinite } from "../hooks/use-list-pois-infinite";
+
+import { ListPoisSection } from "./list-pois-section";
+
+import type { SavedPoiListItem } from "@/features/pois";
+
+vi.mock("../hooks/use-list-pois-infinite", () => ({
+  useListPoisInfinite: vi.fn(),
+}));
+
+vi.mock("../hooks/use-infinite-scroll", () => ({
+  useInfiniteScroll: () => ({ current: null }),
+}));
+
+vi.mock("@/hooks/use-error-message", () => ({
+  useErrorMessage: () => () => "API error message",
+}));
+
+const customSavedPoi: SavedPoiListItem = {
+  id: "sp-1",
+  listId: "list-1",
+  poiId: "poi-1",
+  googlePlaceId: null,
+  createdAt: "2024-01-01T00:00:00.000Z",
+  poi: {
+    id: "poi-1",
+    name: "Fraktion",
+    address: "16 rue de la Grange Batelière, Paris",
+    category: "landmark",
+    latitude: 48.87324153744834,
+    longitude: 2.3412600502008014,
+    photoUrls: [],
+  },
+  googlePlaceCache: undefined,
+};
+
+const googleSavedPoi: SavedPoiListItem = {
+  id: "sp-2",
+  listId: "list-1",
+  poiId: null,
+  googlePlaceId: "ChIJxYJUC2lv5kcRlhdpWba_aGU",
+  createdAt: "2024-01-02T00:00:00.000Z",
+  poi: undefined,
+  googlePlaceCache: {
+    placeId: "ChIJxYJUC2lv5kcRlhdpWba_aGU",
+    name: "Le Tout-Paris",
+    address: "8 Quai du Louvre, Paris",
+    categoryDisplayName: "French Restaurant",
+    latitude: 48.8587493,
+    longitude: 2.3422529,
+    photoReferences: [],
+  },
+};
+
+function mockListPoisInfiniteQuery(
+  overrides: Partial<ReturnType<typeof useListPoisInfinite>> = {}
+) {
+  vi.mocked(useListPoisInfinite).mockReturnValue({
+    data: {
+      pages: [
+        {
+          savedPois: [],
+          pagination: { page: 1, limit: 20, total: 0, totalPages: 0 },
+        },
+      ],
+    },
+    isPending: false,
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+    isFetchingNextPage: false,
+    hasNextPage: false,
+    fetchNextPage: vi.fn(),
+    ...overrides,
+  } as ReturnType<typeof useListPoisInfinite>);
+}
+
+describe("ListPoisSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows skeleton on initial load", () => {
+    mockListPoisInfiniteQuery({
+      data: undefined,
+      isPending: true,
+      isLoading: true,
+    });
+
+    render(<ListPoisSection listId="list-1" />);
+
+    expect(screen.getByLabelText("Loading places")).toBeInTheDocument();
+    expect(screen.queryByText("pois.empty.title")).not.toBeInTheDocument();
+  });
+
+  it("shows empty state when there are no saved POIs", () => {
+    mockListPoisInfiniteQuery();
+
+    render(<ListPoisSection listId="list-1" />);
+
+    expect(screen.getByText("pois.section.title")).toBeInTheDocument();
+    expect(screen.getByText("pois.section.total")).toBeInTheDocument();
+    expect(screen.getByText("pois.empty.title")).toBeInTheDocument();
+    expect(screen.getByText("pois.empty.description")).toBeInTheDocument();
+  });
+
+  it("shows error state with retry", async () => {
+    const user = userEvent.setup();
+    const refetch = vi.fn();
+
+    mockListPoisInfiniteQuery({
+      data: undefined,
+      isError: true,
+      error: new Error("fail"),
+      refetch,
+    });
+
+    render(<ListPoisSection listId="list-1" />);
+
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByText("pois.error.title")).toBeInTheDocument();
+    expect(screen.getByText("API error message")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "pois.error.retry" }));
+
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders custom POI and Google Place rows", () => {
+    mockListPoisInfiniteQuery({
+      data: {
+        pageParams: [1],
+        pages: [
+          {
+            savedPois: [customSavedPoi, googleSavedPoi],
+            pagination: { page: 1, limit: 20, total: 2, totalPages: 1 },
+          },
+        ],
+      },
+    });
+
+    render(<ListPoisSection listId="list-1" />);
+
+    expect(screen.getByText("Fraktion")).toBeInTheDocument();
+    expect(screen.getByText("Le Tout-Paris")).toBeInTheDocument();
+    expect(screen.getByText("16 rue de la Grange Batelière, Paris")).toBeInTheDocument();
+    expect(screen.getByText("8 Quai du Louvre, Paris")).toBeInTheDocument();
+    expect(screen.getByText("pois.section.total")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/lists/components/list-pois-section.tsx
+++ b/apps/web/src/features/lists/components/list-pois-section.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { Loader2Icon, MapPinOffIcon, OctagonXIcon } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useCallback } from "react";
+
+import { useInfiniteScroll } from "../hooks/use-infinite-scroll";
+import { useListPoisInfinite } from "../hooks/use-list-pois-infinite";
+
+import { ListPoiRow } from "./list-poi-row";
+import { ListPoisSkeleton } from "./list-pois-skeleton";
+
+import { Button } from "@/components/ui";
+import type { SavedPoiListItem } from "@/features/pois";
+import { useErrorMessage } from "@/hooks/use-error-message";
+
+type ListPoisSectionProps = {
+  listId: string;
+};
+
+export function ListPoisSection({ listId }: ListPoisSectionProps) {
+  const tLists = useTranslations("lists");
+  const getErrorMessage = useErrorMessage();
+
+  const {
+    data,
+    isPending,
+    isLoading,
+    isError,
+    error,
+    refetch,
+    isFetchingNextPage,
+    hasNextPage,
+    fetchNextPage,
+  } = useListPoisInfinite(listId);
+
+  const items = data?.pages.flatMap((page) => page.savedPois) ?? [];
+  const total = data?.pages[0]?.pagination.total;
+  const isInitialLoading = (isPending || isLoading) && items.length === 0;
+
+  const loadMore = useCallback(() => {
+    if (hasNextPage && !isFetchingNextPage) {
+      void fetchNextPage();
+    }
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  const sentinelRef = useInfiniteScroll(loadMore, {
+    enabled: hasNextPage === true && !isError && items.length > 0,
+  });
+
+  return (
+    <section className="border-t border-border pt-6">
+      <header className="mb-4 grid gap-1">
+        <h2 className="font-display text-base font-semibold tracking-tight">
+          {tLists("pois.section.title")}
+        </h2>
+        {!isInitialLoading && !isError && total !== undefined ? (
+          <p className="text-sm text-muted-foreground">{tLists("pois.section.total", { total })}</p>
+        ) : null}
+      </header>
+
+      {isInitialLoading && <ListPoisSkeleton />}
+
+      {!isInitialLoading && isError && (
+        <div className="flex flex-col items-center gap-4 py-8 text-center" role="alert">
+          <span className="grid size-12 place-items-center rounded-full bg-destructive/10 text-destructive">
+            <OctagonXIcon className="size-6" aria-hidden />
+          </span>
+          <div className="grid max-w-sm gap-1">
+            <h3 className="font-display text-base font-semibold tracking-tight">
+              {tLists("pois.error.title")}
+            </h3>
+            <p className="text-sm text-muted-foreground">{getErrorMessage(error)}</p>
+          </div>
+          <Button type="button" variant="outline" size="sm" onClick={() => refetch()}>
+            {tLists("pois.error.retry")}
+          </Button>
+        </div>
+      )}
+
+      {!isInitialLoading && !isError && items.length === 0 && (
+        <div className="flex flex-col items-center gap-4 py-8 text-center">
+          <span className="grid size-12 place-items-center rounded-full bg-primary/10 text-primary">
+            <MapPinOffIcon className="size-6" aria-hidden />
+          </span>
+          <div className="grid max-w-sm gap-1">
+            <h3 className="font-display text-base font-semibold tracking-tight">
+              {tLists("pois.empty.title")}
+            </h3>
+            <p className="text-sm text-muted-foreground">{tLists("pois.empty.description")}</p>
+          </div>
+        </div>
+      )}
+
+      {!isInitialLoading && !isError && items.length > 0 && (
+        <>
+          <ul className="flex w-full min-w-0 flex-col gap-3">
+            {items.map((savedPoi: SavedPoiListItem, index) => (
+              <li key={savedPoi.id ?? `saved-poi-${index}`}>
+                <ListPoiRow savedPoi={savedPoi} />
+              </li>
+            ))}
+          </ul>
+
+          <div ref={sentinelRef} className="h-1 w-full" aria-hidden />
+
+          {isFetchingNextPage && (
+            <div
+              className="flex items-center justify-center gap-2 py-4 text-sm text-muted-foreground"
+              aria-busy="true"
+              aria-live="polite"
+            >
+              <Loader2Icon className="size-4 animate-spin" />
+              {tLists("pois.loadingMore")}
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/features/lists/components/list-pois-skeleton.tsx
+++ b/apps/web/src/features/lists/components/list-pois-skeleton.tsx
@@ -1,0 +1,15 @@
+import { Skeleton } from "@/components/ui";
+
+export function ListPoisSkeleton() {
+  return (
+    <div className="flex flex-col gap-3" aria-busy="true" aria-label="Loading places">
+      {Array.from({ length: 3 }).map((_, i) => (
+        <div key={i} className="rounded-md border border-border p-4">
+          <Skeleton className="h-4 w-2/3" />
+          <Skeleton className="mt-2 h-3 w-full" />
+          <Skeleton className="mt-2 h-3 w-1/3" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/features/lists/hooks/use-list-pois-infinite.ts
+++ b/apps/web/src/features/lists/hooks/use-list-pois-infinite.ts
@@ -1,0 +1,58 @@
+"use client";
+
+import { useInfiniteQuery } from "@tanstack/react-query";
+
+import { LIST_POIS_PAGE_SIZE } from "./use-list-pois";
+
+import { useAuth } from "@/features/auth";
+import type { GetListPoisData } from "@/lib/api";
+import { getListPois } from "@/lib/api";
+import { queryKeys } from "@/lib/api/query-keys";
+
+export type ListPoisInfiniteFilters = Omit<NonNullable<GetListPoisData["query"]>, "page">;
+
+async function fetchListPoisPage(
+  listId: string,
+  filters: ListPoisInfiniteFilters | undefined,
+  page: number
+) {
+  const response = await getListPois({
+    path: { listId },
+    query: {
+      ...filters,
+      page,
+      limit: filters?.limit ?? LIST_POIS_PAGE_SIZE,
+    },
+  });
+
+  if (response.data) {
+    return response.data;
+  }
+
+  throw response.error;
+}
+
+/**
+ * Paginated saved POIs for infinite scroll (GET /list/:listId/pois).
+ * API errors are thrown for {@link useErrorMessage}.
+ */
+export function useListPoisInfinite(listId: string | undefined, filters?: ListPoisInfiniteFilters) {
+  const { user } = useAuth();
+
+  return useInfiniteQuery({
+    queryKey: queryKeys.lists.pois.infinite(listId ?? "", filters),
+    enabled: Boolean(listId && user),
+    initialPageParam: 1,
+    queryFn: ({ pageParam }) => {
+      if (!listId) {
+        throw new Error("listId is required");
+      }
+
+      return fetchListPoisPage(listId, filters, pageParam);
+    },
+    getNextPageParam: (lastPage) => {
+      const { page, totalPages } = lastPage.pagination;
+      return page < totalPages ? page + 1 : undefined;
+    },
+  });
+}

--- a/apps/web/src/features/lists/index.ts
+++ b/apps/web/src/features/lists/index.ts
@@ -8,6 +8,7 @@ export { useListPois, LIST_POIS_PAGE_SIZE } from "./hooks/use-list-pois";
 export { useAddPoiToList } from "./hooks/use-add-poi-to-list";
 export { useRemovePoiFromList } from "./hooks/use-remove-poi-from-list";
 export { useListSectionUrl } from "./hooks/use-list-section-url";
+export { useListPoisInfinite } from "./hooks/use-list-pois-infinite";
 export { createListFormSchema } from "./schemas/lists.schema";
 export {
   listConstraints,
@@ -29,6 +30,7 @@ export type { UpdateListInput } from "./hooks/use-update-list";
 export type { ListPoisFilters } from "./hooks/use-list-pois";
 export type { AddPoiToListInput } from "./hooks/use-add-poi-to-list";
 export type { RemovePoiFromListInput } from "./hooks/use-remove-poi-from-list";
+export type { ListPoisInfiniteFilters } from "./hooks/use-list-pois-infinite";
 export type { CreateListFormMessages, CreateListFormData } from "./schemas/lists.schema";
 export type { ListVisibility, ListRole } from "./constants/lists.constants";
 export type { ListsSection } from "./types/lists-section.types";

--- a/apps/web/src/features/lists/views/lists-detail-view.test.tsx
+++ b/apps/web/src/features/lists/views/lists-detail-view.test.tsx
@@ -27,6 +27,12 @@ vi.mock("../hooks/use-delete-list", () => ({
   useDeleteList: vi.fn(),
 }));
 
+vi.mock("../components/list-pois-section", () => ({
+  ListPoisSection: ({ listId }: { listId: string }) => (
+    <div data-testid="list-pois-section" data-list-id={listId} />
+  ),
+}));
+
 vi.mock("sonner", () => ({
   toast: {
     success: vi.fn(),
@@ -120,7 +126,7 @@ describe("ListsDetailView", () => {
     expect(refetch).toHaveBeenCalledTimes(1);
   });
 
-  it("renders list content and POI placeholder for OWNER", () => {
+  it("renders list content and ListPoisSection for OWNER", () => {
     mockListQuery();
 
     render(<ListsDetailView listId="list-1" onBack={onBack} onEdit={onEdit} onDelete={onDelete} />);
@@ -129,7 +135,10 @@ describe("ListsDetailView", () => {
     expect(screen.getByText("My favorite places")).toBeInTheDocument();
     expect(screen.getByText("role.OWNER")).toBeInTheDocument();
     expect(screen.getByText("detail.createdAt")).toBeInTheDocument();
-    expect(screen.getByText("pois.section.title")).toBeInTheDocument();
+
+    const poisSection = screen.getByTestId("list-pois-section");
+    expect(poisSection).toBeInTheDocument();
+    expect(poisSection).toHaveAttribute("data-list-id", "list-1");
   });
 
   it("shows edit button for OWNER and calls onEdit", async () => {

--- a/apps/web/src/features/lists/views/lists-detail-view.tsx
+++ b/apps/web/src/features/lists/views/lists-detail-view.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from "next-intl";
 import { useState } from "react";
 
 import { DeleteListDialog } from "../components/delete-list-dialog";
+import { ListPoisSection } from "../components/list-pois-section";
 import { ListsDetailMetadata } from "../components/lists-detail-metadata";
 import { ListsListQueryBoundary } from "../components/lists-list-query-boundary";
 import { ListsSectionLayout } from "../components/lists-section-layout";
@@ -65,9 +66,7 @@ export function ListsDetailView({ listId, onBack, onEdit, onDelete }: ListsDetai
                 onDeleted={onDelete}
               />
             )}
-            <div className="border-t border-border pt-6">
-              <p className="text-sm text-muted-foreground">{tLists("pois.section.title")}</p>
-            </div>
+            <ListPoisSection listId={listId} />
           </div>
         )}
       </ListsListQueryBoundary>

--- a/apps/web/src/features/pois/components/poi-card.tsx
+++ b/apps/web/src/features/pois/components/poi-card.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { ClockIcon, MapPinIcon } from "lucide-react";
+import { useTranslations } from "next-intl";
+import type { ReactNode } from "react";
+
+import type { PoiDisplayData } from "../types/poi-display-types";
+
+import { PoiOpeningHours } from "./poi-opening-hours";
+import { PoiPhoto } from "./poi-photo";
+
+type PoiCardProps = {
+  poi: PoiDisplayData;
+  actions?: ReactNode;
+};
+
+export function PoiCard({ poi, actions }: PoiCardProps) {
+  const tPoi = useTranslations("poi");
+
+  return (
+    <article className="flex flex-col items-start rounded-md border border-border">
+      {poi.photo ? (
+        <div className="overflow-hidden rounded-t-md h-[150px] w-full">
+          <PoiPhoto photo={poi.photo} alt={poi.name} />
+        </div>
+      ) : null}
+      <div className="px-4 py-2 flex flex-col gap-1 w-full">
+        <div className="flex flex-wrap items-start justify-between gap-2">
+          <h3 className="min-w-0 font-display text-base font-semibold tracking-tight">
+            {poi.name}
+          </h3>
+        </div>
+
+        <p className="flex min-w-0 items-center gap-1.5 text-sm text-muted-foreground">
+          <MapPinIcon className="size-3.5 shrink-0" aria-hidden />
+          <span className="min-w-0 wrap-break-words">{poi.address ?? tPoi("addressUnknown")}</span>
+        </p>
+
+        {poi.openingHours ? (
+          <div className="mt-1 flex items-center gap-1.5 text-xs text-muted-foreground">
+            <ClockIcon className="size-3.5 shrink-0" aria-hidden />
+            <PoiOpeningHours hours={poi.openingHours} />
+          </div>
+        ) : null}
+      </div>
+
+      {actions ? <div className="shrink-0">{actions}</div> : null}
+    </article>
+  );
+}

--- a/apps/web/src/features/pois/components/poi-opening-hours.tsx
+++ b/apps/web/src/features/pois/components/poi-opening-hours.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { useLocale, useTranslations } from "next-intl";
+
+import type { PoiOpeningHours as PoiOpeningHoursType } from "../types/poi-display-types";
+import { formatOpeningStatus } from "../utils/format-opening-status";
+
+export function PoiOpeningHours({ hours }: { hours: PoiOpeningHoursType }) {
+  const tPoi = useTranslations("poi");
+  const locale = useLocale();
+
+  const message = formatOpeningStatus(hours, locale, tPoi);
+
+  return <span className={hours.isOpen ? "text-emerald-600" : undefined}>{message}</span>;
+}

--- a/apps/web/src/features/pois/components/poi-photo.tsx
+++ b/apps/web/src/features/pois/components/poi-photo.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { MapPinIcon } from "lucide-react";
+import Image from "next/image";
+
+import type { PoiPhoto as PoiPhotoType } from "../types/poi-display-types";
+
+import { getGooglePlacePhoto } from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+type PoiPhotoProps = {
+  photo: PoiPhotoType;
+  alt: string;
+  className?: string;
+};
+
+export function PoiPhoto({ photo, alt, className }: PoiPhotoProps) {
+  if (photo.kind === "url") {
+    return (
+      <Image
+        src={photo.url}
+        alt={alt}
+        width={400}
+        height={400}
+        loading="lazy"
+        className={cn("size-full object-cover", className)}
+      />
+    );
+  }
+
+  return <GooglePlacePhoto photoRef={photo.photoRef} alt={alt} className={className} />;
+}
+
+function GooglePlacePhoto({
+  photoRef,
+  alt,
+  className,
+}: {
+  photoRef: string;
+  alt: string;
+  className?: string;
+}) {
+  const {
+    data: objectUrl,
+    isPending,
+    isError,
+  } = useQuery({
+    queryKey: ["google-place-photo", photoRef],
+    queryFn: async () => {
+      const response = await getGooglePlacePhoto({
+        query: { ref: photoRef, maxWidth: 400 },
+        parseAs: "blob",
+        cache: "no-store",
+      });
+
+      const blob = response.data as Blob | undefined;
+
+      if (blob) {
+        const isJpeg = await isValidJpegBlob(blob);
+        if (!isJpeg) {
+          throw new Error("Invalid JPEG response from photo API");
+        }
+
+        return URL.createObjectURL(blob);
+      }
+
+      throw response.error;
+    },
+    staleTime: 24 * 60 * 60 * 1000,
+    gcTime: 24 * 60 * 60 * 1000,
+  });
+
+  // Blob URLs are not revoked here: React Strict Mode unmount/remount would revoke
+  // the URL before <img> finishes loading, causing spurious onError events.
+
+  if (isPending) {
+    return <PhotoPlaceholder className={className} />;
+  }
+
+  if (isError || !objectUrl) {
+    return <PhotoPlaceholder className={className} />;
+  }
+
+  return (
+    <Image
+      src={objectUrl}
+      alt={alt}
+      width={400}
+      height={400}
+      loading="lazy"
+      className={cn("size-full object-cover", className)}
+      unoptimized
+    />
+  );
+}
+
+function PhotoPlaceholder({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn("grid size-full place-items-center bg-muted text-muted-foreground", className)}
+      aria-hidden
+    >
+      <MapPinIcon className="size-5" />
+    </div>
+  );
+}
+
+async function isValidJpegBlob(blob: Blob): Promise<boolean> {
+  if (blob.size < 3) return false;
+
+  const header = new Uint8Array(await blob.slice(0, 3).arrayBuffer());
+  return header[0] === 0xff && header[1] === 0xd8 && header[2] === 0xff;
+}

--- a/apps/web/src/features/pois/index.ts
+++ b/apps/web/src/features/pois/index.ts
@@ -1,0 +1,17 @@
+export { PoiCard } from "./components/poi-card";
+export { PoiPhoto } from "./components/poi-photo";
+export { PoiOpeningHours } from "./components/poi-opening-hours";
+
+export {
+  getPoiDisplayDataFromSavedPoi,
+  getPoiDisplayDataFromPoi,
+  getPoiDisplayDataFromGooglePlace,
+} from "./utils/get-poi-display-data";
+
+export type {
+  PoiDisplayData,
+  PoiPhoto as PoiPhotoData,
+  PoiOpeningHours as PoiOpeningHoursData,
+  SavedPoiListItem,
+  PoiSource,
+} from "./types/poi-display-types";

--- a/apps/web/src/features/pois/types/poi-display-types.ts
+++ b/apps/web/src/features/pois/types/poi-display-types.ts
@@ -1,0 +1,29 @@
+import type { GetSavedPoisResponse, GooglePlace, Poi } from "@/lib/api";
+
+export type SavedPoiListItem = GetSavedPoisResponse["savedPois"][number];
+
+export type PoiSource = "custom" | "google";
+
+export type PoiPhoto = { kind: "url"; url: string } | { kind: "google-ref"; photoRef: string };
+
+export type OpeningHoursPeriod = {
+  open: { day: number; hour: number; minute: number };
+  close: { day: number; hour: number; minute: number };
+};
+
+export type PoiOpeningHours = {
+  isOpen: boolean;
+  nextOpenAt: string | null;
+};
+
+export type PoiDisplayData = {
+  id: string;
+  name: string;
+  address: string | null;
+  category: string | null;
+  source: PoiSource;
+  photo: PoiPhoto | null;
+  openingHours: PoiOpeningHours | null;
+};
+
+export type { Poi, GooglePlace };

--- a/apps/web/src/features/pois/utils/compute-opening-status.ts
+++ b/apps/web/src/features/pois/utils/compute-opening-status.ts
@@ -1,0 +1,58 @@
+import type { OpeningHoursPeriod, PoiOpeningHours } from "../types/poi-display-types";
+
+function toMinutes(day: number, hour: number, minute: number): number {
+  return day * 24 * 60 + hour * 60 + minute;
+}
+
+export function computeOpeningStatusFromPeriods(periods: OpeningHoursPeriod[]): PoiOpeningHours {
+  const now = new Date();
+  const currentDay = now.getDay(); // 0 = Sunday (aligné Google)
+  const currentMinutes = currentDay * 24 * 60 + now.getHours() * 60 + now.getMinutes();
+
+  let isOpen = false;
+  let nextOpenAt: Date | null = null;
+
+  for (const period of periods) {
+    const openMin = toMinutes(period.open.day, period.open.hour, period.open.minute);
+    let closeMin = toMinutes(period.close.day, period.close.hour, period.close.minute);
+
+    // fermeture le lendemain (ex: ven 18h → sam 2h)
+    if (closeMin <= openMin) {
+      closeMin += 7 * 24 * 60;
+    }
+
+    const adjustedCurrent = currentMinutes;
+    if (adjustedCurrent < openMin && period.open.day === currentDay) {
+      // ok
+    }
+
+    // Simplification: compare sur fenêtre de 7 jours
+    for (let offset = 0; offset < 7; offset++) {
+      const dayOffset = offset * 24 * 60;
+      const start = openMin + dayOffset;
+      const end = closeMin + dayOffset;
+      const nowAdj = currentMinutes;
+
+      if (nowAdj >= start && nowAdj < end) {
+        isOpen = true;
+      }
+
+      if (start > nowAdj) {
+        const candidate = new Date(now);
+        const daysUntil = Math.floor((start - nowAdj) / (24 * 60));
+        const minutesInDay = start % (24 * 60);
+        candidate.setDate(candidate.getDate() + daysUntil);
+        candidate.setHours(Math.floor(minutesInDay / 60), minutesInDay % 60, 0, 0);
+
+        if (!nextOpenAt || candidate < nextOpenAt) {
+          nextOpenAt = candidate;
+        }
+      }
+    }
+  }
+
+  return {
+    isOpen,
+    nextOpenAt: nextOpenAt?.toISOString() ?? null,
+  };
+}

--- a/apps/web/src/features/pois/utils/format-opening-hours.ts
+++ b/apps/web/src/features/pois/utils/format-opening-hours.ts
@@ -1,0 +1,22 @@
+import type { OpeningHoursPeriod } from "../types/poi-display-types";
+
+const DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
+
+function formatTime(hour: number, minute: number): string {
+  return `${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}`;
+}
+
+export function formatOpeningHoursPeriods(periods: OpeningHoursPeriod[]): string[] {
+  return periods.map((period) => {
+    const openDay = DAY_LABELS[period.open.day] ?? String(period.open.day);
+    const closeDay = DAY_LABELS[period.close.day] ?? String(period.close.day);
+    const openTime = formatTime(period.open.hour, period.open.minute);
+    const closeTime = formatTime(period.close.hour, period.close.minute);
+
+    if (period.open.day === period.close.day) {
+      return `${openDay} ${openTime} – ${closeTime}`;
+    }
+
+    return `${openDay} ${openTime} – ${closeDay} ${closeTime}`;
+  });
+}

--- a/apps/web/src/features/pois/utils/format-opening-status.ts
+++ b/apps/web/src/features/pois/utils/format-opening-status.ts
@@ -1,0 +1,44 @@
+type TranslateFn = (key: string, values?: Record<string, string | number | Date>) => string;
+
+function isSameDay(a: Date, b: Date): boolean {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
+function isTomorrow(next: Date, now: Date): boolean {
+  const tomorrow = new Date(now);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  return isSameDay(next, tomorrow);
+}
+
+export function formatOpeningStatus(
+  hours: { isOpen: boolean; nextOpenAt: string | null },
+  locale: string,
+  t: TranslateFn
+): string {
+  if (hours.isOpen) {
+    return t("openingHours.openNow");
+  }
+
+  if (!hours.nextOpenAt) {
+    return t("openingHours.closedNow");
+  }
+
+  const next = new Date(hours.nextOpenAt);
+  const now = new Date();
+  const time = next.toLocaleTimeString(locale, { hour: "2-digit", minute: "2-digit" });
+
+  if (isSameDay(next, now)) {
+    return t("openingHours.opensAt", { time });
+  }
+
+  if (isTomorrow(next, now)) {
+    return t("openingHours.opensTomorrowAt", { time });
+  }
+
+  const day = next.toLocaleDateString(locale, { weekday: "long" });
+  return t("openingHours.opensDayAt", { day, time });
+}

--- a/apps/web/src/features/pois/utils/get-poi-display-data.test.ts
+++ b/apps/web/src/features/pois/utils/get-poi-display-data.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+
+import { getPoiDisplayDataFromSavedPoi } from "./get-poi-display-data";
+
+import type { Poi } from "@/lib/api";
+
+describe("getPoiDisplayDataFromSavedPoi", () => {
+  it("maps a custom POI", () => {
+    expect(
+      getPoiDisplayDataFromSavedPoi({
+        id: "sp-1",
+        poiId: "poi-1",
+        googlePlaceId: null,
+        poi: {
+          id: "poi-1",
+          name: "Tour Eiffel",
+          address: "Champ de Mars, Paris",
+          category: "monument",
+          photoUrls: ["https://example.com/eiffel.jpg"],
+          openingHours: [
+            {
+              open: { day: 1, hour: 9, minute: 0 },
+              close: { day: 1, hour: 18, minute: 0 },
+            },
+          ] as unknown as Poi["openingHours"],
+        },
+      })
+    ).toMatchObject({
+      id: "sp-1",
+      name: "Tour Eiffel",
+      address: "Champ de Mars, Paris",
+      category: "monument",
+      source: "custom",
+      photo: { kind: "url", url: "https://example.com/eiffel.jpg" },
+      openingHours: {
+        isOpen: expect.any(Boolean),
+        nextOpenAt: expect.anything(),
+      },
+    });
+  });
+
+  it("maps a Google Place with photo and openNow", () => {
+    expect(
+      getPoiDisplayDataFromSavedPoi({
+        id: "sp-2",
+        googlePlaceCache: {
+          placeId: "ChIJ...",
+          name: "Café de Flore",
+          address: "172 Bd Saint-Germain, Paris",
+          categoryDisplayName: "Café",
+          photoReferences: ["places/abc/photos/ref1"],
+          openingHours: {
+            openNow: true,
+            weekdayDescriptions: ["Monday: 7:00 AM – 1:00 AM", "Tuesday: Closed"],
+          },
+        },
+      })
+    ).toMatchObject({
+      id: "sp-2",
+      name: "Café de Flore",
+      source: "google",
+      photo: { kind: "google-ref", photoRef: "places/abc/photos/ref1" },
+      openingHours: {
+        isOpen: true,
+        nextOpenAt: null,
+      },
+    });
+  });
+
+  it("returns null address when missing", () => {
+    expect(
+      getPoiDisplayDataFromSavedPoi({
+        id: "sp-3",
+        poi: {
+          id: "poi-3",
+          name: "No address POI",
+        },
+      })
+    ).toMatchObject({
+      address: null,
+      photo: null,
+      openingHours: null,
+    });
+  });
+
+  it("returns null when saved POI has no poi nor googlePlaceCache", () => {
+    expect(getPoiDisplayDataFromSavedPoi({ id: "sp-4" })).toBeNull();
+  });
+
+  it("prefers googlePlaceCache over poi when both are present", () => {
+    expect(
+      getPoiDisplayDataFromSavedPoi({
+        id: "sp-5",
+        poi: {
+          id: "poi-5",
+          name: "Custom name",
+        },
+        googlePlaceCache: {
+          placeId: "ChIJgoogle",
+          name: "Google name",
+        },
+      })
+    ).toMatchObject({
+      name: "Google name",
+      source: "google",
+    });
+  });
+});

--- a/apps/web/src/features/pois/utils/get-poi-display-data.ts
+++ b/apps/web/src/features/pois/utils/get-poi-display-data.ts
@@ -1,0 +1,111 @@
+import type {
+  GooglePlace,
+  OpeningHoursPeriod,
+  Poi,
+  PoiDisplayData,
+  PoiOpeningHours,
+  PoiPhoto,
+  PoiSource,
+  SavedPoiListItem,
+} from "../types/poi-display-types";
+
+import { computeOpeningStatusFromPeriods } from "./compute-opening-status";
+
+function extractPhotoFromPoi(poi: Poi): PoiPhoto | null {
+  const url = poi.photoUrls?.[0]?.trim();
+  return url ? { kind: "url", url } : null;
+}
+
+function extractPhotoFromGoogle(place: GooglePlace): PoiPhoto | null {
+  const ref = place.photoReferences?.[0]?.trim();
+  return ref ? { kind: "google-ref", photoRef: ref } : null;
+}
+
+function extractOpeningHours(raw: unknown): PoiOpeningHours | null {
+  if (!raw) return null;
+
+  // Google: { openNow, nextOpenTime, periods }
+  if (typeof raw === "object" && !Array.isArray(raw)) {
+    const obj = raw as Record<string, unknown>;
+
+    if (typeof obj.openNow === "boolean") {
+      return {
+        isOpen: obj.openNow,
+        nextOpenAt: typeof obj.nextOpenTime === "string" ? obj.nextOpenTime : null,
+      };
+    }
+  }
+
+  // Custom POI: [{ open, close }]
+  if (Array.isArray(raw) && raw.length > 0) {
+    return computeOpeningStatusFromPeriods(raw as OpeningHoursPeriod[]);
+  }
+
+  return null;
+}
+
+function buildDisplayData(input: {
+  id: string;
+  name: string;
+  address: string | null;
+  category: string | null;
+  source: PoiSource;
+  photo: PoiPhoto | null;
+  openingHours: PoiOpeningHours | null;
+}): PoiDisplayData {
+  return {
+    id: input.id,
+    name: input.name.trim() || "Untitled place",
+    address: input.address?.trim() || null,
+    category: input.category?.trim() || null,
+    source: input.source,
+    photo: input.photo,
+    openingHours: input.openingHours,
+  };
+}
+
+export function getPoiDisplayDataFromPoi(poi: Poi, id?: string): PoiDisplayData | null {
+  if (!poi.name?.trim() && !poi.id) return null;
+
+  return buildDisplayData({
+    id: id ?? poi.id ?? "",
+    name: poi.name?.trim() || "Untitled place",
+    address: poi.address ?? null,
+    category: poi.category ?? null,
+    source: "custom",
+    photo: extractPhotoFromPoi(poi),
+    openingHours: extractOpeningHours(poi.openingHours),
+  });
+}
+
+export function getPoiDisplayDataFromGooglePlace(
+  place: GooglePlace,
+  id?: string
+): PoiDisplayData | null {
+  if (!place.name?.trim() && !place.placeId) return null;
+
+  return buildDisplayData({
+    id: id ?? place.placeId ?? "",
+    name: place.name?.trim() || "Untitled place",
+    address: place.address ?? null,
+    category: place.categoryDisplayName ?? place.category ?? null,
+    source: "google",
+    photo: extractPhotoFromGoogle(place),
+    openingHours: extractOpeningHours(place.openingHours),
+  });
+}
+
+export function getPoiDisplayDataFromSavedPoi(savedPoi: SavedPoiListItem): PoiDisplayData | null {
+  if (savedPoi.googlePlaceCache) {
+    return getPoiDisplayDataFromGooglePlace(
+      savedPoi.googlePlaceCache,
+      savedPoi.id ?? savedPoi.googlePlaceCache.placeId
+    );
+  }
+
+  if (savedPoi.poi) {
+    return getPoiDisplayDataFromPoi(savedPoi.poi, savedPoi.id ?? savedPoi.poi.id);
+  }
+
+  return null;
+}

--- a/apps/web/src/lib/api/query-keys.test.ts
+++ b/apps/web/src/lib/api/query-keys.test.ts
@@ -28,4 +28,22 @@ describe("queryKeys.lists", () => {
     expect(queryKeys.lists.infinite()[0]).toBe(queryKeys.lists.all[0]);
     expect(queryKeys.lists.detail("id")[0]).toBe(queryKeys.lists.all[0]);
   });
+
+  it("pois.infinite includes listId and filters", () => {
+    expect(queryKeys.lists.pois.infinite("list-1")).toEqual([
+      "lists",
+      "pois",
+      "list-1",
+      "infinite",
+      undefined,
+    ]);
+
+    expect(queryKeys.lists.pois.infinite("list-1", { limit: 10 })).toEqual([
+      "lists",
+      "pois",
+      "list-1",
+      "infinite",
+      { limit: 10 },
+    ]);
+  });
 });

--- a/apps/web/src/lib/api/query-keys.ts
+++ b/apps/web/src/lib/api/query-keys.ts
@@ -1,5 +1,6 @@
 import { GetListPoisData, GetListsData } from "./generated/types.gen";
 
+import { ListPoisInfiniteFilters } from "@/features/lists/hooks/use-list-pois-infinite";
 import type { ListsInfiniteFilters } from "@/features/lists/hooks/use-lists-infinite";
 
 export const queryKeys = {
@@ -13,6 +14,8 @@ export const queryKeys = {
       all: (listId: string) => [...queryKeys.lists.all, "pois", listId] as const,
       list: (listId: string, filters?: GetListPoisData["query"]) =>
         [...queryKeys.lists.pois.all(listId), filters] as const,
+      infinite: (listId: string, filters?: ListPoisInfiniteFilters) =>
+        [...queryKeys.lists.pois.all(listId), "infinite", filters] as const,
     },
   },
 };

--- a/apps/web/src/lib/i18n/locales/en/poi.json
+++ b/apps/web/src/lib/i18n/locales/en/poi.json
@@ -1,0 +1,14 @@
+{
+  "source": {
+    "custom": "Custom place",
+    "google": "Google"
+  },
+  "addressUnknown": "No address",
+  "openingHours": {
+    "openNow": "Open now",
+    "closedNow": "Closed",
+    "opensAt": "Opens at {time}",
+    "opensTomorrowAt": "Opens tomorrow at {time}",
+    "opensDayAt": "Opens {day} at {time}"
+  }
+}

--- a/apps/web/src/lib/i18n/locales/fr/poi.json
+++ b/apps/web/src/lib/i18n/locales/fr/poi.json
@@ -1,0 +1,14 @@
+{
+  "source": {
+    "custom": "Lieu personnalisé",
+    "google": "Google"
+  },
+  "addressUnknown": "Aucune adresse",
+  "openingHours": {
+    "openNow": "Ouvert maintenant",
+    "closedNow": "Fermé",
+    "opensAt": "Ouvre à {time}",
+    "opensTomorrowAt": "Ouvre demain à {time}",
+    "opensDayAt": "Ouvre {day} à {time}"
+  }
+}


### PR DESCRIPTION
## 📝 Description

Affichage des POIs sauvegardés dans la vue détail d'une liste (NIR-63) : remplacement du placeholder par une section avec cartes POI, photos Google, horaires d'ouverture et scroll infini. Inclut des correctifs API sur le cache et les photos Google Places, un seed dynamique pour la QA locale, et la mise à jour des tests associés.

## 🎯 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI update (no functional changes)
- [ ] ♻️ Code refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [x] ✅ Test update

## 🔗 Related Issues

Closes NIR-63

Dépend de NIR-61 et NIR-62 (déjà mergés via #98 et #99).

## 🚀 Changes Made

- Remplacement du placeholder dans `ListsDetailView` par `ListPoisSection` (loading / empty / error / scroll infini)
- Nouveau module `features/pois/` : `getPoiDisplayData`, `PoiCard`, `PoiPhoto`, horaires d'ouverture
- Hook `useListPoisInfinite` + clé `queryKeys.lists.pois.infinite`
- Traductions EN/FR (`poi.json`, clés `lists.pois.*`)
- API : correction endpoint photo Google, `hydrateExpiredGooglePlaceCaches` sur routes liste et partagée, seed dynamique via Google Places API
- Tests web et API (dont fix `shared/routes.test.ts` avec `expiresAt` futur sur les caches Google)

## 🧪 Testing

- [x] Tested locally with `pnpm dev`
- [x] All quality checks pass (`pnpm lint`)
- [x] Unit tests pass (`pnpm test`)
- [ ] Database migrations applied if needed

## 📸 Screenshots/Videos

Screenshots recommandés : vue détail de la liste seed « Mes lieux favoris à Paris » (POIs custom + Google avec photos et statut d'ouverture).

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated if needed
- [x] No console errors or warnings
- [x] Removed any debug code