### PR TITLE
feat(lists): add remove poi from list action

### DIFF
--- a/apps/web/src/features/lists/components/list-poi-row.tsx
+++ b/apps/web/src/features/lists/components/list-poi-row.tsx
@@ -1,17 +1,59 @@
 "use client";
 
+import { Trash2Icon } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+
+import { RemovePoiDialog } from "./remove-poi-dialog";
+
+import { Button } from "@/components/ui";
 import { PoiCard, getPoiDisplayDataFromSavedPoi, type SavedPoiListItem } from "@/features/pois";
 
 type ListPoiRowProps = {
   savedPoi: SavedPoiListItem;
+  listId: string;
+  canRemove: boolean;
 };
 
-export function ListPoiRow({ savedPoi }: ListPoiRowProps) {
+export function ListPoiRow({ savedPoi, listId, canRemove }: ListPoiRowProps) {
+  const tLists = useTranslations("lists");
+  const [removeDialogOpen, setRemoveDialogOpen] = useState(false);
   const display = getPoiDisplayDataFromSavedPoi(savedPoi);
 
   if (!display) {
     return null;
   }
 
-  return <PoiCard poi={display} />;
+  const showRemoveAction = canRemove && Boolean(savedPoi.id);
+
+  return (
+    <>
+      <PoiCard
+        poi={display}
+        actions={
+          showRemoveAction ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              className="text-muted-foreground/70 hover:bg-destructive/10 hover:text-destructive"
+              aria-label={tLists("removePoi.action")}
+              onClick={() => setRemoveDialogOpen(true)}
+            >
+              <Trash2Icon className="size-3.5" />
+            </Button>
+          ) : undefined
+        }
+      />
+      {showRemoveAction && savedPoi.id ? (
+        <RemovePoiDialog
+          listId={listId}
+          savedPoiId={savedPoi.id}
+          placeName={display.name}
+          open={removeDialogOpen}
+          onOpenChange={setRemoveDialogOpen}
+        />
+      ) : null}
+    </>
+  );
 }

--- a/apps/web/src/features/lists/components/list-pois-section.test.tsx
+++ b/apps/web/src/features/lists/components/list-pois-section.test.tsx
@@ -20,6 +20,13 @@ vi.mock("@/hooks/use-error-message", () => ({
   useErrorMessage: () => () => "API error message",
 }));
 
+vi.mock("../hooks/use-remove-poi-from-list", () => ({
+  useRemovePoiFromList: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+}));
+
 const customSavedPoi: SavedPoiListItem = {
   id: "sp-1",
   listId: "list-1",
@@ -151,5 +158,41 @@ describe("ListPoisSection", () => {
     expect(screen.getByText("16 rue de la Grange Batelière, Paris")).toBeInTheDocument();
     expect(screen.getByText("8 Quai du Louvre, Paris")).toBeInTheDocument();
     expect(screen.getByText("pois.section.total")).toBeInTheDocument();
+  });
+
+  it("hides remove action for VIEWER", () => {
+    mockListPoisInfiniteQuery({
+      data: {
+        pageParams: [1],
+        pages: [
+          {
+            savedPois: [customSavedPoi, googleSavedPoi],
+            pagination: { page: 1, limit: 20, total: 2, totalPages: 1 },
+          },
+        ],
+      },
+    });
+
+    render(<ListPoisSection listId="list-1" role="VIEWER" />);
+
+    expect(screen.queryByRole("button", { name: "removePoi.action" })).not.toBeInTheDocument();
+  });
+
+  it("shows remove action for EDITOR on each row", () => {
+    mockListPoisInfiniteQuery({
+      data: {
+        pageParams: [1],
+        pages: [
+          {
+            savedPois: [customSavedPoi, googleSavedPoi],
+            pagination: { page: 1, limit: 20, total: 2, totalPages: 1 },
+          },
+        ],
+      },
+    });
+
+    render(<ListPoisSection listId="list-1" role="EDITOR" />);
+
+    expect(screen.getAllByRole("button", { name: "removePoi.action" })).toHaveLength(2);
   });
 });

