### PR TITLE
test(lists): add unit tests for poi list hooks

### DIFF
--- a/apps/web/src/features/lists/hooks/use-add-poi-to-list.test.tsx
+++ b/apps/web/src/features/lists/hooks/use-add-poi-to-list.test.tsx
@@ -1,0 +1,102 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useAddPoiToList } from "./use-add-poi-to-list";
+
+import { addPoiToList } from "@/lib/api";
+import { queryKeys } from "@/lib/api/query-keys";
+
+vi.mock("@/lib/api", () => ({
+  addPoiToList: vi.fn(),
+}));
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+function apiResponse(value: { data?: unknown; error?: unknown }) {
+  return value as Awaited<ReturnType<typeof addPoiToList>>;
+}
+
+describe("useAddPoiToList", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+  });
+
+  it("calls addPoiToList and returns data on success", async () => {
+    const input = {
+      listId: "list-1",
+      body: { googlePlaceId: "place-1" },
+    };
+    const data = { savedPoi: { id: "saved-1", googlePlaceId: "place-1" } };
+    vi.mocked(addPoiToList).mockResolvedValue(apiResponse({ data }));
+
+    const { result } = renderHook(() => useAddPoiToList(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    let resolved: unknown;
+    await act(async () => {
+      resolved = await result.current.mutateAsync(input);
+    });
+
+    expect(addPoiToList).toHaveBeenCalledWith({
+      path: { listId: "list-1" },
+      body: { googlePlaceId: "place-1" },
+    });
+    expect(resolved).toEqual(data);
+  });
+
+  it("invalidates POI, detail, and lists cache on success", async () => {
+    const listId = "list-1";
+    vi.mocked(addPoiToList).mockResolvedValue(
+      apiResponse({ data: { savedPoi: { id: "saved-1" } } })
+    );
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useAddPoiToList(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ listId, body: { googlePlaceId: "place-1" } });
+    });
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: queryKeys.lists.pois.all(listId),
+      });
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: queryKeys.lists.detail(listId),
+      });
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.lists.all });
+    });
+  });
+
+  it("throws API error when response has no data", async () => {
+    const apiError = { message: "Forbidden" };
+    vi.mocked(addPoiToList).mockResolvedValue(apiResponse({ error: apiError }));
+
+    const { result } = renderHook(() => useAddPoiToList(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await expect(
+      act(async () => {
+        await result.current.mutateAsync({
+          listId: "list-1",
+          body: { googlePlaceId: "place-1" },
+        });
+      })
+    ).rejects.toEqual(apiError);
+  });
+});

