### PR TITLE
feat(map): focus selected POI and sync list selection

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -204,6 +204,20 @@ html {
   outline: none;
 }
 
+.nirby-poi-marker--selected {
+  transform: scale(1.25);
+  z-index: 1;
+  box-shadow:
+    0 0 0 3px var(--primary),
+    0 0 0 5.5px var(--background),
+    0 6px 16px oklch(0 0 0 / 30%);
+}
+
+.nirby-poi-marker--selected:hover,
+.nirby-poi-marker--selected:focus-visible {
+  transform: scale(1.25);
+}
+
 .mapboxgl-popup-content {
   padding: 0.375rem 0.75rem;
   border-radius: var(--radius-md);

--- a/apps/web/src/features/app-shell/context/shell-context.test.tsx
+++ b/apps/web/src/features/app-shell/context/shell-context.test.tsx
@@ -2,10 +2,11 @@ import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const replace = vi.fn();
+const push = vi.fn();
 let searchParams = new URLSearchParams();
 
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push: vi.fn(), replace, prefetch: vi.fn(), back: vi.fn() }),
+  useRouter: () => ({ push, replace, prefetch: vi.fn(), back: vi.fn() }),
   usePathname: () => "/",
   useSearchParams: () => searchParams,
 }));
@@ -93,5 +94,97 @@ describe("ShellProvider search", () => {
 
     expect(result.current.searchDraft).toBe("café");
     expect(replace).toHaveBeenCalledWith("/?q=caf%C3%A9", { scroll: false });
+  });
+});
+
+describe("ShellProvider POI selection", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    replace.mockClear();
+    push.mockClear();
+    replace.mockImplementation((href: string) => {
+      searchParams = new URLSearchParams(href.split("?")[1] ?? "");
+    });
+    push.mockImplementation((href: string) => {
+      searchParams = new URLSearchParams(href.split("?")[1] ?? "");
+    });
+    searchParams = new URLSearchParams("view=lists");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("selectPoi stores the id and enters map mode", () => {
+    const { result } = renderShell();
+
+    act(() => {
+      result.current.selectPoi("poi-1");
+    });
+
+    expect(result.current.selectedPoiId).toBe("poi-1");
+    expect(result.current.mapMode).toBe(true);
+  });
+
+  it("clearSelection resets the id and exits map mode", () => {
+    const { result } = renderShell();
+
+    act(() => {
+      result.current.selectPoi("poi-1");
+    });
+    act(() => {
+      result.current.clearSelection();
+    });
+
+    expect(result.current.selectedPoiId).toBeNull();
+    expect(result.current.mapMode).toBe(false);
+  });
+
+  it("clears selection when exiting map mode from the active tab", () => {
+    searchParams = new URLSearchParams("view=lists&mapMode=1");
+    const { result, rerender } = renderShell();
+    rerender();
+
+    act(() => {
+      result.current.selectPoi("poi-1");
+    });
+
+    act(() => {
+      result.current.setViewAndExitMapMode("lists");
+    });
+
+    expect(result.current.selectedPoiId).toBeNull();
+    expect(result.current.mapMode).toBe(false);
+  });
+
+  it("clears selection when the search query changes", () => {
+    const { result, rerender } = renderShell();
+
+    act(() => {
+      result.current.selectPoi("poi-1");
+    });
+
+    act(() => {
+      result.current.setSearchDraft("caf");
+    });
+    act(() => {
+      vi.advanceTimersByTime(EXPLORE_SEARCH_DEBOUNCE_MS);
+    });
+    rerender();
+
+    expect(result.current.selectedPoiId).toBeNull();
+  });
+
+  it("clears selection when switching shell views", () => {
+    const { result } = renderShell();
+
+    act(() => {
+      result.current.selectPoi("poi-1");
+    });
+    act(() => {
+      result.current.setView("explore");
+    });
+
+    expect(result.current.selectedPoiId).toBeNull();
   });
 });

--- a/apps/web/src/features/app-shell/context/shell-context.tsx
+++ b/apps/web/src/features/app-shell/context/shell-context.tsx
@@ -1,6 +1,15 @@
 "use client";
 
-import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 
 import { DEFAULT_SHELL_VIEW } from "../constants/shell.constants";
 import { useShellMapModeUrl } from "../hooks/use-shell-map-mode-url";
@@ -14,6 +23,9 @@ type ShellContextValue = ShellSearch & {
   setViewAndExitMapMode: (view: ShellView) => void;
   mapMode: boolean;
   setMapMode: (value: boolean) => void;
+  selectedPoiId: string | null;
+  selectPoi: (id: string) => void;
+  clearSelection: () => void;
 };
 
 const ShellContext = createContext<ShellContextValue | null>(null);
