### PR TITLE
feat(map): add reusable POI markers layer (#148)

### DIFF
--- a/apps/web/src/features/map/components/index.ts
+++ b/apps/web/src/features/map/components/index.ts
@@ -1,2 +1,3 @@
 export * from "./mapbox-map";
 export * from "./controls";
+export { PoiMarkersLayer } from "./poi-markers-layer";

--- a/apps/web/src/features/map/components/poi-markers-layer.test.tsx
+++ b/apps/web/src/features/map/components/poi-markers-layer.test.tsx
@@ -4,7 +4,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { MapPoi } from "@/features/pois";
 
 const fitBounds = vi.fn();
-const useMapMock = vi.fn(() => ({ map: { fitBounds } }));
+const useMapMock = vi.fn((): { map: { fitBounds: typeof fitBounds } | null } => ({
+  map: { fitBounds },
+}));
 
 type MarkerMock = {
   setLngLat: ReturnType<typeof vi.fn>;

--- a/apps/web/src/features/map/components/poi-markers-layer.test.tsx
+++ b/apps/web/src/features/map/components/poi-markers-layer.test.tsx
@@ -1,0 +1,116 @@
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { MapPoi } from "@/features/pois";
+
+const fitBounds = vi.fn();
+const useMapMock = vi.fn(() => ({ map: { fitBounds } }));
+
+type MarkerMock = {
+  setLngLat: ReturnType<typeof vi.fn>;
+  addTo: ReturnType<typeof vi.fn>;
+  remove: ReturnType<typeof vi.fn>;
+  setPopup: ReturnType<typeof vi.fn>;
+};
+
+const markerInstances: MarkerMock[] = [];
+
+vi.mock("../context", () => ({
+  useMap: () => useMapMock(),
+}));
+
+vi.mock("mapbox-gl", () => {
+  class Marker {
+    setLngLat = vi.fn().mockReturnThis();
+    addTo = vi.fn().mockReturnThis();
+    remove = vi.fn();
+    setPopup = vi.fn().mockReturnThis();
+
+    constructor() {
+      markerInstances.push(this);
+    }
+  }
+
+  class Popup {
+    setText = vi.fn().mockReturnThis();
+  }
+
+  return { default: { Marker, Popup } };
+});
+
+import { PoiMarkersLayer } from "./poi-markers-layer";
+
+const paris: MapPoi = { id: "paris", lat: 48.8566, lng: 2.3522, label: "Paris" };
+const lyon: MapPoi = { id: "lyon", lat: 45.764, lng: 4.8357, label: "Lyon" };
+
+describe("PoiMarkersLayer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    markerInstances.length = 0;
+    useMapMock.mockReturnValue({ map: { fitBounds } });
+  });
+
+  it("creates a marker per POI and fits bounds", () => {
+    render(<PoiMarkersLayer pois={[paris, lyon]} />);
+
+    expect(markerInstances).toHaveLength(2);
+    expect(markerInstances[0].setLngLat).toHaveBeenCalledWith([2.3522, 48.8566]);
+    expect(markerInstances[1].setLngLat).toHaveBeenCalledWith([4.8357, 45.764]);
+    expect(markerInstances[0].addTo).toHaveBeenCalledWith({ fitBounds });
+    expect(markerInstances[1].addTo).toHaveBeenCalledWith({ fitBounds });
+    expect(fitBounds).toHaveBeenCalledWith(
+      [
+        [2.3522, 45.764],
+        [4.8357, 48.8566],
+      ],
+      { padding: 80, maxZoom: 15, duration: 800 }
+    );
+  });
+
+  it("removes markers on unmount", () => {
+    const { unmount } = render(<PoiMarkersLayer pois={[paris]} />);
+
+    unmount();
+
+    expect(markerInstances[0].remove).toHaveBeenCalledTimes(1);
+  });
+
+  it("cleans up markers and skips fitBounds for an empty set", () => {
+    const { rerender } = render(<PoiMarkersLayer pois={[paris]} />);
+
+    expect(markerInstances).toHaveLength(1);
+    expect(fitBounds).toHaveBeenCalledTimes(1);
+
+    rerender(<PoiMarkersLayer pois={[]} />);
+
+    expect(markerInstances[0].remove).toHaveBeenCalledTimes(1);
+    expect(markerInstances).toHaveLength(1);
+    expect(fitBounds).toHaveBeenCalledTimes(1);
+  });
+
+  it("replaces markers and refits when the set changes", () => {
+    const { rerender } = render(<PoiMarkersLayer pois={[paris]} />);
+
+    rerender(<PoiMarkersLayer pois={[lyon]} />);
+
+    expect(markerInstances).toHaveLength(2);
+    expect(markerInstances[0].remove).toHaveBeenCalledTimes(1);
+    expect(markerInstances[1].setLngLat).toHaveBeenCalledWith([4.8357, 45.764]);
+    expect(fitBounds).toHaveBeenLastCalledWith(
+      [
+        [4.8357, 45.764],
+        [4.8357, 45.764],
+      ],
+      { padding: 80, maxZoom: 15, duration: 800 }
+    );
+  });
+
+  it("creates no markers when the map is not ready", () => {
+    useMapMock.mockReturnValue({ map: null });
+
+    render(<PoiMarkersLayer pois={[paris]} />);
+
+    expect(markerInstances).toHaveLength(0);
+    expect(fitBounds).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/features/map/components/poi-markers-layer.tsx
+++ b/apps/web/src/features/map/components/poi-markers-layer.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import mapboxgl from "mapbox-gl";
+import { useEffect } from "react";
+
+import { useMap } from "../context";
+import { getMapPoiBounds } from "../utils/map-bounds";
+
+import type { MapPoi } from "@/features/pois";
+
+type PoiMarkersLayerProps = {
+  pois: MapPoi[];
+};
+
+export function PoiMarkersLayer({ pois }: PoiMarkersLayerProps) {
+  const { map } = useMap();
+
+  useEffect(() => {
+    if (!map) return;
+
+    const markers = pois.map((poi) => {
+      const marker = new mapboxgl.Marker().setLngLat([poi.lng, poi.lat]);
+
+      if (poi.label) {
+        marker.setPopup(new mapboxgl.Popup({ closeButton: false }).setText(poi.label));
+      }
+
+      return marker.addTo(map);
+    });
+
+    const bounds = getMapPoiBounds(pois);
+    if (bounds) {
+      map.fitBounds(bounds, { padding: 80, maxZoom: 15, duration: 800 });
+    }
+
+    return () => {
+      markers.forEach((marker) => marker.remove());
+    };
+  }, [map, pois]);
+
+  return null;
+}

--- a/apps/web/src/features/map/index.ts
+++ b/apps/web/src/features/map/index.ts
@@ -1,2 +1,3 @@
 export * from "./context";
 export * from "./components";
+export { getMapPoiBounds } from "./utils/map-bounds";

--- a/apps/web/src/features/map/utils/map-bounds.test.ts
+++ b/apps/web/src/features/map/utils/map-bounds.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { getMapPoiBounds } from "./map-bounds";
+
+describe("getMapPoiBounds", () => {
+  it("returns null for an empty set", () => {
+    expect(getMapPoiBounds([])).toBeNull();
+  });
+
+  it("returns a degenerate bbox for a single POI", () => {
+    expect(getMapPoiBounds([{ id: "paris", lat: 48.8566, lng: 2.3522, label: "Paris" }])).toEqual([
+      [2.3522, 48.8566],
+      [2.3522, 48.8566],
+    ]);
+  });
+
+  it("returns min/max lng/lat for multiple POIs", () => {
+    expect(
+      getMapPoiBounds([
+        { id: "paris", lat: 48.8566, lng: 2.3522 },
+        { id: "lyon", lat: 45.764, lng: 4.8357 },
+      ])
+    ).toEqual([
+      [2.3522, 45.764],
+      [4.8357, 48.8566],
+    ]);
+  });
+});

--- a/apps/web/src/features/map/utils/map-bounds.ts
+++ b/apps/web/src/features/map/utils/map-bounds.ts
@@ -1,0 +1,22 @@
+import type { MapPoi } from "@/features/pois";
+
+export function getMapPoiBounds(pois: MapPoi[]): [[number, number], [number, number]] | null {
+  if (pois.length === 0) return null;
+
+  let minLng = pois[0].lng;
+  let minLat = pois[0].lat;
+  let maxLng = pois[0].lng;
+  let maxLat = pois[0].lat;
+
+  for (const poi of pois) {
+    if (poi.lng < minLng) minLng = poi.lng;
+    if (poi.lat < minLat) minLat = poi.lat;
+    if (poi.lng > maxLng) maxLng = poi.lng;
+    if (poi.lat > maxLat) maxLat = poi.lat;
+  }
+
+  return [
+    [minLng, minLat],
+    [maxLng, maxLat],
+  ];
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Description

Adds a shared Mapbox markers primitive (`PoiMarkersLayer` + `getMapPoiBounds`) so Explore and list views can later show POIs on the existing map without duplicating Marker / fitBounds logic.

## 🎯 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] ✅ Test update

## 🔗 Related Issues

Closes #148 (NIR-71). Related to #144 (epic) and #147 (coordinate helpers already on `nir-67`).

## 🚀 Changes Made

- Add `getMapPoiBounds` (empty set → `null`, otherwise `[[minLng, minLat], [maxLng, maxLat]]`)
- Add `PoiMarkersLayer` that creates/destroys `mapboxgl.Marker` from `MapPoi[]`
- `fitBounds` when the set is non-empty (padding 80, maxZoom 15); skip camera move on empty set
- Optional popup from `label`
- Export from `features/map`
- No changes to `MapboxMap`, geoloc, theme, or app layout
- Fix `useMap` test mock typing so `map: null` passes `tsc` (CI `ci-web`)

## 🧪 Testing

- [ ] Tested locally with `pnpm dev`
- [x] Typecheck passes (`pnpm -C apps/web exec tsc --noEmit`)
- [x] Unit tests pass — 8/8 in `src/features/map`
- [ ] Database migrations applied if needed

## 📸 Screenshots/Videos

N/A — primitive only, not wired to Explore/lists yet.

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated if needed
- [x] No console errors or warnings
- [x] Removed any debug code

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffb1c-fe21-7132-bd50-80fb5cbf3b2b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffb1c-fe21-7132-bd50-80fb5cbf3b2b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