--- a/apps/web/src/features/lists/hooks/use-list-pois-infinite.test.tsx
+++ b/apps/web/src/features/lists/hooks/use-list-pois-infinite.test.tsx
@@ -1,0 +1,89 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { LIST_POIS_PAGE_SIZE } from "./use-list-pois";
+import { useListPoisInfinite } from "./use-list-pois-infinite";
+
+const getListPois = vi.fn();
+const useAuth = vi.fn();
+
+vi.mock("@/features/auth", () => ({
+  useAuth: () => useAuth(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  getListPois: (...args: unknown[]) => getListPois(...args),
+}));
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe("useListPoisInfinite", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    useAuth.mockReturnValue({ user: { id: "user-1" } });
+    getListPois.mockResolvedValue({
+      data: { pois: [{ id: "poi-1" }], pagination: { page: 1, totalPages: 1, total: 1 } },
+    });
+  });
+
+  it("does not fetch when listId is undefined", () => {
+    renderHook(() => useListPoisInfinite(undefined), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    expect(getListPois).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch when user is absent", () => {
+    useAuth.mockReturnValue({ user: null });
+
+    renderHook(() => useListPoisInfinite("list-1"), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    expect(getListPois).not.toHaveBeenCalled();
+  });
+
+  it("fetches first page with default limit", async () => {
+    const { result } = renderHook(() => useListPoisInfinite("list-1"), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(getListPois).toHaveBeenCalledWith({
+      path: { listId: "list-1" },
+      query: { page: 1, limit: LIST_POIS_PAGE_SIZE },
+    });
+    expect(result.current.data?.pages[0]).toEqual({
+      pois: [{ id: "poi-1" }],
+      pagination: { page: 1, totalPages: 1, total: 1 },
+    });
+  });
+
+  it("passes custom limit filter on first page", async () => {
+    renderHook(() => useListPoisInfinite("list-1", { limit: 10 }), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => {
+      expect(getListPois).toHaveBeenCalledWith({
+        path: { listId: "list-1" },
+        query: { page: 1, limit: 10 },
+      });
+    });
+  });
+});

--- a/apps/web/src/features/lists/hooks/use-list-pois.test.tsx
+++ b/apps/web/src/features/lists/hooks/use-list-pois.test.tsx
@@ -1,0 +1,91 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useListPois } from "./use-list-pois";
+
+const getListPois = vi.fn();
+const useAuth = vi.fn();
+
+vi.mock("@/features/auth", () => ({
+  useAuth: () => useAuth(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  getListPois: (...args: unknown[]) => getListPois(...args),
+}));
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe("useListPois", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    useAuth.mockReturnValue({ user: { id: "user-1" } });
+    getListPois.mockResolvedValue({
+      data: { pois: [{ id: "poi-1" }], pagination: { page: 1, totalPages: 1, total: 1 } },
+    });
+  });
+
+  it("does not fetch when listId is undefined", () => {
+    renderHook(() => useListPois(undefined), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    expect(getListPois).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch when user is absent", () => {
+    useAuth.mockReturnValue({ user: null });
+
+    renderHook(() => useListPois("list-1"), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    expect(getListPois).not.toHaveBeenCalled();
+  });
+
+  it("fetches POIs with listId and filters", async () => {
+    const filters = { page: 1, limit: 10 };
+    const { result } = renderHook(() => useListPois("list-1", filters), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(getListPois).toHaveBeenCalledWith({
+      path: { listId: "list-1" },
+      query: filters,
+    });
+    expect(result.current.data).toEqual({
+      pois: [{ id: "poi-1" }],
+      pagination: { page: 1, totalPages: 1, total: 1 },
+    });
+  });
+
+  it("throws API error when response has no data", async () => {
+    const apiError = { message: "Not found" };
+    getListPois.mockResolvedValue({ error: apiError });
+
+    const { result } = renderHook(() => useListPois("list-1"), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error).toEqual(apiError);
+  });
+});

--- a/apps/web/src/features/lists/hooks/use-remove-poi-from-list.test.tsx
+++ b/apps/web/src/features/lists/hooks/use-remove-poi-from-list.test.tsx
@@ -1,0 +1,93 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useRemovePoiFromList } from "./use-remove-poi-from-list";
+
+import { removePoiFromList } from "@/lib/api";
+import { queryKeys } from "@/lib/api/query-keys";
+
+vi.mock("@/lib/api", () => ({
+  removePoiFromList: vi.fn(),
+}));
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+function apiResponse(value: { data?: unknown; error?: unknown }) {
+  return value as Awaited<ReturnType<typeof removePoiFromList>>;
+}
+
+describe("useRemovePoiFromList", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+  });
+
+  it("calls removePoiFromList and returns data on success", async () => {
+    const input = { listId: "list-1", savedPoiId: "saved-1" };
+    const data = { message: "POI removed" };
+    vi.mocked(removePoiFromList).mockResolvedValue(apiResponse({ data }));
+
+    const { result } = renderHook(() => useRemovePoiFromList(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    let resolved: unknown;
+    await act(async () => {
+      resolved = await result.current.mutateAsync(input);
+    });
+
+    expect(removePoiFromList).toHaveBeenCalledWith({
+      path: { listId: "list-1", savedPoiId: "saved-1" },
+    });
+    expect(resolved).toEqual(data);
+  });
+
+  it("invalidates POI, detail, and lists cache on success", async () => {
+    const listId = "list-1";
+    vi.mocked(removePoiFromList).mockResolvedValue(apiResponse({ data: { message: "POI removed" } }));
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useRemovePoiFromList(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ listId, savedPoiId: "saved-1" });
+    });
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: queryKeys.lists.pois.all(listId),
+      });
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: queryKeys.lists.detail(listId),
+      });
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.lists.all });
+    });
+  });
+
+  it("throws API error when response has no data", async () => {
+    const apiError = { message: "Not found" };
+    vi.mocked(removePoiFromList).mockResolvedValue(apiResponse({ error: apiError }));
+
+    const { result } = renderHook(() => useRemovePoiFromList(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await expect(
+      act(async () => {
+        await result.current.mutateAsync({ listId: "list-1", savedPoiId: "saved-1" });
+      })
+    ).rejects.toEqual(apiError);
+  });
+});

