### PR TITLE
feat(lists): show list POIs as map markers (#150)

### DIFF
--- a/apps/web/src/features/lists/hooks/use-list-map-pois.test.tsx
+++ b/apps/web/src/features/lists/hooks/use-list-map-pois.test.tsx
@@ -1,0 +1,169 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useListMapPois } from "./use-list-map-pois";
+import { useListPoisInfinite } from "./use-list-pois-infinite";
+
+import type { SavedPoiListItem } from "@/features/pois";
+
+vi.mock("./use-list-pois-infinite", () => ({
+  useListPoisInfinite: vi.fn(),
+}));
+
+const customSavedPoi: SavedPoiListItem = {
+  id: "sp-1",
+  listId: "list-1",
+  poiId: "poi-1",
+  googlePlaceId: null,
+  createdAt: "2024-01-01T00:00:00.000Z",
+  poi: {
+    id: "poi-1",
+    name: "Fraktion",
+    address: "16 rue de la Grange Batelière, Paris",
+    category: "landmark",
+    latitude: 48.87324153744834,
+    longitude: 2.3412600502008014,
+    photoUrls: [],
+  },
+  googlePlaceCache: undefined,
+};
+
+const googleSavedPoi: SavedPoiListItem = {
+  id: "sp-2",
+  listId: "list-1",
+  poiId: null,
+  googlePlaceId: "ChIJxYJUC2lv5kcRlhdpWba_aGU",
+  createdAt: "2024-01-02T00:00:00.000Z",
+  poi: undefined,
+  googlePlaceCache: {
+    placeId: "ChIJxYJUC2lv5kcRlhdpWba_aGU",
+    name: "Le Tout-Paris",
+    address: "8 Quai du Louvre, Paris",
+    categoryDisplayName: "French Restaurant",
+    latitude: 48.8587493,
+    longitude: 2.3422529,
+    photoReferences: [],
+  },
+};
+
+const noGeoSavedPoi: SavedPoiListItem = {
+  id: "sp-3",
+  poi: {
+    id: "poi-3",
+    name: "No geo",
+  },
+};
+
+const zeroZeroSavedPoi: SavedPoiListItem = {
+  id: "sp-4",
+  googlePlaceCache: {
+    placeId: "ChIJzero",
+    name: "Unknown",
+    latitude: 0,
+    longitude: 0,
+  },
+};
+
+function mockInfinite(overrides: Partial<ReturnType<typeof useListPoisInfinite>> = {}) {
+  vi.mocked(useListPoisInfinite).mockReturnValue({
+    data: undefined,
+    isError: false,
+    ...overrides,
+  } as ReturnType<typeof useListPoisInfinite>);
+}
+
+describe("useListMapPois", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("flattens infinite pages into MapPoi ids", () => {
+    mockInfinite({
+      data: {
+        pages: [
+          {
+            savedPois: [customSavedPoi],
+            pagination: { page: 1, limit: 20, total: 2, totalPages: 2 },
+          },
+          {
+            savedPois: [googleSavedPoi],
+            pagination: { page: 2, limit: 20, total: 2, totalPages: 2 },
+          },
+        ],
+        pageParams: [1, 2],
+      },
+    });
+
+    const { result } = renderHook(() => useListMapPois("list-1"));
+
+    expect(result.current.map((poi) => poi.id)).toEqual(["sp-1", "sp-2"]);
+  });
+
+  it("maps a mix of custom POIs and Google cache", () => {
+    mockInfinite({
+      data: {
+        pages: [
+          {
+            savedPois: [customSavedPoi, googleSavedPoi],
+            pagination: { page: 1, limit: 20, total: 2, totalPages: 1 },
+          },
+        ],
+        pageParams: [1],
+      },
+    });
+
+    const { result } = renderHook(() => useListMapPois("list-1"));
+
+    expect(result.current).toEqual([
+      {
+        id: "sp-1",
+        lat: 48.87324153744834,
+        lng: 2.3412600502008014,
+        label: "Fraktion",
+      },
+      {
+        id: "sp-2",
+        lat: 48.8587493,
+        lng: 2.3422529,
+        label: "Le Tout-Paris",
+      },
+    ]);
+  });
+
+  it("ignores saved POIs without geo or with the (0, 0) sentinel", () => {
+    mockInfinite({
+      data: {
+        pages: [
+          {
+            savedPois: [customSavedPoi, noGeoSavedPoi, zeroZeroSavedPoi],
+            pagination: { page: 1, limit: 20, total: 3, totalPages: 1 },
+          },
+        ],
+        pageParams: [1],
+      },
+    });
+
+    const { result } = renderHook(() => useListMapPois("list-1"));
+
+    expect(result.current.map((poi) => poi.id)).toEqual(["sp-1"]);
+  });
+
+  it("returns an empty list when the query errors", () => {
+    mockInfinite({
+      isError: true,
+      data: {
+        pages: [
+          {
+            savedPois: [customSavedPoi],
+            pagination: { page: 1, limit: 20, total: 1, totalPages: 1 },
+          },
+        ],
+        pageParams: [1],
+      },
+    });
+
+    const { result } = renderHook(() => useListMapPois("list-1"));
+
+    expect(result.current).toEqual([]);
+  });
+});

