### PR TITLE
feat(explore): show search results as map markers (#149)

### DIFF
--- a/apps/web/src/features/explore/views/explore-results-view.test.tsx
+++ b/apps/web/src/features/explore/views/explore-results-view.test.tsx
@@ -47,6 +47,12 @@ vi.mock("../components/add-to-list-picker", () => ({
     open ? <div>picker for {placeName}</div> : null,
 }));
 
+vi.mock("@/features/map", () => ({
+  PoiMarkersLayer: ({ pois }: { pois: { id: string }[] }) => (
+    <div data-testid="poi-markers-layer" data-ids={pois.map((poi) => poi.id).join(",")} />
+  ),
+}));
+
 type SearchResult = ReturnType<typeof useSearchGooglePlaces>;
 
 function mockSearch(overrides: Partial<Record<keyof SearchResult, unknown>>) {
@@ -122,5 +128,70 @@ describe("ExploreResultsView", () => {
     await user.click(screen.getByRole("button", { name: "Louvre" }));
 
     expect(screen.getByText("picker for Louvre")).toBeInTheDocument();
+  });
+
+  it("passes geolocated places to the markers layer", () => {
+    mockSearch({
+      data: {
+        places: [
+          { placeId: "ChIJeiffel", name: "Tour Eiffel", latitude: 48.8584, longitude: 2.2945 },
+          { placeId: "ChIJlouvre", name: "Louvre", latitude: 48.8606, longitude: 2.3376 },
+        ],
+      },
+    });
+
+    render(<ExploreResultsView />);
+
+    expect(screen.getByTestId("poi-markers-layer")).toHaveAttribute(
+      "data-ids",
+      "ChIJeiffel,ChIJlouvre"
+    );
+  });
+
+  it("omits places without coordinates or with the (0, 0) sentinel", () => {
+    mockSearch({
+      data: {
+        places: [
+          { placeId: "ChIJeiffel", name: "Tour Eiffel", latitude: 48.8584, longitude: 2.2945 },
+          { placeId: "ChIJmissing", name: "No coords" },
+          { placeId: "ChIJzero", name: "Unknown", latitude: 0, longitude: 0 },
+        ],
+      },
+    });
+
+    render(<ExploreResultsView />);
+
+    expect(screen.getByTestId("poi-markers-layer")).toHaveAttribute("data-ids", "ChIJeiffel");
+  });
+
+  it("clears markers when the search errors", () => {
+    mockSearch({
+      isError: true,
+      error: { error: { code: "GOOGLE_PLACE_SEARCH_ERROR" } },
+      data: {
+        places: [
+          { placeId: "ChIJeiffel", name: "Tour Eiffel", latitude: 48.8584, longitude: 2.2945 },
+        ],
+      },
+    });
+
+    render(<ExploreResultsView />);
+
+    expect(screen.getByTestId("poi-markers-layer")).toHaveAttribute("data-ids", "");
+  });
+
+  it("does not mount the markers layer on the idle state", () => {
+    mockUseShell.mockReturnValue({ query: "c" });
+    mockSearch({
+      data: {
+        places: [
+          { placeId: "ChIJeiffel", name: "Tour Eiffel", latitude: 48.8584, longitude: 2.2945 },
+        ],
+      },
+    });
+
+    render(<ExploreResultsView />);
+
+    expect(screen.queryByTestId("poi-markers-layer")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/explore/views/explore-results-view.tsx
+++ b/apps/web/src/features/explore/views/explore-results-view.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 import { AddToListPicker, type AddToListTarget } from "../components/add-to-list-picker";
 import { ExploreResultRow } from "../components/explore-result-row";
@@ -11,6 +11,8 @@ import { usePoiListMembership } from "../hooks/use-poi-list-membership";
 import { useSearchGooglePlaces } from "../hooks/use-search-google-places";
 
 import { EXPLORE_MIN_QUERY_LENGTH, useShell } from "@/features/app-shell";
+import { PoiMarkersLayer } from "@/features/map";
+import { getCoordinatesFromGooglePlace, type MapPoi } from "@/features/pois";
 import { useErrorMessage } from "@/hooks/use-error-message";
 
 export function ExploreResultsView() {
@@ -24,6 +26,10 @@ export function ExploreResultsView() {
     .filter((placeId): placeId is string => Boolean(placeId));
   const { data: membershipData } = usePoiListMembership(placeIds);
   const membership = membershipData?.membership ?? {};
+  const mapPois = useMemo(() => {
+    if (isError) return [];
+    return places.map(getCoordinatesFromGooglePlace).filter((poi): poi is MapPoi => poi !== null);
+  }, [isError, places]);
   // A single picker for the whole list: mounting one per row would duplicate the lists query.
   const [target, setTarget] = useState<AddToListTarget | null>(null);
   const [isPickerOpen, setIsPickerOpen] = useState(false);
@@ -82,6 +88,8 @@ export function ExploreResultsView() {
           onOpenChange={setIsPickerOpen}
         />
       ) : null}
+
+      <PoiMarkersLayer pois={mapPois} />
     </div>
   );
 }

--- a/apps/web/src/features/explore/views/explore-results-view.tsx
+++ b/apps/web/src/features/explore/views/explore-results-view.tsx
@@ -28,8 +28,10 @@ export function ExploreResultsView() {
   const membership = membershipData?.membership ?? {};
   const mapPois = useMemo(() => {
     if (isError) return [];
-    return places.map(getCoordinatesFromGooglePlace).filter((poi): poi is MapPoi => poi !== null);
-  }, [isError, places]);
+    return (data?.places ?? [])
+      .map(getCoordinatesFromGooglePlace)
+      .filter((poi): poi is MapPoi => poi !== null);
+  }, [isError, data?.places]);
   // A single picker for the whole list: mounting one per row would duplicate the lists query.
   const [target, setTarget] = useState<AddToListTarget | null>(null);
   const [isPickerOpen, setIsPickerOpen] = useState(false);

--- a/apps/web/src/features/map/components/poi-markers-layer.test.tsx
+++ b/apps/web/src/features/map/components/poi-markers-layer.test.tsx
@@ -115,4 +115,16 @@ describe("PoiMarkersLayer", () => {
     expect(markerInstances).toHaveLength(0);
     expect(fitBounds).not.toHaveBeenCalled();
   });
+
+  it("does not refit when the same POIs are passed with a new array reference", () => {
+    const { rerender } = render(<PoiMarkersLayer pois={[paris]} />);
+
+    expect(fitBounds).toHaveBeenCalledTimes(1);
+
+    rerender(<PoiMarkersLayer pois={[{ ...paris }]} />);
+
+    expect(fitBounds).toHaveBeenCalledTimes(1);
+    expect(markerInstances).toHaveLength(1);
+    expect(markerInstances[0].remove).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/features/map/components/poi-markers-layer.tsx
+++ b/apps/web/src/features/map/components/poi-markers-layer.tsx
@@ -20,7 +20,10 @@ export function PoiMarkersLayer({ pois }: PoiMarkersLayerProps) {
   const { map } = useMap();
   const poisRef = useRef(pois);
   const poisKey = getPoisKey(pois);
-  poisRef.current = pois;
+
+  useEffect(() => {
+    poisRef.current = pois;
+  }, [pois]);
 
   useEffect(() => {
     if (!map) return;

--- a/apps/web/src/features/map/components/poi-markers-layer.tsx
+++ b/apps/web/src/features/map/components/poi-markers-layer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import mapboxgl from "mapbox-gl";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 import { useMap } from "../context";
 import { getMapPoiBounds } from "../utils/map-bounds";
@@ -12,13 +12,21 @@ type PoiMarkersLayerProps = {
   pois: MapPoi[];
 };
 
+function getPoisKey(pois: MapPoi[]): string {
+  return pois.map((poi) => `${poi.id}:${poi.lat}:${poi.lng}`).join("|");
+}
+
 export function PoiMarkersLayer({ pois }: PoiMarkersLayerProps) {
   const { map } = useMap();
+  const poisRef = useRef(pois);
+  const poisKey = getPoisKey(pois);
+  poisRef.current = pois;
 
   useEffect(() => {
     if (!map) return;
 
-    const markers = pois.map((poi) => {
+    const currentPois = poisRef.current;
+    const markers = currentPois.map((poi) => {
       const marker = new mapboxgl.Marker().setLngLat([poi.lng, poi.lat]);
 
       if (poi.label) {
@@ -28,7 +36,7 @@ export function PoiMarkersLayer({ pois }: PoiMarkersLayerProps) {
       return marker.addTo(map);
     });
 
-    const bounds = getMapPoiBounds(pois);
+    const bounds = getMapPoiBounds(currentPois);
     if (bounds) {
       map.fitBounds(bounds, { padding: 80, maxZoom: 15, duration: 800 });
     }
@@ -36,7 +44,7 @@ export function PoiMarkersLayer({ pois }: PoiMarkersLayerProps) {
     return () => {
       markers.forEach((marker) => marker.remove());
     };
-  }, [map, pois]);
+  }, [map, poisKey]);
 
   return null;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Description

Shows Explore Google Places results on the existing Mapbox map via `PoiMarkersLayer`, using the NIR-70 coordinate helpers. Markers are cleared on a short query, search error, or places without valid coordinates.

## 🎯 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] ✅ Test update

## 🔗 Related Issues

Closes #149 (NIR-72). Related to #144 (epic), #147 (coords), #148 (marker layer).

## 🚀 Changes Made

- Derive `MapPoi[]` from search results in `ExploreResultsView` (`getCoordinatesFromGooglePlace`)
- Mount `PoiMarkersLayer` when Explore is active and the query is long enough
- Clear markers on error (even if `keepPreviousData` still has places) and unmount on idle
- `PoiMarkersLayer` syncs on a stable id/lat/lng key so a new array ref does not `fitBounds` and steal the user's pan
- CI lint: update the POI ref in an effect (not during render) and memoize map POIs on `data.places`

## 🧪 Testing

- [ ] Tested locally with `pnpm dev`
- [x] Lint passes (`pnpm -C apps/web lint`) — 0 errors
- [x] Typecheck passes (`pnpm -C apps/web exec tsc --noEmit`)
- [x] Unit tests pass — 18/18 in Explore results view + map
- [ ] Database migrations applied if needed

## 📸 Screenshots/Videos

N/A

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated if needed
- [x] No console errors or warnings
- [x] Removed any debug code

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffb1c-fe21-7132-bd50-80fb5cbf3b2b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffb1c-fe21-7132-bd50-80fb5cbf3b2b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