--- a/apps/web/src/lib/api/query-keys.test.ts
+++ b/apps/web/src/lib/api/query-keys.test.ts
@@ -29,6 +29,21 @@ describe("queryKeys.lists", () => {
     expect(queryKeys.lists.detail("id")[0]).toBe(queryKeys.lists.all[0]);
   });
 
+  it("pois.all includes listId", () => {
+    expect(queryKeys.lists.pois.all("list-1")).toEqual(["lists", "pois", "list-1"]);
+  });
+
+  it("pois.list includes listId and filters", () => {
+    expect(queryKeys.lists.pois.list("list-1")).toEqual(["lists", "pois", "list-1", undefined]);
+
+    expect(queryKeys.lists.pois.list("list-1", { page: 1 })).toEqual([
+      "lists",
+      "pois",
+      "list-1",
+      { page: 1 },
+    ]);
+  });
+
   it("pois.infinite includes listId and filters", () => {
     expect(queryKeys.lists.pois.infinite("list-1")).toEqual([
       "lists",
@@ -45,5 +60,16 @@ describe("queryKeys.lists", () => {
       "infinite",
       { limit: 10 },
     ]);
+  });
+
+  it("poiMembership keys are prefixed by lists root", () => {
+    expect(queryKeys.lists.poiMembership.all).toEqual(["lists", "poi-membership"]);
+    expect(queryKeys.lists.poiMembership.byPlaces(["a", "b"])).toEqual([
+      "lists",
+      "poi-membership",
+      ["a", "b"],
+    ]);
+    expect(queryKeys.lists.poiMembership.all[0]).toBe(queryKeys.lists.all[0]);
+    expect(queryKeys.lists.poiMembership.byPlaces(["a"])[0]).toBe(queryKeys.lists.all[0]);
   });
 });


### PR DESCRIPTION
## 📝 Description

Complète la couverture de tests unitaires pour la gestion des POIs dans les listes (ticket NIR-66) : query keys React Query et hooks de lecture/mutation, avec mocks API uniquement.

## 🎯 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI update (no functional changes)
- [ ] ♻️ Code refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [x] ✅ Test update

## 🔗 Related Issues

Closes #97

## 🚀 Changes Made

- Extension de `query-keys.test.ts` : `pois.all`, `pois.list`, `poiMembership`
- Ajout de `use-list-pois.test.tsx` (enabled, fetch, gestion d'erreur API)
- Ajout de `use-list-pois-infinite.test.tsx` (enabled, première page avec pagination)
- Ajout de `use-add-poi-to-list.test.tsx` (succès, invalidation cache, erreur API)
- Ajout de `use-remove-poi-from-list.test.tsx` (succès, invalidation cache, erreur API)

## 🧪 Testing

- [x] Tested locally with `pnpm dev`
- [x] All quality checks pass (`pnpm lint`)
- [x] Unit tests pass (`pnpm test`)
- [ ] Database migrations applied if needed

## 📸 Screenshots/Videos

N/A

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated if needed
- [x] No console errors or warnings
- [x] Removed any debug code