--- a/apps/web/src/features/lists/hooks/use-list-map-pois.ts
+++ b/apps/web/src/features/lists/hooks/use-list-map-pois.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { useListPoisInfinite } from "./use-list-pois-infinite";
+
+import { getCoordinatesFromSavedPoi, type MapPoi } from "@/features/pois";
+
+export function useListMapPois(listId: string | undefined): MapPoi[] {
+  const { data, isError } = useListPoisInfinite(listId);
+
+  return useMemo(() => {
+    if (isError) return [];
+
+    return (data?.pages ?? [])
+      .flatMap((page) => page.savedPois)
+      .map(getCoordinatesFromSavedPoi)
+      .filter((poi): poi is MapPoi => poi !== null);
+  }, [isError, data?.pages]);
+}

--- a/apps/web/src/features/lists/views/lists-detail-view.test.tsx
+++ b/apps/web/src/features/lists/views/lists-detail-view.test.tsx
@@ -8,6 +8,7 @@ import { useList } from "../hooks/use-list";
 
 import { ListsDetailView } from "./lists-detail-view";
 
+import type { MapPoi } from "@/features/pois";
 import type { ListWithRole } from "@/lib/api";
 import { getErrorCode } from "@/lib/api/errors";
 
@@ -25,6 +26,18 @@ vi.mock("@/lib/api/errors", () => ({
 
 vi.mock("../hooks/use-delete-list", () => ({
   useDeleteList: vi.fn(),
+}));
+
+const useListMapPois = vi.fn((): MapPoi[] => []);
+
+vi.mock("../hooks/use-list-map-pois", () => ({
+  useListMapPois: () => useListMapPois(),
+}));
+
+vi.mock("@/features/map", () => ({
+  PoiMarkersLayer: ({ pois }: { pois: { id: string }[] }) => (
+    <div data-testid="poi-markers-layer" data-ids={pois.map((poi) => poi.id).join(",")} />
+  ),
 }));
 
 vi.mock("../components/list-pois-section", () => ({
@@ -77,6 +90,7 @@ describe("ListsDetailView", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    useListMapPois.mockReturnValue([]);
     vi.mocked(getErrorCode).mockReturnValue(null);
     mutateAsync.mockResolvedValue({ message: "List deleted successfully" });
     vi.mocked(useDeleteList).mockReturnValue({
@@ -208,5 +222,26 @@ describe("ListsDetailView", () => {
     expect(mutateAsync).toHaveBeenCalledWith("list-1");
     expect(toast.success).toHaveBeenCalledWith("deleteList.success");
     expect(onDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes geolocated list POIs to the markers layer", () => {
+    mockListQuery();
+    useListMapPois.mockReturnValue([
+      { id: "sp-1", lat: 48.8732, lng: 2.3413, label: "Fraktion" },
+      { id: "sp-2", lat: 48.8587, lng: 2.3423, label: "Le Tout-Paris" },
+    ]);
+
+    render(<ListsDetailView listId="list-1" onBack={onBack} onEdit={onEdit} onDelete={onDelete} />);
+
+    expect(screen.getByTestId("poi-markers-layer")).toHaveAttribute("data-ids", "sp-1,sp-2");
+  });
+
+  it("renders an empty markers layer when the list has no geo POIs", () => {
+    mockListQuery();
+    useListMapPois.mockReturnValue([]);
+
+    render(<ListsDetailView listId="list-1" onBack={onBack} onEdit={onEdit} onDelete={onDelete} />);
+
+    expect(screen.getByTestId("poi-markers-layer")).toHaveAttribute("data-ids", "");
   });
 });

--- a/apps/web/src/features/lists/views/lists-detail-view.tsx
+++ b/apps/web/src/features/lists/views/lists-detail-view.tsx
@@ -11,8 +11,10 @@ import { ListsListQueryBoundary } from "../components/lists-list-query-boundary"
 import { ListsSectionLayout } from "../components/lists-section-layout";
 import { canDeleteList, canEditList } from "../constants/lists.constants";
 import { useList } from "../hooks/use-list";
+import { useListMapPois } from "../hooks/use-list-map-pois";
 
 import { Button } from "@/components/ui";
+import { PoiMarkersLayer } from "@/features/map";
 
 type ListsDetailViewProps = {
   listId: string;
@@ -24,6 +26,7 @@ type ListsDetailViewProps = {
 export function ListsDetailView({ listId, onBack, onEdit, onDelete }: ListsDetailViewProps) {
   const tLists = useTranslations("lists");
   const { data } = useList(listId);
+  const mapPois = useListMapPois(listId);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const list = data?.list;
 
@@ -33,6 +36,7 @@ export function ListsDetailView({ listId, onBack, onEdit, onDelete }: ListsDetai
       description={list?.description ?? undefined}
       onBack={onBack}
     >
+      <PoiMarkersLayer pois={mapPois} />
       <ListsListQueryBoundary listId={listId}>
         {(loadedList) => (
           <div className="grid gap-6">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Description

Shows a list’s saved places on the existing Mapbox map when the list detail is open. Uses the shared coordinate helpers and `PoiMarkersLayer`. Explore markers disappear automatically because the shell only mounts one view.

## 🎯 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] ✅ Test update

## 🔗 Related Issues

Closes #150 (NIR-73). Related to #144 (epic), #147 (coords), #148 (layer), #149 (Explore markers).

## 🚀 Changes Made

- Add `useListMapPois` to flatten infinite `savedPois` pages into `MapPoi[]` (Google cache first, custom POI fallback, skip missing / `(0, 0)`)
- Mount `PoiMarkersLayer` on `ListsDetailView` (unmounts when leaving detail)
- Reuse the existing `useListPoisInfinite` query cache (no extra fetch)
- Tests: multi-page flatten, custom + Google mix, no-geo / error → empty, layer receives ids

## 🧪 Testing

- [ ] Tested locally with `pnpm dev`
- [x] Typecheck passes (`pnpm -C apps/web exec tsc --noEmit`)
- [x] Lint passes on changed files
- [x] Unit tests pass — 16/16 in `use-list-map-pois` + `lists-detail-view`
- [ ] Database migrations applied if needed

## 📸 Screenshots/Videos

N/A

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated if needed
- [x] No console errors or warnings
- [x] Removed any debug code

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffb1c-fe21-7132-bd50-80fb5cbf3b2b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffb1c-fe21-7132-bd50-80fb5cbf3b2b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