--- a/apps/web/src/features/lists/components/list-pois-section.tsx
+++ b/apps/web/src/features/lists/components/list-pois-section.tsx
@@ -4,6 +4,7 @@ import { Loader2Icon, MapPinOffIcon, OctagonXIcon } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useCallback } from "react";
 
+import { canEditList, type ListRole } from "../constants/lists.constants";
 import { useInfiniteScroll } from "../hooks/use-infinite-scroll";
 import { useListPoisInfinite } from "../hooks/use-list-pois-infinite";
 
@@ -16,9 +17,11 @@ import { useErrorMessage } from "@/hooks/use-error-message";
 
 type ListPoisSectionProps = {
   listId: string;
+  role?: ListRole;
 };
 
-export function ListPoisSection({ listId }: ListPoisSectionProps) {
+export function ListPoisSection({ listId, role }: ListPoisSectionProps) {
+  const canRemove = canEditList(role);
   const tLists = useTranslations("lists");
   const getErrorMessage = useErrorMessage();
 
@@ -97,7 +100,7 @@ export function ListPoisSection({ listId }: ListPoisSectionProps) {
           <ul className="flex w-full min-w-0 flex-col gap-3">
             {items.map((savedPoi: SavedPoiListItem, index) => (
               <li key={savedPoi.id ?? `saved-poi-${index}`}>
-                <ListPoiRow savedPoi={savedPoi} />
+                <ListPoiRow savedPoi={savedPoi} listId={listId} canRemove={canRemove} />
               </li>
             ))}
           </ul>

--- a/apps/web/src/features/lists/components/remove-poi-dialog.test.tsx
+++ b/apps/web/src/features/lists/components/remove-poi-dialog.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { toast } from "sonner";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useRemovePoiFromList } from "../hooks/use-remove-poi-from-list";
+
+import { RemovePoiDialog } from "./remove-poi-dialog";
+
+import { getErrorCode } from "@/lib/api/errors";
+
+vi.mock("../hooks/use-remove-poi-from-list", () => ({
+  useRemovePoiFromList: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-error-message", () => ({
+  useErrorMessage: () => () => "API error message",
+}));
+
+vi.mock("@/lib/api/errors", () => ({
+  getErrorCode: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("RemovePoiDialog", () => {
+  const mutateAsync = vi.fn();
+  const onOpenChange = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getErrorCode).mockReturnValue(null);
+    mutateAsync.mockResolvedValue({ message: "POI removed from list successfully" });
+    vi.mocked(useRemovePoiFromList).mockReturnValue({
+      mutateAsync,
+      isPending: false,
+    } as unknown as ReturnType<typeof useRemovePoiFromList>);
+  });
+
+  it("confirms removal and shows success toast", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <RemovePoiDialog
+        listId="list-1"
+        savedPoiId="sp-1"
+        placeName="Fraktion"
+        open
+        onOpenChange={onOpenChange}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "removePoi.confirmSubmit" }));
+
+    expect(mutateAsync).toHaveBeenCalledWith({ listId: "list-1", savedPoiId: "sp-1" });
+    expect(toast.success).toHaveBeenCalledWith("removePoi.success");
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("closes without error toast when saved POI is already gone", async () => {
+    const user = userEvent.setup();
+    vi.mocked(getErrorCode).mockReturnValue("SAVED_POI_NOT_FOUND");
+    mutateAsync.mockRejectedValue({ error: { code: "SAVED_POI_NOT_FOUND" } });
+
+    render(
+      <RemovePoiDialog
+        listId="list-1"
+        savedPoiId="sp-1"
+        placeName="Fraktion"
+        open
+        onOpenChange={onOpenChange}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "removePoi.confirmSubmit" }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("shows error toast for other API failures", async () => {
+    const user = userEvent.setup();
+    mutateAsync.mockRejectedValue({ error: { code: "LIST_ACCESS_DENIED" } });
+
+    render(
+      <RemovePoiDialog
+        listId="list-1"
+        savedPoiId="sp-1"
+        placeName="Fraktion"
+        open
+        onOpenChange={onOpenChange}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "removePoi.confirmSubmit" }));
+
+    expect(toast.error).toHaveBeenCalledWith("removePoi.error", {
+      description: "API error message",
+    });
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+});

--- a/apps/web/src/features/lists/components/remove-poi-dialog.tsx
+++ b/apps/web/src/features/lists/components/remove-poi-dialog.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { toast } from "sonner";
+
+import { useRemovePoiFromList } from "../hooks/use-remove-poi-from-list";
+
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui";
+import { useErrorMessage } from "@/hooks/use-error-message";
+import { getErrorCode } from "@/lib/api/errors";
+
+export type RemovePoiDialogProps = {
+  listId: string;
+  savedPoiId: string;
+  placeName: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+export function RemovePoiDialog({
+  listId,
+  savedPoiId,
+  placeName,
+  open,
+  onOpenChange,
+}: RemovePoiDialogProps) {
+  const tLists = useTranslations("lists");
+  const tCommon = useTranslations("common");
+  const getErrorMessage = useErrorMessage();
+  const { mutateAsync: removePoi, isPending } = useRemovePoiFromList();
+
+  async function handleRemove() {
+    if (isPending) return;
+
+    try {
+      await removePoi({ listId, savedPoiId });
+      toast.success(tLists("removePoi.success"));
+      onOpenChange(false);
+    } catch (error) {
+      if (getErrorCode(error) === "SAVED_POI_NOT_FOUND") {
+        onOpenChange(false);
+        return;
+      }
+
+      toast.error(tLists("removePoi.error"), {
+        description: getErrorMessage(error),
+      });
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{tLists("removePoi.title")}</DialogTitle>
+          <DialogDescription>
+            {tLists("removePoi.description", { placeName })}
+          </DialogDescription>
+        </DialogHeader>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isPending}
+          >
+            {tCommon("buttons.cancel")}
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            disabled={isPending}
+            loading={isPending}
+            onClick={handleRemove}
+          >
+            {tLists("removePoi.confirmSubmit")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/features/lists/hooks/use-add-poi-to-list.ts
+++ b/apps/web/src/features/lists/hooks/use-add-poi-to-list.ts
@@ -34,6 +34,7 @@ export function useAddPoiToList() {
     onSuccess: (_data, { listId }) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.lists.pois.all(listId) });
       queryClient.invalidateQueries({ queryKey: queryKeys.lists.detail(listId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.lists.all });
     },
   });
 }

--- a/apps/web/src/features/lists/hooks/use-remove-poi-from-list.ts
+++ b/apps/web/src/features/lists/hooks/use-remove-poi-from-list.ts
@@ -35,6 +35,7 @@ export function useRemovePoiFromList() {
     onSuccess: (_data, { listId }) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.lists.pois.all(listId) });
       queryClient.invalidateQueries({ queryKey: queryKeys.lists.detail(listId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.lists.all });
     },
   });
 }