@@ -21,6 +33,7 @@ const ShellContext = createContext<ShellContextValue | null>(null);
 export function ShellProvider({ children }: { children: ReactNode }) {
   const [view, setViewState] = useState<ShellView>(DEFAULT_SHELL_VIEW);
   const [mapMode, setMapModeState] = useState(false);
+  const [selectedPoiId, setSelectedPoiId] = useState<string | null>(null);
 
   const { setView } = useShellViewUrl(view, setViewState);
   const { setMapMode } = useShellMapModeUrl(mapMode, setMapModeState);
@@ -28,24 +41,58 @@ export function ShellProvider({ children }: { children: ReactNode }) {
   // adopt those params, so switching to Explore needs no extra wiring here.
   const { query, searchDraft, setSearchDraft, setQuery } = useShellSearch();
 
+  const prevQueryRef = useRef(query);
+
+  useEffect(() => {
+    if (query !== prevQueryRef.current) {
+      prevQueryRef.current = query;
+      setSelectedPoiId(null);
+    }
+  }, [query]);
+
+  const clearSelection = useCallback(() => {
+    setSelectedPoiId(null);
+    setMapMode(false);
+  }, [setMapMode]);
+
+  const selectPoi = useCallback(
+    (id: string) => {
+      setSelectedPoiId(id);
+      setMapMode(true);
+    },
+    [setMapMode]
+  );
+
+  const setViewWithClear = useCallback(
+    (next: ShellView) => {
+      setSelectedPoiId(null);
+      setView(next);
+    },
+    [setView]
+  );
+
   const setViewAndExitMapMode = useCallback(
     (next: ShellView) => {
       if (mapMode && next === view) {
-        setMapMode(false);
+        clearSelection();
         return;
       }
+      setSelectedPoiId(null);
       setView(next);
     },
-    [mapMode, view, setMapMode, setView]
+    [mapMode, view, clearSelection, setView]
   );
 
   const value = useMemo(
     () => ({
       view,
-      setView,
+      setView: setViewWithClear,
       setViewAndExitMapMode,
       mapMode,
       setMapMode,
+      selectedPoiId,
+      selectPoi,
+      clearSelection,
       query,
       searchDraft,
       setSearchDraft,
@@ -53,10 +100,13 @@ export function ShellProvider({ children }: { children: ReactNode }) {
     }),
     [
       view,
-      setView,
+      setViewWithClear,
       setViewAndExitMapMode,
       mapMode,
       setMapMode,
+      selectedPoiId,
+      selectPoi,
+      clearSelection,
       query,
       searchDraft,
       setSearchDraft,

--- a/apps/web/src/features/explore/components/explore-result-row.tsx
+++ b/apps/web/src/features/explore/components/explore-result-row.tsx
@@ -13,9 +13,17 @@ type ExploreResultRowProps = {
   place: GooglePlace;
   savedListCount: number;
   onAddToList: (target: AddToListTarget) => void;
+  isSelected?: boolean;
+  onSelect?: (id: string) => void;
 };
 
-export function ExploreResultRow({ place, savedListCount, onAddToList }: ExploreResultRowProps) {
+export function ExploreResultRow({
+  place,
+  savedListCount,
+  onAddToList,
+  isSelected,
+  onSelect,
+}: ExploreResultRowProps) {
   const tExplore = useTranslations("explore");
   const display = getPoiDisplayDataFromGooglePlace(place);
 
@@ -28,6 +36,8 @@ export function ExploreResultRow({ place, savedListCount, onAddToList }: Explore
   return (
     <PoiCard
       poi={display}
+      isSelected={isSelected}
+      onSelect={onSelect ? () => onSelect(googlePlaceId) : undefined}
       badge={
         savedListCount > 0 ? (
           <Badge variant="secondary" className="gap-1 text-xs font-normal">

--- a/apps/web/src/features/explore/views/explore-results-view.test.tsx
+++ b/apps/web/src/features/explore/views/explore-results-view.test.tsx
@@ -6,7 +6,14 @@ import { useSearchGooglePlaces } from "../hooks/use-search-google-places";
 
 import { ExploreResultsView } from "./explore-results-view";
 
-const mockUseShell = vi.fn(() => ({ query: "café" }));
+const defaultShellState = {
+  query: "café",
+  selectedPoiId: null,
+  selectPoi: vi.fn(),
+  clearSelection: vi.fn(),
+};
+
+const mockUseShell = vi.fn(() => defaultShellState);
 
 vi.mock("../hooks/use-search-google-places", () => ({
   useSearchGooglePlaces: vi.fn(),
@@ -48,8 +55,24 @@ vi.mock("../components/add-to-list-picker", () => ({
 }));
 
 vi.mock("@/features/map", () => ({
-  PoiMarkersLayer: ({ pois }: { pois: { id: string }[] }) => (
-    <div data-testid="poi-markers-layer" data-ids={pois.map((poi) => poi.id).join(",")} />
+  PoiMarkersLayer: ({
+    pois,
+    selectedPoiId,
+    onSelectPoi,
+    onDeselect,
+  }: {
+    pois: { id: string }[];
+    selectedPoiId?: string | null;
+    onSelectPoi?: (id: string) => void;
+    onDeselect?: () => void;
+  }) => (
+    <div
+      data-testid="poi-markers-layer"
+      data-ids={pois.map((poi) => poi.id).join(",")}
+      data-selected={selectedPoiId ?? ""}
+      data-has-select={onSelectPoi ? "1" : "0"}
+      data-has-deselect={onDeselect ? "1" : "0"}
+    />
   ),
 }));
 
@@ -70,11 +93,11 @@ function mockSearch(overrides: Partial<Record<keyof SearchResult, unknown>>) {
 describe("ExploreResultsView", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUseShell.mockReturnValue({ query: "café" });
+    mockUseShell.mockReturnValue({ ...defaultShellState, query: "café" });
   });
 
   it("shows the idle state when the query is too short", () => {
-    mockUseShell.mockReturnValue({ query: "c" });
+    mockUseShell.mockReturnValue({ ...defaultShellState, query: "c" });
     mockSearch({});
 
     render(<ExploreResultsView />);
@@ -181,7 +204,7 @@ describe("ExploreResultsView", () => {
   });
 
   it("does not mount the markers layer on the idle state", () => {
-    mockUseShell.mockReturnValue({ query: "c" });
+    mockUseShell.mockReturnValue({ ...defaultShellState, query: "c" });
     mockSearch({
       data: {
         places: [

--- a/apps/web/src/features/explore/views/explore-results-view.tsx
+++ b/apps/web/src/features/explore/views/explore-results-view.tsx
@@ -18,7 +18,7 @@ import { useErrorMessage } from "@/hooks/use-error-message";
 export function ExploreResultsView() {
   const tExplore = useTranslations("explore");
   const getErrorMessage = useErrorMessage();
-  const { query } = useShell();
+  const { query, selectedPoiId, selectPoi, clearSelection } = useShell();
   const { data, isLoading, isError, error, refetch, isFetching } = useSearchGooglePlaces(query);
   const places = data?.places ?? [];
   const placeIds = places
@@ -75,6 +75,8 @@ export function ExploreResultsView() {
                 place={place}
                 savedListCount={place.placeId ? (membership[place.placeId]?.length ?? 0) : 0}
                 onAddToList={openPicker}
+                isSelected={place.placeId === selectedPoiId}
+                onSelect={selectPoi}
               />
             </li>
           ))}
@@ -91,7 +93,12 @@ export function ExploreResultsView() {
         />
       ) : null}
 
-      <PoiMarkersLayer pois={mapPois} />
+      <PoiMarkersLayer
+        pois={mapPois}
+        selectedPoiId={selectedPoiId}
+        onSelectPoi={selectPoi}
+        onDeselect={clearSelection}
+      />
     </div>
   );
 }

--- a/apps/web/src/features/lists/components/list-poi-row.tsx
+++ b/apps/web/src/features/lists/components/list-poi-row.tsx
@@ -7,15 +7,22 @@ import { useState } from "react";
 import { RemovePoiDialog } from "./remove-poi-dialog";
 
 import { Button } from "@/components/ui";
-import { PoiCard, getPoiDisplayDataFromSavedPoi, type SavedPoiListItem } from "@/features/pois";
+import {
+  PoiCard,
+  getPoiDisplayDataFromSavedPoi,
+  getSavedPoiMapId,
+  type SavedPoiListItem,
+} from "@/features/pois";
 
 type ListPoiRowProps = {
   savedPoi: SavedPoiListItem;
   listId: string;
   canRemove: boolean;
+  isSelected?: boolean;
+  onSelect?: (id: string) => void;
 };
 
-export function ListPoiRow({ savedPoi, listId, canRemove }: ListPoiRowProps) {
+export function ListPoiRow({ savedPoi, listId, canRemove, isSelected, onSelect }: ListPoiRowProps) {
   const tLists = useTranslations("lists");
   const [removeDialogOpen, setRemoveDialogOpen] = useState(false);
   const display = getPoiDisplayDataFromSavedPoi(savedPoi);
@@ -25,11 +32,14 @@ export function ListPoiRow({ savedPoi, listId, canRemove }: ListPoiRowProps) {
   }
 
   const showRemoveAction = canRemove && Boolean(savedPoi.id);
+  const mapId = getSavedPoiMapId(savedPoi);
 
   return (
     <>
       <PoiCard
         poi={display}
+        isSelected={isSelected}
+        onSelect={mapId && onSelect ? () => onSelect(mapId) : undefined}
         actions={
           showRemoveAction ? (
             <Button

--- a/apps/web/src/features/lists/components/list-pois-section.tsx
+++ b/apps/web/src/features/lists/components/list-pois-section.tsx
@@ -12,15 +12,22 @@ import { ListPoiRow } from "./list-poi-row";
 import { ListPoisSkeleton } from "./list-pois-skeleton";
 
 import { Button } from "@/components/ui";
-import type { SavedPoiListItem } from "@/features/pois";
+import { getSavedPoiMapId, type SavedPoiListItem } from "@/features/pois";
 import { useErrorMessage } from "@/hooks/use-error-message";
 
 type ListPoisSectionProps = {
   listId: string;
   role?: ListRole;
+  selectedPoiId?: string | null;
+  onSelectPoi?: (id: string) => void;
 };
 
-export function ListPoisSection({ listId, role }: ListPoisSectionProps) {
+export function ListPoisSection({
+  listId,
+  role,
+  selectedPoiId,
+  onSelectPoi,
+}: ListPoisSectionProps) {
   const canRemove = canEditList(role);
   const tLists = useTranslations("lists");
   const getErrorMessage = useErrorMessage();
@@ -98,11 +105,21 @@ export function ListPoisSection({ listId, role }: ListPoisSectionProps) {
       {!isInitialLoading && !isError && items.length > 0 && (
         <>
           <ul className="flex w-full min-w-0 flex-col gap-3">
-            {items.map((savedPoi: SavedPoiListItem, index) => (
-              <li key={savedPoi.id ?? `saved-poi-${index}`}>
-                <ListPoiRow savedPoi={savedPoi} listId={listId} canRemove={canRemove} />
-              </li>
-            ))}
+            {items.map((savedPoi: SavedPoiListItem, index) => {
+              const mapId = getSavedPoiMapId(savedPoi);
+
+              return (
+                <li key={savedPoi.id ?? `saved-poi-${index}`}>
+                  <ListPoiRow
+                    savedPoi={savedPoi}
+                    listId={listId}
+                    canRemove={canRemove}
+                    isSelected={mapId !== null && selectedPoiId === mapId}
+                    onSelect={onSelectPoi}
+                  />
+                </li>
+              );
+            })}
           </ul>
 
           <div ref={sentinelRef} className="h-1 w-full" aria-hidden />

--- a/apps/web/src/features/lists/views/lists-detail-view.test.tsx
+++ b/apps/web/src/features/lists/views/lists-detail-view.test.tsx
@@ -34,9 +34,33 @@ vi.mock("../hooks/use-list-map-pois", () => ({
   useListMapPois: () => useListMapPois(),
 }));
 
+vi.mock("@/features/app-shell", () => ({
+  useShell: () => ({
+    selectedPoiId: null,
+    selectPoi: vi.fn(),
+    clearSelection: vi.fn(),
+  }),
+}));
+
 vi.mock("@/features/map", () => ({
-  PoiMarkersLayer: ({ pois }: { pois: { id: string }[] }) => (
-    <div data-testid="poi-markers-layer" data-ids={pois.map((poi) => poi.id).join(",")} />
+  PoiMarkersLayer: ({
+    pois,
+    selectedPoiId,
+    onSelectPoi,
+    onDeselect,
+  }: {
+    pois: { id: string }[];
+    selectedPoiId?: string | null;
+    onSelectPoi?: (id: string) => void;
+    onDeselect?: () => void;
+  }) => (
+    <div
+      data-testid="poi-markers-layer"
+      data-ids={pois.map((poi) => poi.id).join(",")}
+      data-selected={selectedPoiId ?? ""}
+      data-has-select={onSelectPoi ? "1" : "0"}
+      data-has-deselect={onDeselect ? "1" : "0"}
+    />
   ),
 }));
 

--- a/apps/web/src/features/lists/views/lists-detail-view.tsx
+++ b/apps/web/src/features/lists/views/lists-detail-view.tsx
@@ -14,6 +14,7 @@ import { useList } from "../hooks/use-list";
 import { useListMapPois } from "../hooks/use-list-map-pois";
 
 import { Button } from "@/components/ui";
+import { useShell } from "@/features/app-shell";
 import { PoiMarkersLayer } from "@/features/map";
 
 type ListsDetailViewProps = {
@@ -25,6 +26,7 @@ type ListsDetailViewProps = {
 
 export function ListsDetailView({ listId, onBack, onEdit, onDelete }: ListsDetailViewProps) {
   const tLists = useTranslations("lists");
+  const { selectedPoiId, selectPoi, clearSelection } = useShell();
   const { data } = useList(listId);
   const mapPois = useListMapPois(listId);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -36,7 +38,12 @@ export function ListsDetailView({ listId, onBack, onEdit, onDelete }: ListsDetai
       description={list?.description ?? undefined}
       onBack={onBack}
     >
-      <PoiMarkersLayer pois={mapPois} />
+      <PoiMarkersLayer
+        pois={mapPois}
+        selectedPoiId={selectedPoiId}
+        onSelectPoi={selectPoi}
+        onDeselect={clearSelection}
+      />
       <ListsListQueryBoundary listId={listId}>
         {(loadedList) => (
           <div className="grid gap-6">
@@ -70,7 +77,12 @@ export function ListsDetailView({ listId, onBack, onEdit, onDelete }: ListsDetai
                 onDeleted={onDelete}
               />
             )}
-            <ListPoisSection listId={listId} role={loadedList.role} />
+            <ListPoisSection
+              listId={listId}
+              role={loadedList.role}
+              selectedPoiId={selectedPoiId}
+              onSelectPoi={selectPoi}
+            />
           </div>
         )}
       </ListsListQueryBoundary>

--- a/apps/web/src/features/map/components/poi-markers-layer.test.tsx
+++ b/apps/web/src/features/map/components/poi-markers-layer.test.tsx
@@ -1,18 +1,58 @@
 import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { PoiMarkersLayer } from "./poi-markers-layer";
 
 import type { MapPoi } from "@/features/pois";
 
 const fitBounds = vi.fn();
-const useMapMock = vi.fn((): { map: { fitBounds: typeof fitBounds } | null } => ({
-  map: { fitBounds },
-}));
+const flyTo = vi.fn();
+const getZoom = vi.fn(() => 13);
+const mapClickHandlers: Array<() => void> = [];
+
+const useMapMock = vi.fn(
+  (): {
+    map: {
+      fitBounds: typeof fitBounds;
+      flyTo: typeof flyTo;
+      getZoom: typeof getZoom;
+      getContainer: () => HTMLElement;
+      on: (event: string, handler: () => void) => void;
+      off: (event: string, handler: () => void) => void;
+    } | null;
+  } => ({
+    map: {
+      fitBounds,
+      flyTo,
+      getZoom,
+      getContainer: () => ({ clientWidth: 1024 }) as HTMLElement,
+      on: (event, handler) => {
+        if (event === "click") {
+          mapClickHandlers.push(handler);
+        }
+      },
+      off: (event, handler) => {
+        if (event === "click") {
+          const index = mapClickHandlers.indexOf(handler);
+          if (index >= 0) {
+            mapClickHandlers.splice(index, 1);
+          }
+        }
+      },
+    },
+  })
+);
 
 type MarkerMock = {
+  element: HTMLDivElement;
   setLngLat: ReturnType<typeof vi.fn>;
   addTo: ReturnType<typeof vi.fn>;
   remove: ReturnType<typeof vi.fn>;
   setPopup: ReturnType<typeof vi.fn>;
+  getElement: () => HTMLDivElement;
+  getPopup: ReturnType<typeof vi.fn>;
+  togglePopup: ReturnType<typeof vi.fn>;
 };
 
 const markerInstances: MarkerMock[] = [];
@@ -23,13 +63,23 @@ vi.mock("../context", () => ({
 
 vi.mock("mapbox-gl", () => {
   class Marker {
+    element: HTMLDivElement;
     setLngLat = vi.fn().mockReturnThis();
     addTo = vi.fn().mockReturnThis();
     remove = vi.fn();
     setPopup = vi.fn().mockReturnThis();
+    togglePopup = vi.fn();
+    getPopup = vi.fn(() => ({
+      isOpen: () => false,
+    }));
 
-    constructor() {
+    constructor(options?: { element?: HTMLDivElement }) {
+      this.element = options?.element ?? document.createElement("div");
       markerInstances.push(this);
+    }
+
+    getElement() {
+      return this.element;
     }
   }
 
@@ -40,8 +90,6 @@ vi.mock("mapbox-gl", () => {
   return { default: { Marker, Popup } };
 });
 
-import { PoiMarkersLayer } from "./poi-markers-layer";
-
 const paris: MapPoi = { id: "paris", lat: 48.8566, lng: 2.3522, label: "Paris" };
 const lyon: MapPoi = { id: "lyon", lat: 45.764, lng: 4.8357, label: "Lyon" };
 
@@ -49,7 +97,29 @@ describe("PoiMarkersLayer", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     markerInstances.length = 0;
-    useMapMock.mockReturnValue({ map: { fitBounds } });
+    mapClickHandlers.length = 0;
+    getZoom.mockReturnValue(13);
+    useMapMock.mockReturnValue({
+      map: {
+        fitBounds,
+        flyTo,
+        getZoom,
+        getContainer: () => ({ clientWidth: 1024 }) as HTMLElement,
+        on: (event, handler) => {
+          if (event === "click") {
+            mapClickHandlers.push(handler);
+          }
+        },
+        off: (event, handler) => {
+          if (event === "click") {
+            const index = mapClickHandlers.indexOf(handler);
+            if (index >= 0) {
+              mapClickHandlers.splice(index, 1);
+            }
+          }
+        },
+      },
+    });
   });
 
   it("creates a marker per POI and fits bounds", () => {
@@ -58,14 +128,16 @@ describe("PoiMarkersLayer", () => {
     expect(markerInstances).toHaveLength(2);
     expect(markerInstances[0].setLngLat).toHaveBeenCalledWith([2.3522, 48.8566]);
     expect(markerInstances[1].setLngLat).toHaveBeenCalledWith([4.8357, 45.764]);
-    expect(markerInstances[0].addTo).toHaveBeenCalledWith({ fitBounds });
-    expect(markerInstances[1].addTo).toHaveBeenCalledWith({ fitBounds });
     expect(fitBounds).toHaveBeenCalledWith(
       [
         [2.3522, 45.764],
         [4.8357, 48.8566],
       ],
-      { padding: 80, maxZoom: 15, duration: 800 }
+      {
+        padding: { left: 390, top: 80, right: 80, bottom: 80 },
+        maxZoom: 15,
+        duration: 800,
+      }
     );
   });
 
@@ -103,7 +175,11 @@ describe("PoiMarkersLayer", () => {
         [4.8357, 45.764],
         [4.8357, 45.764],
       ],
-      { padding: 80, maxZoom: 15, duration: 800 }
+      {
+        padding: { left: 390, top: 80, right: 80, bottom: 80 },
+        maxZoom: 15,
+        duration: 800,
+      }
     );
   });
 
@@ -126,5 +202,74 @@ describe("PoiMarkersLayer", () => {
     expect(fitBounds).toHaveBeenCalledTimes(1);
     expect(markerInstances).toHaveLength(1);
     expect(markerInstances[0].remove).not.toHaveBeenCalled();
+  });
+
+  it("flies to the selected POI with a zoom floor", () => {
+    render(<PoiMarkersLayer pois={[paris, lyon]} selectedPoiId="lyon" />);
+
+    expect(flyTo).toHaveBeenCalledWith({
+      center: [4.8357, 45.764],
+      zoom: 15,
+      padding: { left: 390, top: 80, right: 80, bottom: 80 },
+      duration: 800,
+    });
+    expect(fitBounds).not.toHaveBeenCalled();
+  });
+
+  it("does not zoom out when the map is already closer than the floor", () => {
+    getZoom.mockReturnValue(16);
+
+    render(<PoiMarkersLayer pois={[paris]} selectedPoiId="paris" />);
+
+    expect(flyTo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        zoom: 16,
+      })
+    );
+  });
+
+  it("calls onSelectPoi when a marker is clicked", async () => {
+    const user = userEvent.setup();
+    const onSelectPoi = vi.fn();
+
+    render(<PoiMarkersLayer pois={[paris]} onSelectPoi={onSelectPoi} />);
+
+    await user.click(markerInstances[0].element);
+
+    expect(onSelectPoi).toHaveBeenCalledWith("paris");
+  });
+
+  it("does not call onDeselect when a marker is clicked", async () => {
+    const user = userEvent.setup();
+    const onDeselect = vi.fn();
+    const onSelectPoi = vi.fn();
+
+    render(<PoiMarkersLayer pois={[paris]} onSelectPoi={onSelectPoi} onDeselect={onDeselect} />);
+
+    await user.click(markerInstances[0].element);
+
+    expect(onSelectPoi).toHaveBeenCalledWith("paris");
+    expect(onDeselect).not.toHaveBeenCalled();
+  });
+
+  it("calls onDeselect when the map is clicked", () => {
+    const onDeselect = vi.fn();
+
+    render(<PoiMarkersLayer pois={[paris]} onDeselect={onDeselect} />);
+
+    mapClickHandlers[0]();
+
+    expect(onDeselect).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onDeselect when the selected POI disappears from the set", () => {
+    const onDeselect = vi.fn();
+    const { rerender } = render(
+      <PoiMarkersLayer pois={[paris, lyon]} selectedPoiId="lyon" onDeselect={onDeselect} />
+    );
+
+    rerender(<PoiMarkersLayer pois={[paris]} selectedPoiId="lyon" onDeselect={onDeselect} />);
+
+    expect(onDeselect).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/features/map/components/poi-markers-layer.tsx
+++ b/apps/web/src/features/map/components/poi-markers-layer.tsx
@@ -5,52 +5,142 @@ import { useEffect, useRef } from "react";
 
 import { useMap } from "../context";
 import { getMapPoiBounds } from "../utils/map-bounds";
+import { getShellViewportPadding, getSelectedPoiZoom } from "../utils/map-camera";
 import { createPoiMarkerElement } from "../utils/poi-marker-element";
 
 import type { MapPoi } from "@/features/pois";
 
 type PoiMarkersLayerProps = {
   pois: MapPoi[];
+  selectedPoiId?: string | null;
+  onSelectPoi?: (id: string) => void;
+  onDeselect?: () => void;
 };
 
 function getPoisKey(pois: MapPoi[]): string {
   return pois.map((poi) => `${poi.id}:${poi.lat}:${poi.lng}`).join("|");
 }
 
-export function PoiMarkersLayer({ pois }: PoiMarkersLayerProps) {
+export function PoiMarkersLayer({
+  pois,
+  selectedPoiId = null,
+  onSelectPoi,
+  onDeselect,
+}: PoiMarkersLayerProps) {
   const { map } = useMap();
   const poisRef = useRef(pois);
   const poisKey = getPoisKey(pois);
+  const markersRef = useRef<Map<string, mapboxgl.Marker>>(new Map());
+  const onSelectPoiRef = useRef(onSelectPoi);
+  const onDeselectRef = useRef(onDeselect);
+  const selectedPoiIdRef = useRef(selectedPoiId);
 
   useEffect(() => {
     poisRef.current = pois;
   }, [pois]);
 
   useEffect(() => {
+    onSelectPoiRef.current = onSelectPoi;
+  }, [onSelectPoi]);
+
+  useEffect(() => {
+    onDeselectRef.current = onDeselect;
+  }, [onDeselect]);
+
+  useEffect(() => {
+    selectedPoiIdRef.current = selectedPoiId;
+  }, [selectedPoiId]);
+
+  useEffect(() => {
     if (!map) return;
 
     const currentPois = poisRef.current;
-    const markers = currentPois.map((poi) => {
-      const marker = new mapboxgl.Marker({
-        element: createPoiMarkerElement(poi.label),
-      }).setLngLat([poi.lng, poi.lat]);
+    const markers = new Map<string, mapboxgl.Marker>();
+
+    currentPois.forEach((poi) => {
+      const element = createPoiMarkerElement(poi.label);
+      element.addEventListener("click", (event) => {
+        event.stopPropagation();
+        onSelectPoiRef.current?.(poi.id);
+      });
+
+      const marker = new mapboxgl.Marker({ element }).setLngLat([poi.lng, poi.lat]);
 
       if (poi.label) {
         marker.setPopup(new mapboxgl.Popup({ closeButton: false, offset: 18 }).setText(poi.label));
       }
 
-      return marker.addTo(map);
+      marker.addTo(map);
+      markers.set(poi.id, marker);
     });
 
+    markersRef.current = markers;
+
     const bounds = getMapPoiBounds(currentPois);
-    if (bounds) {
-      map.fitBounds(bounds, { padding: 80, maxZoom: 15, duration: 800 });
+    if (bounds && !selectedPoiIdRef.current) {
+      const padding = getShellViewportPadding(map.getContainer());
+      map.fitBounds(bounds, { padding, maxZoom: 15, duration: 800 });
     }
 
     return () => {
       markers.forEach((marker) => marker.remove());
+      markersRef.current = new Map();
     };
   }, [map, poisKey]);
+
+  useEffect(() => {
+    if (!map) return;
+
+    const handleMapClick = () => {
+      onDeselectRef.current?.();
+    };
+
+    map.on("click", handleMapClick);
+
+    return () => {
+      map.off("click", handleMapClick);
+    };
+  }, [map]);
+
+  useEffect(() => {
+    if (!map) return;
+
+    markersRef.current.forEach((marker, id) => {
+      const element = marker.getElement();
+      element.classList.toggle("nirby-poi-marker--selected", id === selectedPoiId);
+
+      const popup = marker.getPopup();
+      if (!popup) return;
+
+      if (id === selectedPoiId) {
+        if (!popup.isOpen()) {
+          marker.togglePopup();
+        }
+      } else if (popup.isOpen()) {
+        marker.togglePopup();
+      }
+    });
+  }, [map, selectedPoiId, poisKey]);
+
+  useEffect(() => {
+    if (!map || !selectedPoiId) return;
+
+    const poi = poisRef.current.find((item) => item.id === selectedPoiId);
+    if (!poi) {
+      onDeselectRef.current?.();
+      return;
+    }
+
+    const padding = getShellViewportPadding(map.getContainer());
+    const zoom = getSelectedPoiZoom(map.getZoom());
+
+    map.flyTo({
+      center: [poi.lng, poi.lat],
+      zoom,
+      padding,
+      duration: 800,
+    });
+  }, [map, selectedPoiId, poisKey]);
 
   return null;
 }

--- a/apps/web/src/features/map/utils/map-camera.test.ts
+++ b/apps/web/src/features/map/utils/map-camera.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { SELECTED_POI_MIN_ZOOM, getSelectedPoiZoom, getShellViewportPadding } from "./map-camera";
+
+describe("getSelectedPoiZoom", () => {
+  it("raises the zoom to the minimum floor when the map is zoomed out", () => {
+    expect(getSelectedPoiZoom(10)).toBe(SELECTED_POI_MIN_ZOOM);
+  });
+
+  it("keeps the current zoom when already closer than the floor", () => {
+    expect(getSelectedPoiZoom(16)).toBe(16);
+  });
+});
+
+describe("getShellViewportPadding", () => {
+  it("reserves space for the desktop sidebar", () => {
+    const container = { clientWidth: 1024 } as HTMLElement;
+
+    expect(getShellViewportPadding(container)).toEqual({
+      left: 390,
+      top: 80,
+      right: 80,
+      bottom: 80,
+    });
+  });
+
+  it("reserves space for the mobile bottom chrome", () => {
+    const container = { clientWidth: 375 } as HTMLElement;
+
+    expect(getShellViewportPadding(container)).toEqual({
+      bottom: 96,
+      top: 80,
+      left: 24,
+      right: 24,
+    });
+  });
+});

--- a/apps/web/src/features/map/utils/map-camera.ts
+++ b/apps/web/src/features/map/utils/map-camera.ts
@@ -1,0 +1,17 @@
+import type { PaddingOptions } from "mapbox-gl";
+
+export const SELECTED_POI_MIN_ZOOM = 15;
+
+export function getSelectedPoiZoom(currentZoom: number): number {
+  return Math.max(currentZoom, SELECTED_POI_MIN_ZOOM);
+}
+
+export function getShellViewportPadding(container: HTMLElement): PaddingOptions {
+  const isDesktop = container.clientWidth >= 768;
+
+  if (isDesktop) {
+    return { left: 390, top: 80, right: 80, bottom: 80 };
+  }
+
+  return { bottom: 96, top: 80, left: 24, right: 24 };
+}

--- a/apps/web/src/features/pois/components/poi-card.test.tsx
+++ b/apps/web/src/features/pois/components/poi-card.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { PoiDisplayData } from "../types/poi-display-types";
+
+import { PoiCard } from "./poi-card";
+
+vi.mock("./poi-photo", () => ({
+  PoiPhoto: ({ alt }: { alt: string }) => <div data-testid="poi-photo">{alt}</div>,
+}));
+
+const poi: PoiDisplayData = {
+  name: "Tour Eiffel",
+  address: "Champ de Mars, Paris",
+  category: null,
+  source: "google",
+  photo: { kind: "url", url: "https://example.com/eiffel.jpg" },
+  openingHours: null,
+};
+
+describe("PoiCard", () => {
+  beforeEach(() => {
+    HTMLElement.prototype.scrollIntoView = vi.fn();
+  });
+
+  it("calls onSelect when the overlay button is clicked", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+
+    render(<PoiCard poi={poi} onSelect={onSelect} />);
+
+    await user.click(screen.getByRole("button", { name: "select" }));
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the select overlay above card content so photo clicks work", () => {
+    const { container } = render(<PoiCard poi={poi} onSelect={vi.fn()} />);
+    const article = container.querySelector("article");
+    const button = screen.getByRole("button", { name: "select" });
+
+    expect(article?.lastElementChild).toBe(button);
+    expect(button).toHaveClass("z-10");
+  });
+
+  it("applies the selected ring style", () => {
+    const { container } = render(<PoiCard poi={poi} isSelected onSelect={vi.fn()} />);
+
+    expect(container.querySelector("article")).toHaveClass("ring-2", "ring-primary");
+  });
+
+  it("scrolls the card into view when it becomes selected", () => {
+    const scrollIntoView = vi.mocked(HTMLElement.prototype.scrollIntoView);
+
+    const { rerender } = render(<PoiCard poi={poi} onSelect={vi.fn()} />);
+
+    rerender(<PoiCard poi={poi} isSelected onSelect={vi.fn()} />);
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest", behavior: "smooth" });
+  });
+});

--- a/apps/web/src/features/pois/components/poi-card.tsx
+++ b/apps/web/src/features/pois/components/poi-card.tsx
@@ -2,28 +2,46 @@
 
 import { ClockIcon, MapPinIcon } from "lucide-react";
 import { useTranslations } from "next-intl";
-import type { ReactNode } from "react";
+import { useEffect, useRef, type ReactNode } from "react";
 
 import type { PoiDisplayData } from "../types/poi-display-types";
 
 import { PoiOpeningHours } from "./poi-opening-hours";
 import { PoiPhoto } from "./poi-photo";
 
+import { cn } from "@/lib/utils";
+
 type PoiCardProps = {
   poi: PoiDisplayData;
   actions?: ReactNode;
   badge?: ReactNode;
+  isSelected?: boolean;
+  onSelect?: () => void;
 };
 
-export function PoiCard({ poi, actions, badge }: PoiCardProps) {
+export function PoiCard({ poi, actions, badge, isSelected, onSelect }: PoiCardProps) {
   const tPoi = useTranslations("poi");
+  const cardRef = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    if (isSelected && cardRef.current) {
+      cardRef.current.scrollIntoView({ block: "nearest", behavior: "smooth" });
+    }
+  }, [isSelected]);
 
   return (
-    <article className="group flex flex-col items-start rounded-md border border-border">
+    <article
+      ref={cardRef}
+      className={cn(
+        "group relative flex flex-col items-start rounded-md border border-border",
+        isSelected && "ring-2 ring-primary",
+        onSelect && "cursor-pointer"
+      )}
+    >
       {poi.photo ? (
         <div className="relative overflow-hidden rounded-t-md h-[150px] w-full">
           <PoiPhoto photo={poi.photo} alt={poi.name} />
-          {badge ? <div className="absolute top-2 right-2">{badge}</div> : null}
+          {badge ? <div className="absolute top-2 right-2 z-20">{badge}</div> : null}
         </div>
       ) : null}
       <div className="px-4 py-2 flex flex-col gap-1 w-full">
@@ -31,7 +49,9 @@ export function PoiCard({ poi, actions, badge }: PoiCardProps) {
           <h3 className="min-w-0 font-display text-base font-semibold tracking-tight">
             {poi.name}
           </h3>
-          {actions ? <div className="shrink-0">{actions}</div> : null}
+          {actions ? (
+            <div className="relative z-20 shrink-0 pointer-events-auto">{actions}</div>
+          ) : null}
         </div>
 
         <p className="flex min-w-0 items-center gap-1.5 text-sm text-muted-foreground">
@@ -46,6 +66,15 @@ export function PoiCard({ poi, actions, badge }: PoiCardProps) {
           </div>
         ) : null}
       </div>
+      {onSelect ? (
+        <button
+          type="button"
+          className="absolute inset-0 z-10 rounded-md"
+          aria-label={tPoi("select", { name: poi.name })}
+          aria-pressed={isSelected}
+          onClick={onSelect}
+        />
+      ) : null}
     </article>
   );
 }

--- a/apps/web/src/features/pois/index.ts
+++ b/apps/web/src/features/pois/index.ts
@@ -11,6 +11,7 @@ export {
 export {
   getCoordinatesFromGooglePlace,
   getCoordinatesFromSavedPoi,
+  getSavedPoiMapId,
 } from "./utils/get-poi-coordinates";
 
 export type {

--- a/apps/web/src/features/pois/utils/get-poi-coordinates.test.ts
+++ b/apps/web/src/features/pois/utils/get-poi-coordinates.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   getCoordinatesFromGooglePlace,
   getCoordinatesFromSavedPoi,
+  getSavedPoiMapId,
 } from "./get-poi-coordinates";
 
 describe("getCoordinatesFromGooglePlace", () => {
@@ -163,5 +164,32 @@ describe("getCoordinatesFromSavedPoi", () => {
       lng: 2.2945,
       label: "Custom fallback",
     });
+  });
+});
+
+describe("getSavedPoiMapId", () => {
+  it("prefers the saved POI id", () => {
+    expect(
+      getSavedPoiMapId({
+        id: "sp-1",
+        googlePlaceCache: { placeId: "ChIJgoogle", name: "Google place" },
+      })
+    ).toBe("sp-1");
+  });
+
+  it("falls back to the Google place id", () => {
+    expect(
+      getSavedPoiMapId({
+        googlePlaceCache: { placeId: "ChIJgoogle", name: "Google place" },
+      })
+    ).toBe("ChIJgoogle");
+  });
+
+  it("falls back to the custom POI id", () => {
+    expect(
+      getSavedPoiMapId({
+        poi: { id: "poi-1", name: "Custom place" },
+      })
+    ).toBe("poi-1");
   });
 });

--- a/apps/web/src/features/pois/utils/get-poi-coordinates.ts
+++ b/apps/web/src/features/pois/utils/get-poi-coordinates.ts
@@ -15,6 +15,13 @@ function toMapPoi(id: string, lat: number, lng: number, name?: string | null): M
   return label ? { id, lat, lng, label } : { id, lat, lng };
 }
 
+export function getSavedPoiMapId(savedPoi: SavedPoiListItem): string | null {
+  if (savedPoi.id) return savedPoi.id;
+  if (savedPoi.googlePlaceCache?.placeId) return savedPoi.googlePlaceCache.placeId;
+  if (savedPoi.poi?.id) return savedPoi.poi.id;
+  return null;
+}
+
 export function getCoordinatesFromGooglePlace(place: GooglePlace): MapPoi | null {
   const coords = parseCoordinates(place.latitude, place.longitude);
   if (!coords) return null;
@@ -30,18 +37,20 @@ function getCoordinatesFromPoi(poi: Poi, id: string): MapPoi | null {
 }
 
 export function getCoordinatesFromSavedPoi(savedPoi: SavedPoiListItem): MapPoi | null {
+  const mapId = getSavedPoiMapId(savedPoi);
+
   if (savedPoi.googlePlaceCache) {
     const fromCache = getCoordinatesFromGooglePlace(savedPoi.googlePlaceCache);
     if (fromCache) {
       return {
         ...fromCache,
-        id: savedPoi.id ?? savedPoi.googlePlaceCache.placeId ?? fromCache.id,
+        id: mapId ?? fromCache.id,
       };
     }
   }
 
   if (savedPoi.poi) {
-    return getCoordinatesFromPoi(savedPoi.poi, savedPoi.id ?? savedPoi.poi.id ?? "");
+    return getCoordinatesFromPoi(savedPoi.poi, mapId ?? "");
   }
 
   return null;

--- a/apps/web/src/lib/i18n/locales/en/poi.json
+++ b/apps/web/src/lib/i18n/locales/en/poi.json
@@ -4,6 +4,7 @@
     "google": "Google"
   },
   "addressUnknown": "No address",
+  "select": "Select {name}",
   "openingHours": {
     "openNow": "Open now",
     "closedNow": "Closed",

--- a/apps/web/src/lib/i18n/locales/fr/poi.json
+++ b/apps/web/src/lib/i18n/locales/fr/poi.json
@@ -4,6 +4,7 @@
     "google": "Google"
   },
   "addressUnknown": "Aucune adresse",
+  "select": "Sélectionner {name}",
   "openingHours": {
     "openNow": "Ouvert maintenant",
     "closedNow": "Fermé",


### PR DESCRIPTION
## 📝 Description

Ajoute la sélection de POI synchronisée entre la liste/recherche et la carte : clic sur une carte ou un marker pour centrer la vue, désélection au clic sur la carte pour revenir à la vue liste (mobile).

## 🎯 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI update (no functional changes)
- [ ] ♻️ Code refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update

## 🔗 Related Issues

Closes NIR-83  
Related to NIR-67

## 🚀 Changes Made

- Ajout de l'état partagé `selectedPoiId` / `selectPoi` / `clearSelection` dans le shell, couplé au `mapMode` mobile
- Centrage carte via `flyTo` avec zoom plancher (15) et padding adapté au chrome desktop/mobile (`map-camera.ts`)
- `PoiMarkersLayer` interactif : sélection/désélection, marker surligné, popup, réconciliation si le POI disparaît
- `PoiCard` cliquable (overlay couvrant photo + contenu, actions conservées) avec surbrillance et scroll automatique
- Branchement Explore et détail de liste sur la sélection bidirectionnelle liste ↔ marker
- Helper `getSavedPoiMapId` pour garantir la même identité POI entre liste et carte
- Traductions `poi.select` (fr/en) et tests unitaires associés

## 🧪 Testing

- [x] Tested locally with `pnpm dev`
- [x] All quality checks pass (`pnpm lint`)
- [x] Unit tests pass (`pnpm test`)
- [ ] Database migrations applied if needed

## 📸 Screenshots/Videos

N/A

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated if needed
- [x] No console errors or warnings
- [x] Removed any debug code