### PR TITLE
feat(pois): add POI coordinate helpers (#147)

### DIFF
--- a/apps/web/src/features/pois/index.ts
+++ b/apps/web/src/features/pois/index.ts
@@ -8,10 +8,16 @@ export {
   getPoiDisplayDataFromGooglePlace,
 } from "./utils/get-poi-display-data";
 
+export {
+  getCoordinatesFromGooglePlace,
+  getCoordinatesFromSavedPoi,
+} from "./utils/get-poi-coordinates";
+
 export type {
   PoiDisplayData,
   PoiPhoto as PoiPhotoData,
   PoiOpeningHours as PoiOpeningHoursData,
   SavedPoiListItem,
   PoiSource,
+  MapPoi,
 } from "./types/poi-display-types";

--- a/apps/web/src/features/pois/types/poi-display-types.ts
+++ b/apps/web/src/features/pois/types/poi-display-types.ts
@@ -26,4 +26,11 @@ export type PoiDisplayData = {
   openingHours: PoiOpeningHours | null;
 };
 
+export type MapPoi = {
+  id: string;
+  lat: number;
+  lng: number;
+  label?: string;
+};
+
 export type { Poi, GooglePlace };

--- a/apps/web/src/features/pois/utils/get-poi-coordinates.test.ts
+++ b/apps/web/src/features/pois/utils/get-poi-coordinates.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getCoordinatesFromGooglePlace,
+  getCoordinatesFromSavedPoi,
+} from "./get-poi-coordinates";
+
+describe("getCoordinatesFromGooglePlace", () => {
+  it("returns MapPoi for a Google Place with valid coordinates", () => {
+    expect(
+      getCoordinatesFromGooglePlace({
+        placeId: "ChIJLU7jZClu5kcR4PcOOO6p3I0",
+        name: "Tour Eiffel",
+        latitude: 48.8566,
+        longitude: 2.3522,
+      })
+    ).toEqual({
+      id: "ChIJLU7jZClu5kcR4PcOOO6p3I0",
+      lat: 48.8566,
+      lng: 2.3522,
+      label: "Tour Eiffel",
+    });
+  });
+
+  it("returns null for Google (0, 0) sentinel coordinates", () => {
+    expect(
+      getCoordinatesFromGooglePlace({
+        placeId: "ChIJmissing",
+        name: "Unknown place",
+        latitude: 0,
+        longitude: 0,
+      })
+    ).toBeNull();
+  });
+
+  it("returns null when lat/lng are undefined", () => {
+    expect(
+      getCoordinatesFromGooglePlace({
+        placeId: "ChIJno-geo",
+        name: "No coords",
+      })
+    ).toBeNull();
+  });
+
+  it("omits label when the name is empty", () => {
+    expect(
+      getCoordinatesFromGooglePlace({
+        placeId: "ChIJno-name",
+        name: "   ",
+        latitude: 48.8566,
+        longitude: 2.3522,
+      })
+    ).toEqual({
+      id: "ChIJno-name",
+      lat: 48.8566,
+      lng: 2.3522,
+    });
+  });
+});
+
+describe("getCoordinatesFromSavedPoi", () => {
+  it("maps a custom SavedPoi with coordinates", () => {
+    expect(
+      getCoordinatesFromSavedPoi({
+        id: "sp-1",
+        poiId: "poi-1",
+        googlePlaceId: null,
+        poi: {
+          id: "poi-1",
+          name: "Tour Eiffel",
+          latitude: 48.8584,
+          longitude: 2.2945,
+        },
+      })
+    ).toEqual({
+      id: "sp-1",
+      lat: 48.8584,
+      lng: 2.2945,
+      label: "Tour Eiffel",
+    });
+  });
+
+  it("maps a SavedPoi from Google Place cache", () => {
+    expect(
+      getCoordinatesFromSavedPoi({
+        id: "sp-2",
+        googlePlaceCache: {
+          placeId: "ChIJ...",
+          name: "Café de Flore",
+          latitude: 48.8542,
+          longitude: 2.3326,
+        },
+      })
+    ).toEqual({
+      id: "sp-2",
+      lat: 48.8542,
+      lng: 2.3326,
+      label: "Café de Flore",
+    });
+  });
+
+  it("returns null when SavedPoi has no geo", () => {
+    expect(getCoordinatesFromSavedPoi({ id: "sp-4" })).toBeNull();
+  });
+
+  it("returns null when SavedPoi sources have no coordinates", () => {
+    expect(
+      getCoordinatesFromSavedPoi({
+        id: "sp-5",
+        poi: {
+          id: "poi-5",
+          name: "No address POI",
+        },
+      })
+    ).toBeNull();
+  });
+
+  it("prefers googlePlaceCache over poi when both have coordinates", () => {
+    expect(
+      getCoordinatesFromSavedPoi({
+        id: "sp-6",
+        poi: {
+          id: "poi-6",
+          name: "Custom name",
+          latitude: 48.86,
+          longitude: 2.3,
+        },
+        googlePlaceCache: {
+          placeId: "ChIJgoogle",
+          name: "Google name",
+          latitude: 48.8542,
+          longitude: 2.3326,
+        },
+      })
+    ).toEqual({
+      id: "sp-6",
+      lat: 48.8542,
+      lng: 2.3326,
+      label: "Google name",
+    });
+  });
+
+  it("falls back to poi when googlePlaceCache is (0, 0)", () => {
+    expect(
+      getCoordinatesFromSavedPoi({
+        id: "sp-7",
+        poi: {
+          id: "poi-7",
+          name: "Custom fallback",
+          latitude: 48.8584,
+          longitude: 2.2945,
+        },
+        googlePlaceCache: {
+          placeId: "ChIJzero",
+          name: "Missing location",
+          latitude: 0,
+          longitude: 0,
+        },
+      })
+    ).toEqual({
+      id: "sp-7",
+      lat: 48.8584,
+      lng: 2.2945,
+      label: "Custom fallback",
+    });
+  });
+});