--- a/apps/web/src/features/lists/views/lists-detail-view.test.tsx
+++ b/apps/web/src/features/lists/views/lists-detail-view.test.tsx
@@ -28,8 +28,8 @@ vi.mock("../hooks/use-delete-list", () => ({
 }));
 
 vi.mock("../components/list-pois-section", () => ({
-  ListPoisSection: ({ listId }: { listId: string }) => (
-    <div data-testid="list-pois-section" data-list-id={listId} />
+  ListPoisSection: ({ listId, role }: { listId: string; role?: string }) => (
+    <div data-testid="list-pois-section" data-list-id={listId} data-role={role ?? ""} />
   ),
 }));
 
@@ -139,6 +139,7 @@ describe("ListsDetailView", () => {
     const poisSection = screen.getByTestId("list-pois-section");
     expect(poisSection).toBeInTheDocument();
     expect(poisSection).toHaveAttribute("data-list-id", "list-1");
+    expect(poisSection).toHaveAttribute("data-role", "OWNER");
   });
 
   it("shows edit button for OWNER and calls onEdit", async () => {

--- a/apps/web/src/features/lists/views/lists-detail-view.tsx
+++ b/apps/web/src/features/lists/views/lists-detail-view.tsx
@@ -66,7 +66,7 @@ export function ListsDetailView({ listId, onBack, onEdit, onDelete }: ListsDetai
                 onDeleted={onDelete}
               />
             )}
-            <ListPoisSection listId={listId} />
+            <ListPoisSection listId={listId} role={loadedList.role} />
           </div>
         )}
       </ListsListQueryBoundary>