--- a/apps/web/src/features/pois/utils/get-poi-coordinates.ts
+++ b/apps/web/src/features/pois/utils/get-poi-coordinates.ts
@@ -1,0 +1,48 @@
+import type { GooglePlace, MapPoi, Poi, SavedPoiListItem } from "../types/poi-display-types";
+
+function parseCoordinates(
+  lat: number | undefined,
+  lng: number | undefined
+): { lat: number; lng: number } | null {
+  if (typeof lat !== "number" || typeof lng !== "number") return null;
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+  if (lat === 0 && lng === 0) return null;
+  return { lat, lng };
+}
+
+function toMapPoi(id: string, lat: number, lng: number, name?: string | null): MapPoi {
+  const label = name?.trim();
+  return label ? { id, lat, lng, label } : { id, lat, lng };
+}
+
+export function getCoordinatesFromGooglePlace(place: GooglePlace): MapPoi | null {
+  const coords = parseCoordinates(place.latitude, place.longitude);
+  if (!coords) return null;
+
+  return toMapPoi(place.placeId ?? "", coords.lat, coords.lng, place.name);
+}
+
+function getCoordinatesFromPoi(poi: Poi, id: string): MapPoi | null {
+  const coords = parseCoordinates(poi.latitude, poi.longitude);
+  if (!coords) return null;
+
+  return toMapPoi(id, coords.lat, coords.lng, poi.name);
+}
+
+export function getCoordinatesFromSavedPoi(savedPoi: SavedPoiListItem): MapPoi | null {
+  if (savedPoi.googlePlaceCache) {
+    const fromCache = getCoordinatesFromGooglePlace(savedPoi.googlePlaceCache);
+    if (fromCache) {
+      return {
+        ...fromCache,
+        id: savedPoi.id ?? savedPoi.googlePlaceCache.placeId ?? fromCache.id,
+      };
+    }
+  }
+
+  if (savedPoi.poi) {
+    return getCoordinatesFromPoi(savedPoi.poi, savedPoi.id ?? savedPoi.poi.id ?? "");
+  }
+
+  return null;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Description

Adds shared helpers to extract map coordinates from Google Places and SavedPoi items, so Explore and list views can later render markers without duplicating geo logic or pinning places at `(0, 0)`.

## 🎯 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] ✅ Test update

## 🔗 Related Issues

Closes #147 (NIR-70). Related to #144 (epic: POI markers on the map).

## 🚀 Changes Made

- Add `MapPoi` (`id`, `lat`, `lng`, `label?`) in POI display types
- Add `getCoordinatesFromGooglePlace` and `getCoordinatesFromSavedPoi`
- Reject missing, non-finite, or sentinel `(0, 0)` coordinates
- Prefer `googlePlaceCache`, then fall back to custom `poi` when cache geo is invalid
- Export helpers and `MapPoi` from `features/pois`

## 🧪 Testing

- [ ] Tested locally with `pnpm dev`
- [ ] All quality checks pass (`pnpm lint`)
- [x] Unit tests pass (`pnpm test`) — 10/10 in `get-poi-coordinates.test.ts`, full web suite 186/186
- [ ] Database migrations applied if needed

## 📸 Screenshots/Videos

N/A — pure helpers, no UI.

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated if needed
- [x] No console errors or warnings
- [x] Removed any debug code

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffb1c-fe21-7132-bd50-80fb5cbf3b2b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffb1c-fe21-7132-bd50-80fb5cbf3b2b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