--- a/apps/web/src/features/pois/components/poi-card.tsx
+++ b/apps/web/src/features/pois/components/poi-card.tsx
@@ -18,17 +18,18 @@ export function PoiCard({ poi, actions }: PoiCardProps) {
   const tPoi = useTranslations("poi");
 
   return (
-    <article className="flex flex-col items-start rounded-md border border-border">
+    <article className="group flex flex-col items-start rounded-md border border-border">
       {poi.photo ? (
         <div className="overflow-hidden rounded-t-md h-[150px] w-full">
           <PoiPhoto photo={poi.photo} alt={poi.name} />
         </div>
       ) : null}
       <div className="px-4 py-2 flex flex-col gap-1 w-full">
-        <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="flex items-start justify-between gap-2">
           <h3 className="min-w-0 font-display text-base font-semibold tracking-tight">
             {poi.name}
           </h3>
+          {actions ? <div className="shrink-0">{actions}</div> : null}
         </div>
 
         <p className="flex min-w-0 items-center gap-1.5 text-sm text-muted-foreground">
@@ -43,8 +44,6 @@ export function PoiCard({ poi, actions }: PoiCardProps) {
           </div>
         ) : null}
       </div>
-
-      {actions ? <div className="shrink-0">{actions}</div> : null}
     </article>
   );
 }


### PR DESCRIPTION
## 📝 Description

Ajout de la suppression d'un lieu depuis le détail d'une liste (NIR-64) : bouton discret sur chaque carte POI, dialog de confirmation, et rafraîchissement du cache React Query (liste des POIs, détail et index des listes).

## 🎯 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI update (no functional changes)
- [ ] ♻️ Code refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [x] ✅ Test update

## 🔗 Related Issues

Closes #95
Related to NIR-64 (parent: NIR-60)

## 🚀 Changes Made

- Création de `RemovePoiDialog` (confirmation, toasts, gestion `SAVED_POI_NOT_FOUND` / 403)
- Bouton icône « Retirer » intégré dans l'en-tête de `PoiCard`, visible selon `canEditList(role)`
- Propagation du rôle utilisateur : `ListsDetailView` → `ListPoisSection` → `ListPoiRow`
- Invalidation du cache `lists.all` après suppression (compteur de lieux à jour sur l'index)
- Tests unitaires : `remove-poi-dialog.test.tsx`, extension de `list-pois-section` et `lists-detail-view`

## 🧪 Testing

- [x] Tested locally with `pnpm dev`
- [x] All quality checks pass (`pnpm lint`)
- [ ] Unit tests pass (`pnpm test`)
- [ ] Database migrations applied if needed

## 📸 Screenshots/Videos

Recommandé : capture du bouton icône sur une carte POI + dialog de confirmation.

N/A (non fourni dans cette MR)

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated if needed
- [x] No console errors or warnings
- [x] Removed any debug code
- [x] Translations added for any new text