### PR TITLE
feat(map): add poi markers and selection sync

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -204,6 +204,20 @@ html {
   outline: none;
 }
 
+.nirby-poi-marker--selected {
+  transform: scale(1.25);
+  z-index: 1;
+  box-shadow:
+    0 0 0 3px var(--primary),
+    0 0 0 5.5px var(--background),
+    0 6px 16px oklch(0 0 0 / 30%);
+}
+
+.nirby-poi-marker--selected:hover,
+.nirby-poi-marker--selected:focus-visible {
+  transform: scale(1.25);
+}
+
 .mapboxgl-popup-content {
   padding: 0.375rem 0.75rem;
   border-radius: var(--radius-md);

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -171,6 +171,69 @@ html {
   background-size: cover;
 }
 
+.nirby-poi-marker {
+  width: 1.75rem;
+  height: 1.75rem;
+  display: grid;
+  place-items: center;
+  border-radius: 9999px;
+  background-color: var(--primary);
+  box-shadow:
+    0 0 0 2.5px var(--background),
+    0 4px 10px oklch(0 0 0 / 25%);
+  cursor: pointer;
+  transition:
+    transform 150ms ease,
+    box-shadow 150ms ease;
+}
+
+.nirby-poi-marker::after {
+  content: "";
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 9999px;
+  background-color: var(--primary-foreground);
+}
+
+.nirby-poi-marker:hover,
+.nirby-poi-marker:focus-visible {
+  transform: scale(1.15);
+  box-shadow:
+    0 0 0 2.5px var(--background),
+    0 6px 16px oklch(0 0 0 / 30%);
+  outline: none;
+}
+
+.mapboxgl-popup-content {
+  padding: 0.375rem 0.75rem;
+  border-radius: var(--radius-md);
+  background-color: var(--popover);
+  color: var(--popover-foreground);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  box-shadow: 0 4px 14px oklch(0 0 0 / 18%);
+}
+
+.mapboxgl-popup-anchor-top .mapboxgl-popup-tip,
+.mapboxgl-popup-anchor-top-left .mapboxgl-popup-tip,
+.mapboxgl-popup-anchor-top-right .mapboxgl-popup-tip {
+  border-bottom-color: var(--popover);
+}
+
+.mapboxgl-popup-anchor-bottom .mapboxgl-popup-tip,
+.mapboxgl-popup-anchor-bottom-left .mapboxgl-popup-tip,
+.mapboxgl-popup-anchor-bottom-right .mapboxgl-popup-tip {
+  border-top-color: var(--popover);
+}
+
+.mapboxgl-popup-anchor-left .mapboxgl-popup-tip {
+  border-right-color: var(--popover);
+}
+
+.mapboxgl-popup-anchor-right .mapboxgl-popup-tip {
+  border-left-color: var(--popover);
+}
+
 .mapboxgl-user-location-dot {
   background-color: "#30c8ff" !important;
 }

--- a/apps/web/src/features/app-shell/context/shell-context.test.tsx
+++ b/apps/web/src/features/app-shell/context/shell-context.test.tsx
@@ -2,10 +2,11 @@ import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const replace = vi.fn();
+const push = vi.fn();
 let searchParams = new URLSearchParams();
 
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push: vi.fn(), replace, prefetch: vi.fn(), back: vi.fn() }),
+  useRouter: () => ({ push, replace, prefetch: vi.fn(), back: vi.fn() }),
   usePathname: () => "/",
   useSearchParams: () => searchParams,
 }));
@@ -93,5 +94,97 @@ describe("ShellProvider search", () => {
 
     expect(result.current.searchDraft).toBe("café");
     expect(replace).toHaveBeenCalledWith("/?q=caf%C3%A9", { scroll: false });
+  });
+});
+
+describe("ShellProvider POI selection", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    replace.mockClear();
+    push.mockClear();
+    replace.mockImplementation((href: string) => {
+      searchParams = new URLSearchParams(href.split("?")[1] ?? "");
+    });
+    push.mockImplementation((href: string) => {
+      searchParams = new URLSearchParams(href.split("?")[1] ?? "");
+    });
+    searchParams = new URLSearchParams("view=lists");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("selectPoi stores the id and enters map mode", () => {
+    const { result } = renderShell();
+
+    act(() => {
+      result.current.selectPoi("poi-1");
+    });
+
+    expect(result.current.selectedPoiId).toBe("poi-1");
+    expect(result.current.mapMode).toBe(true);
+  });
+
+  it("clearSelection resets the id and exits map mode", () => {
+    const { result } = renderShell();
+
+    act(() => {
+      result.current.selectPoi("poi-1");
+    });
+    act(() => {
+      result.current.clearSelection();
+    });
+
+    expect(result.current.selectedPoiId).toBeNull();
+    expect(result.current.mapMode).toBe(false);
+  });
+
+  it("clears selection when exiting map mode from the active tab", () => {
+    searchParams = new URLSearchParams("view=lists&mapMode=1");
+    const { result, rerender } = renderShell();
+    rerender();
+
+    act(() => {
+      result.current.selectPoi("poi-1");
+    });
+
+    act(() => {
+      result.current.setViewAndExitMapMode("lists");
+    });
+
+    expect(result.current.selectedPoiId).toBeNull();
+    expect(result.current.mapMode).toBe(false);
+  });
+
+  it("clears selection when the search query changes", () => {
+    const { result, rerender } = renderShell();
+
+    act(() => {
+      result.current.selectPoi("poi-1");
+    });
+
+    act(() => {
+      result.current.setSearchDraft("caf");
+    });
+    act(() => {
+      vi.advanceTimersByTime(EXPLORE_SEARCH_DEBOUNCE_MS);
+    });
+    rerender();
+
+    expect(result.current.selectedPoiId).toBeNull();
+  });
+
+  it("clears selection when switching shell views", () => {
+    const { result } = renderShell();
+
+    act(() => {
+      result.current.selectPoi("poi-1");
+    });
+    act(() => {
+      result.current.setView("explore");
+    });
+
+    expect(result.current.selectedPoiId).toBeNull();
   });
 });

--- a/apps/web/src/features/app-shell/context/shell-context.tsx
+++ b/apps/web/src/features/app-shell/context/shell-context.tsx
@@ -1,6 +1,15 @@
 "use client";
 
-import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 
 import { DEFAULT_SHELL_VIEW } from "../constants/shell.constants";
 import { useShellMapModeUrl } from "../hooks/use-shell-map-mode-url";
@@ -14,6 +23,9 @@ type ShellContextValue = ShellSearch & {
   setViewAndExitMapMode: (view: ShellView) => void;
   mapMode: boolean;
   setMapMode: (value: boolean) => void;
+  selectedPoiId: string | null;
+  selectPoi: (id: string) => void;
+  clearSelection: () => void;
 };
 
 const ShellContext = createContext<ShellContextValue | null>(null);
@@ -21,6 +33,7 @@ const ShellContext = createContext<ShellContextValue | null>(null);
 export function ShellProvider({ children }: { children: ReactNode }) {
   const [view, setViewState] = useState<ShellView>(DEFAULT_SHELL_VIEW);
   const [mapMode, setMapModeState] = useState(false);
+  const [selectedPoiId, setSelectedPoiId] = useState<string | null>(null);
 
   const { setView } = useShellViewUrl(view, setViewState);
   const { setMapMode } = useShellMapModeUrl(mapMode, setMapModeState);
@@ -28,24 +41,58 @@ export function ShellProvider({ children }: { children: ReactNode }) {
   // adopt those params, so switching to Explore needs no extra wiring here.
   const { query, searchDraft, setSearchDraft, setQuery } = useShellSearch();
 
+  const prevQueryRef = useRef(query);
+
+  useEffect(() => {
+    if (query !== prevQueryRef.current) {
+      prevQueryRef.current = query;
+      setSelectedPoiId(null);
+    }
+  }, [query]);
+
+  const clearSelection = useCallback(() => {
+    setSelectedPoiId(null);
+    setMapMode(false);
+  }, [setMapMode]);
+
+  const selectPoi = useCallback(
+    (id: string) => {
+      setSelectedPoiId(id);
+      setMapMode(true);
+    },
+    [setMapMode]
+  );
+
+  const setViewWithClear = useCallback(
+    (next: ShellView) => {
+      setSelectedPoiId(null);
+      setView(next);
+    },
+    [setView]
+  );
+
   const setViewAndExitMapMode = useCallback(
     (next: ShellView) => {
       if (mapMode && next === view) {
-        setMapMode(false);
+        clearSelection();
         return;
       }
+      setSelectedPoiId(null);
       setView(next);
     },
-    [mapMode, view, setMapMode, setView]
+    [mapMode, view, clearSelection, setView]
   );
 
   const value = useMemo(
     () => ({
       view,
-      setView,
+      setView: setViewWithClear,
       setViewAndExitMapMode,
       mapMode,
       setMapMode,
+      selectedPoiId,
+      selectPoi,
+      clearSelection,
       query,
       searchDraft,
       setSearchDraft,
@@ -53,10 +100,13 @@ export function ShellProvider({ children }: { children: ReactNode }) {
     }),
     [
       view,
-      setView,
+      setViewWithClear,
       setViewAndExitMapMode,
       mapMode,
       setMapMode,
+      selectedPoiId,
+      selectPoi,
+      clearSelection,
       query,
       searchDraft,
       setSearchDraft,

--- a/apps/web/src/features/app-shell/context/shell-context.tsx
+++ b/apps/web/src/features/app-shell/context/shell-context.tsx
@@ -1,15 +1,6 @@
 "use client";
 
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type ReactNode,
-} from "react";
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from "react";
 
 import { DEFAULT_SHELL_VIEW } from "../constants/shell.constants";
 import { useShellMapModeUrl } from "../hooks/use-shell-map-mode-url";
@@ -41,14 +32,14 @@ export function ShellProvider({ children }: { children: ReactNode }) {
   // adopt those params, so switching to Explore needs no extra wiring here.
   const { query, searchDraft, setSearchDraft, setQuery } = useShellSearch();
 
-  const prevQueryRef = useRef(query);
+  const [lastQueryForSelection, setLastQueryForSelection] = useState(query);
 
-  useEffect(() => {
-    if (query !== prevQueryRef.current) {
-      prevQueryRef.current = query;
+  if (query !== lastQueryForSelection) {
+    setLastQueryForSelection(query);
+    if (selectedPoiId !== null) {
       setSelectedPoiId(null);
     }
-  }, [query]);
+  }
 
   const clearSelection = useCallback(() => {
     setSelectedPoiId(null);

--- a/apps/web/src/features/explore/components/explore-result-row.tsx
+++ b/apps/web/src/features/explore/components/explore-result-row.tsx
@@ -13,9 +13,17 @@ type ExploreResultRowProps = {
   place: GooglePlace;
   savedListCount: number;
   onAddToList: (target: AddToListTarget) => void;
+  isSelected?: boolean;
+  onSelect?: (id: string) => void;
 };
 
-export function ExploreResultRow({ place, savedListCount, onAddToList }: ExploreResultRowProps) {
+export function ExploreResultRow({
+  place,
+  savedListCount,
+  onAddToList,
+  isSelected,
+  onSelect,
+}: ExploreResultRowProps) {
   const tExplore = useTranslations("explore");
   const display = getPoiDisplayDataFromGooglePlace(place);
 
@@ -28,6 +36,8 @@ export function ExploreResultRow({ place, savedListCount, onAddToList }: Explore
   return (
     <PoiCard
       poi={display}
+      isSelected={isSelected}
+      onSelect={onSelect ? () => onSelect(googlePlaceId) : undefined}
       badge={
         savedListCount > 0 ? (
           <Badge variant="secondary" className="gap-1 text-xs font-normal">

--- a/apps/web/src/features/explore/views/explore-results-view.test.tsx
+++ b/apps/web/src/features/explore/views/explore-results-view.test.tsx
@@ -47,6 +47,12 @@ vi.mock("../components/add-to-list-picker", () => ({
     open ? <div>picker for {placeName}</div> : null,
 }));
 
+vi.mock("@/features/map", () => ({
+  PoiMarkersLayer: ({ pois }: { pois: { id: string }[] }) => (
+    <div data-testid="poi-markers-layer" data-ids={pois.map((poi) => poi.id).join(",")} />
+  ),
+}));
+
 type SearchResult = ReturnType<typeof useSearchGooglePlaces>;
 
 function mockSearch(overrides: Partial<Record<keyof SearchResult, unknown>>) {
@@ -122,5 +128,70 @@ describe("ExploreResultsView", () => {
     await user.click(screen.getByRole("button", { name: "Louvre" }));
 
     expect(screen.getByText("picker for Louvre")).toBeInTheDocument();
+  });
+
+  it("passes geolocated places to the markers layer", () => {
+    mockSearch({
+      data: {
+        places: [
+          { placeId: "ChIJeiffel", name: "Tour Eiffel", latitude: 48.8584, longitude: 2.2945 },
+          { placeId: "ChIJlouvre", name: "Louvre", latitude: 48.8606, longitude: 2.3376 },
+        ],
+      },
+    });
+
+    render(<ExploreResultsView />);
+
+    expect(screen.getByTestId("poi-markers-layer")).toHaveAttribute(
+      "data-ids",
+      "ChIJeiffel,ChIJlouvre"
+    );
+  });
+
+  it("omits places without coordinates or with the (0, 0) sentinel", () => {
+    mockSearch({
+      data: {
+        places: [
+          { placeId: "ChIJeiffel", name: "Tour Eiffel", latitude: 48.8584, longitude: 2.2945 },
+          { placeId: "ChIJmissing", name: "No coords" },
+          { placeId: "ChIJzero", name: "Unknown", latitude: 0, longitude: 0 },
+        ],
+      },
+    });
+
+    render(<ExploreResultsView />);
+
+    expect(screen.getByTestId("poi-markers-layer")).toHaveAttribute("data-ids", "ChIJeiffel");
+  });
+
+  it("clears markers when the search errors", () => {
+    mockSearch({
+      isError: true,
+      error: { error: { code: "GOOGLE_PLACE_SEARCH_ERROR" } },
+      data: {
+        places: [
+          { placeId: "ChIJeiffel", name: "Tour Eiffel", latitude: 48.8584, longitude: 2.2945 },
+        ],
+      },
+    });
+
+    render(<ExploreResultsView />);
+
+    expect(screen.getByTestId("poi-markers-layer")).toHaveAttribute("data-ids", "");
+  });
+
+  it("does not mount the markers layer on the idle state", () => {
+    mockUseShell.mockReturnValue({ query: "c" });
+    mockSearch({
+      data: {
+        places: [
+          { placeId: "ChIJeiffel", name: "Tour Eiffel", latitude: 48.8584, longitude: 2.2945 },
+        ],
+      },
+    });
+
+    render(<ExploreResultsView />);
+
+    expect(screen.queryByTestId("poi-markers-layer")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/explore/views/explore-results-view.test.tsx
+++ b/apps/web/src/features/explore/views/explore-results-view.test.tsx
@@ -6,7 +6,14 @@ import { useSearchGooglePlaces } from "../hooks/use-search-google-places";
 
 import { ExploreResultsView } from "./explore-results-view";
 
-const mockUseShell = vi.fn(() => ({ query: "café" }));
+const defaultShellState = {
+  query: "café",
+  selectedPoiId: null,
+  selectPoi: vi.fn(),
+  clearSelection: vi.fn(),
+};
+
+const mockUseShell = vi.fn(() => defaultShellState);
 
 vi.mock("../hooks/use-search-google-places", () => ({
   useSearchGooglePlaces: vi.fn(),
@@ -48,8 +55,24 @@ vi.mock("../components/add-to-list-picker", () => ({
 }));
 
 vi.mock("@/features/map", () => ({
-  PoiMarkersLayer: ({ pois }: { pois: { id: string }[] }) => (
-    <div data-testid="poi-markers-layer" data-ids={pois.map((poi) => poi.id).join(",")} />
+  PoiMarkersLayer: ({
+    pois,
+    selectedPoiId,
+    onSelectPoi,
+    onDeselect,
+  }: {
+    pois: { id: string }[];
+    selectedPoiId?: string | null;
+    onSelectPoi?: (id: string) => void;
+    onDeselect?: () => void;
+  }) => (
+    <div
+      data-testid="poi-markers-layer"
+      data-ids={pois.map((poi) => poi.id).join(",")}
+      data-selected={selectedPoiId ?? ""}
+      data-has-select={onSelectPoi ? "1" : "0"}
+      data-has-deselect={onDeselect ? "1" : "0"}
+    />
   ),
 }));
 
@@ -70,11 +93,11 @@ function mockSearch(overrides: Partial<Record<keyof SearchResult, unknown>>) {
 describe("ExploreResultsView", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUseShell.mockReturnValue({ query: "café" });
+    mockUseShell.mockReturnValue({ ...defaultShellState, query: "café" });
   });
 
   it("shows the idle state when the query is too short", () => {
-    mockUseShell.mockReturnValue({ query: "c" });
+    mockUseShell.mockReturnValue({ ...defaultShellState, query: "c" });
     mockSearch({});
 
     render(<ExploreResultsView />);
@@ -181,7 +204,7 @@ describe("ExploreResultsView", () => {
   });
 
   it("does not mount the markers layer on the idle state", () => {
-    mockUseShell.mockReturnValue({ query: "c" });
+    mockUseShell.mockReturnValue({ ...defaultShellState, query: "c" });
     mockSearch({
       data: {
         places: [

--- a/apps/web/src/features/explore/views/explore-results-view.tsx
+++ b/apps/web/src/features/explore/views/explore-results-view.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 import { AddToListPicker, type AddToListTarget } from "../components/add-to-list-picker";
 import { ExploreResultRow } from "../components/explore-result-row";
@@ -11,6 +11,8 @@ import { usePoiListMembership } from "../hooks/use-poi-list-membership";
 import { useSearchGooglePlaces } from "../hooks/use-search-google-places";
 
 import { EXPLORE_MIN_QUERY_LENGTH, useShell } from "@/features/app-shell";
+import { PoiMarkersLayer } from "@/features/map";
+import { getCoordinatesFromGooglePlace, type MapPoi } from "@/features/pois";
 import { useErrorMessage } from "@/hooks/use-error-message";
 
 export function ExploreResultsView() {
@@ -24,6 +26,12 @@ export function ExploreResultsView() {
     .filter((placeId): placeId is string => Boolean(placeId));
   const { data: membershipData } = usePoiListMembership(placeIds);
   const membership = membershipData?.membership ?? {};
+  const mapPois = useMemo(() => {
+    if (isError) return [];
+    return (data?.places ?? [])
+      .map(getCoordinatesFromGooglePlace)
+      .filter((poi): poi is MapPoi => poi !== null);
+  }, [isError, data?.places]);
   // A single picker for the whole list: mounting one per row would duplicate the lists query.
   const [target, setTarget] = useState<AddToListTarget | null>(null);
   const [isPickerOpen, setIsPickerOpen] = useState(false);
@@ -82,6 +90,8 @@ export function ExploreResultsView() {
           onOpenChange={setIsPickerOpen}
         />
       ) : null}
+
+      <PoiMarkersLayer pois={mapPois} />
     </div>
   );
 }

--- a/apps/web/src/features/explore/views/explore-results-view.tsx
+++ b/apps/web/src/features/explore/views/explore-results-view.tsx
@@ -18,7 +18,7 @@ import { useErrorMessage } from "@/hooks/use-error-message";
 export function ExploreResultsView() {
   const tExplore = useTranslations("explore");
   const getErrorMessage = useErrorMessage();
-  const { query } = useShell();
+  const { query, selectedPoiId, selectPoi, clearSelection } = useShell();
   const { data, isLoading, isError, error, refetch, isFetching } = useSearchGooglePlaces(query);
   const places = data?.places ?? [];
   const placeIds = places
@@ -75,6 +75,8 @@ export function ExploreResultsView() {
                 place={place}
                 savedListCount={place.placeId ? (membership[place.placeId]?.length ?? 0) : 0}
                 onAddToList={openPicker}
+                isSelected={place.placeId === selectedPoiId}
+                onSelect={selectPoi}
               />
             </li>
           ))}
@@ -91,7 +93,12 @@ export function ExploreResultsView() {
         />
       ) : null}
 
-      <PoiMarkersLayer pois={mapPois} />
+      <PoiMarkersLayer
+        pois={mapPois}
+        selectedPoiId={selectedPoiId}
+        onSelectPoi={selectPoi}
+        onDeselect={clearSelection}
+      />
     </div>
   );
 }

--- a/apps/web/src/features/lists/components/list-poi-row.tsx
+++ b/apps/web/src/features/lists/components/list-poi-row.tsx
@@ -7,15 +7,22 @@ import { useState } from "react";
 import { RemovePoiDialog } from "./remove-poi-dialog";
 
 import { Button } from "@/components/ui";
-import { PoiCard, getPoiDisplayDataFromSavedPoi, type SavedPoiListItem } from "@/features/pois";
+import {
+  PoiCard,
+  getPoiDisplayDataFromSavedPoi,
+  getSavedPoiMapId,
+  type SavedPoiListItem,
+} from "@/features/pois";
 
 type ListPoiRowProps = {
   savedPoi: SavedPoiListItem;
   listId: string;
   canRemove: boolean;
+  isSelected?: boolean;
+  onSelect?: (id: string) => void;
 };
 
-export function ListPoiRow({ savedPoi, listId, canRemove }: ListPoiRowProps) {
+export function ListPoiRow({ savedPoi, listId, canRemove, isSelected, onSelect }: ListPoiRowProps) {
   const tLists = useTranslations("lists");
   const [removeDialogOpen, setRemoveDialogOpen] = useState(false);
   const display = getPoiDisplayDataFromSavedPoi(savedPoi);
@@ -25,11 +32,14 @@ export function ListPoiRow({ savedPoi, listId, canRemove }: ListPoiRowProps) {
   }
 
   const showRemoveAction = canRemove && Boolean(savedPoi.id);
+  const mapId = getSavedPoiMapId(savedPoi);
 
   return (
     <>
       <PoiCard
         poi={display}
+        isSelected={isSelected}
+        onSelect={mapId && onSelect ? () => onSelect(mapId) : undefined}
         actions={
           showRemoveAction ? (
             <Button

--- a/apps/web/src/features/lists/components/list-pois-section.tsx
+++ b/apps/web/src/features/lists/components/list-pois-section.tsx
@@ -12,15 +12,22 @@ import { ListPoiRow } from "./list-poi-row";
 import { ListPoisSkeleton } from "./list-pois-skeleton";
 
 import { Button } from "@/components/ui";
-import type { SavedPoiListItem } from "@/features/pois";
+import { getSavedPoiMapId, type SavedPoiListItem } from "@/features/pois";
 import { useErrorMessage } from "@/hooks/use-error-message";
 
 type ListPoisSectionProps = {
   listId: string;
   role?: ListRole;
+  selectedPoiId?: string | null;
+  onSelectPoi?: (id: string) => void;
 };
 
-export function ListPoisSection({ listId, role }: ListPoisSectionProps) {
+export function ListPoisSection({
+  listId,
+  role,
+  selectedPoiId,
+  onSelectPoi,
+}: ListPoisSectionProps) {
   const canRemove = canEditList(role);
   const tLists = useTranslations("lists");
   const getErrorMessage = useErrorMessage();
@@ -98,11 +105,21 @@ export function ListPoisSection({ listId, role }: ListPoisSectionProps) {
       {!isInitialLoading && !isError && items.length > 0 && (
         <>
           <ul className="flex w-full min-w-0 flex-col gap-3">
-            {items.map((savedPoi: SavedPoiListItem, index) => (
-              <li key={savedPoi.id ?? `saved-poi-${index}`}>
-                <ListPoiRow savedPoi={savedPoi} listId={listId} canRemove={canRemove} />
-              </li>
-            ))}
+            {items.map((savedPoi: SavedPoiListItem, index) => {
+              const mapId = getSavedPoiMapId(savedPoi);
+
+              return (
+                <li key={savedPoi.id ?? `saved-poi-${index}`}>
+                  <ListPoiRow
+                    savedPoi={savedPoi}
+                    listId={listId}
+                    canRemove={canRemove}
+                    isSelected={mapId !== null && selectedPoiId === mapId}
+                    onSelect={onSelectPoi}
+                  />
+                </li>
+              );
+            })}
           </ul>
 
           <div ref={sentinelRef} className="h-1 w-full" aria-hidden />

--- a/apps/web/src/features/lists/hooks/use-list-map-pois.test.tsx
+++ b/apps/web/src/features/lists/hooks/use-list-map-pois.test.tsx
@@ -1,0 +1,169 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useListMapPois } from "./use-list-map-pois";
+import { useListPoisInfinite } from "./use-list-pois-infinite";
+
+import type { SavedPoiListItem } from "@/features/pois";
+
+vi.mock("./use-list-pois-infinite", () => ({
+  useListPoisInfinite: vi.fn(),
+}));
+
+const customSavedPoi: SavedPoiListItem = {
+  id: "sp-1",
+  listId: "list-1",
+  poiId: "poi-1",
+  googlePlaceId: null,
+  createdAt: "2024-01-01T00:00:00.000Z",
+  poi: {
+    id: "poi-1",
+    name: "Fraktion",
+    address: "16 rue de la Grange Batelière, Paris",
+    category: "landmark",
+    latitude: 48.87324153744834,
+    longitude: 2.3412600502008014,
+    photoUrls: [],
+  },
+  googlePlaceCache: undefined,
+};
+
+const googleSavedPoi: SavedPoiListItem = {
+  id: "sp-2",
+  listId: "list-1",
+  poiId: null,
+  googlePlaceId: "ChIJxYJUC2lv5kcRlhdpWba_aGU",
+  createdAt: "2024-01-02T00:00:00.000Z",
+  poi: undefined,
+  googlePlaceCache: {
+    placeId: "ChIJxYJUC2lv5kcRlhdpWba_aGU",
+    name: "Le Tout-Paris",
+    address: "8 Quai du Louvre, Paris",
+    categoryDisplayName: "French Restaurant",
+    latitude: 48.8587493,
+    longitude: 2.3422529,
+    photoReferences: [],
+  },
+};
+
+const noGeoSavedPoi: SavedPoiListItem = {
+  id: "sp-3",
+  poi: {
+    id: "poi-3",
+    name: "No geo",
+  },
+};
+
+const zeroZeroSavedPoi: SavedPoiListItem = {
+  id: "sp-4",
+  googlePlaceCache: {
+    placeId: "ChIJzero",
+    name: "Unknown",
+    latitude: 0,
+    longitude: 0,
+  },
+};
+
+function mockInfinite(overrides: Partial<ReturnType<typeof useListPoisInfinite>> = {}) {
+  vi.mocked(useListPoisInfinite).mockReturnValue({
+    data: undefined,
+    isError: false,
+    ...overrides,
+  } as ReturnType<typeof useListPoisInfinite>);
+}
+
+describe("useListMapPois", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("flattens infinite pages into MapPoi ids", () => {
+    mockInfinite({
+      data: {
+        pages: [
+          {
+            savedPois: [customSavedPoi],
+            pagination: { page: 1, limit: 20, total: 2, totalPages: 2 },
+          },
+          {
+            savedPois: [googleSavedPoi],
+            pagination: { page: 2, limit: 20, total: 2, totalPages: 2 },
+          },
+        ],
+        pageParams: [1, 2],
+      },
+    });
+
+    const { result } = renderHook(() => useListMapPois("list-1"));
+
+    expect(result.current.map((poi) => poi.id)).toEqual(["sp-1", "sp-2"]);
+  });
+
+  it("maps a mix of custom POIs and Google cache", () => {
+    mockInfinite({
+      data: {
+        pages: [
+          {
+            savedPois: [customSavedPoi, googleSavedPoi],
+            pagination: { page: 1, limit: 20, total: 2, totalPages: 1 },
+          },
+        ],
+        pageParams: [1],
+      },
+    });
+
+    const { result } = renderHook(() => useListMapPois("list-1"));
+
+    expect(result.current).toEqual([
+      {
+        id: "sp-1",
+        lat: 48.87324153744834,
+        lng: 2.3412600502008014,
+        label: "Fraktion",
+      },
+      {
+        id: "sp-2",
+        lat: 48.8587493,
+        lng: 2.3422529,
+        label: "Le Tout-Paris",
+      },
+    ]);
+  });
+
+  it("ignores saved POIs without geo or with the (0, 0) sentinel", () => {
+    mockInfinite({
+      data: {
+        pages: [
+          {
+            savedPois: [customSavedPoi, noGeoSavedPoi, zeroZeroSavedPoi],
+            pagination: { page: 1, limit: 20, total: 3, totalPages: 1 },
+          },
+        ],
+        pageParams: [1],
+      },
+    });
+
+    const { result } = renderHook(() => useListMapPois("list-1"));
+
+    expect(result.current.map((poi) => poi.id)).toEqual(["sp-1"]);
+  });
+
+  it("returns an empty list when the query errors", () => {
+    mockInfinite({
+      isError: true,
+      data: {
+        pages: [
+          {
+            savedPois: [customSavedPoi],
+            pagination: { page: 1, limit: 20, total: 1, totalPages: 1 },
+          },
+        ],
+        pageParams: [1],
+      },
+    });
+
+    const { result } = renderHook(() => useListMapPois("list-1"));
+
+    expect(result.current).toEqual([]);
+  });
+});

--- a/apps/web/src/features/lists/hooks/use-list-map-pois.ts
+++ b/apps/web/src/features/lists/hooks/use-list-map-pois.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { useListPoisInfinite } from "./use-list-pois-infinite";
+
+import { getCoordinatesFromSavedPoi, type MapPoi } from "@/features/pois";
+
+export function useListMapPois(listId: string | undefined): MapPoi[] {
+  const { data, isError } = useListPoisInfinite(listId);
+
+  return useMemo(() => {
+    if (isError) return [];
+
+    return (data?.pages ?? [])
+      .flatMap((page) => page.savedPois)
+      .map(getCoordinatesFromSavedPoi)
+      .filter((poi): poi is MapPoi => poi !== null);
+  }, [isError, data?.pages]);
+}

--- a/apps/web/src/features/lists/views/lists-detail-view.test.tsx
+++ b/apps/web/src/features/lists/views/lists-detail-view.test.tsx
@@ -34,9 +34,33 @@ vi.mock("../hooks/use-list-map-pois", () => ({
   useListMapPois: () => useListMapPois(),
 }));
 
+vi.mock("@/features/app-shell", () => ({
+  useShell: () => ({
+    selectedPoiId: null,
+    selectPoi: vi.fn(),
+    clearSelection: vi.fn(),
+  }),
+}));
+
 vi.mock("@/features/map", () => ({
-  PoiMarkersLayer: ({ pois }: { pois: { id: string }[] }) => (
-    <div data-testid="poi-markers-layer" data-ids={pois.map((poi) => poi.id).join(",")} />
+  PoiMarkersLayer: ({
+    pois,
+    selectedPoiId,
+    onSelectPoi,
+    onDeselect,
+  }: {
+    pois: { id: string }[];
+    selectedPoiId?: string | null;
+    onSelectPoi?: (id: string) => void;
+    onDeselect?: () => void;
+  }) => (
+    <div
+      data-testid="poi-markers-layer"
+      data-ids={pois.map((poi) => poi.id).join(",")}
+      data-selected={selectedPoiId ?? ""}
+      data-has-select={onSelectPoi ? "1" : "0"}
+      data-has-deselect={onDeselect ? "1" : "0"}
+    />
   ),
 }));
 

--- a/apps/web/src/features/lists/views/lists-detail-view.test.tsx
+++ b/apps/web/src/features/lists/views/lists-detail-view.test.tsx
@@ -8,6 +8,7 @@ import { useList } from "../hooks/use-list";
 
 import { ListsDetailView } from "./lists-detail-view";
 
+import type { MapPoi } from "@/features/pois";
 import type { ListWithRole } from "@/lib/api";
 import { getErrorCode } from "@/lib/api/errors";
 
@@ -25,6 +26,18 @@ vi.mock("@/lib/api/errors", () => ({
 
 vi.mock("../hooks/use-delete-list", () => ({
   useDeleteList: vi.fn(),
+}));
+
+const useListMapPois = vi.fn((): MapPoi[] => []);
+
+vi.mock("../hooks/use-list-map-pois", () => ({
+  useListMapPois: () => useListMapPois(),
+}));
+
+vi.mock("@/features/map", () => ({
+  PoiMarkersLayer: ({ pois }: { pois: { id: string }[] }) => (
+    <div data-testid="poi-markers-layer" data-ids={pois.map((poi) => poi.id).join(",")} />
+  ),
 }));
 
 vi.mock("../components/list-pois-section", () => ({
@@ -77,6 +90,7 @@ describe("ListsDetailView", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    useListMapPois.mockReturnValue([]);
     vi.mocked(getErrorCode).mockReturnValue(null);
     mutateAsync.mockResolvedValue({ message: "List deleted successfully" });
     vi.mocked(useDeleteList).mockReturnValue({
@@ -208,5 +222,26 @@ describe("ListsDetailView", () => {
     expect(mutateAsync).toHaveBeenCalledWith("list-1");
     expect(toast.success).toHaveBeenCalledWith("deleteList.success");
     expect(onDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes geolocated list POIs to the markers layer", () => {
+    mockListQuery();
+    useListMapPois.mockReturnValue([
+      { id: "sp-1", lat: 48.8732, lng: 2.3413, label: "Fraktion" },
+      { id: "sp-2", lat: 48.8587, lng: 2.3423, label: "Le Tout-Paris" },
+    ]);
+
+    render(<ListsDetailView listId="list-1" onBack={onBack} onEdit={onEdit} onDelete={onDelete} />);
+
+    expect(screen.getByTestId("poi-markers-layer")).toHaveAttribute("data-ids", "sp-1,sp-2");
+  });
+
+  it("renders an empty markers layer when the list has no geo POIs", () => {
+    mockListQuery();
+    useListMapPois.mockReturnValue([]);
+
+    render(<ListsDetailView listId="list-1" onBack={onBack} onEdit={onEdit} onDelete={onDelete} />);
+
+    expect(screen.getByTestId("poi-markers-layer")).toHaveAttribute("data-ids", "");
   });
 });

--- a/apps/web/src/features/lists/views/lists-detail-view.tsx
+++ b/apps/web/src/features/lists/views/lists-detail-view.tsx
@@ -14,6 +14,7 @@ import { useList } from "../hooks/use-list";
 import { useListMapPois } from "../hooks/use-list-map-pois";
 
 import { Button } from "@/components/ui";
+import { useShell } from "@/features/app-shell";
 import { PoiMarkersLayer } from "@/features/map";
 
 type ListsDetailViewProps = {
@@ -25,6 +26,7 @@ type ListsDetailViewProps = {
 
 export function ListsDetailView({ listId, onBack, onEdit, onDelete }: ListsDetailViewProps) {
   const tLists = useTranslations("lists");
+  const { selectedPoiId, selectPoi, clearSelection } = useShell();
   const { data } = useList(listId);
   const mapPois = useListMapPois(listId);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -36,7 +38,12 @@ export function ListsDetailView({ listId, onBack, onEdit, onDelete }: ListsDetai
       description={list?.description ?? undefined}
       onBack={onBack}
     >
-      <PoiMarkersLayer pois={mapPois} />
+      <PoiMarkersLayer
+        pois={mapPois}
+        selectedPoiId={selectedPoiId}
+        onSelectPoi={selectPoi}
+        onDeselect={clearSelection}
+      />
       <ListsListQueryBoundary listId={listId}>
         {(loadedList) => (
           <div className="grid gap-6">
@@ -70,7 +77,12 @@ export function ListsDetailView({ listId, onBack, onEdit, onDelete }: ListsDetai
                 onDeleted={onDelete}
               />
             )}
-            <ListPoisSection listId={listId} role={loadedList.role} />
+            <ListPoisSection
+              listId={listId}
+              role={loadedList.role}
+              selectedPoiId={selectedPoiId}
+              onSelectPoi={selectPoi}
+            />
           </div>
         )}
       </ListsListQueryBoundary>

--- a/apps/web/src/features/lists/views/lists-detail-view.tsx
+++ b/apps/web/src/features/lists/views/lists-detail-view.tsx
@@ -11,8 +11,10 @@ import { ListsListQueryBoundary } from "../components/lists-list-query-boundary"
 import { ListsSectionLayout } from "../components/lists-section-layout";
 import { canDeleteList, canEditList } from "../constants/lists.constants";
 import { useList } from "../hooks/use-list";
+import { useListMapPois } from "../hooks/use-list-map-pois";
 
 import { Button } from "@/components/ui";
+import { PoiMarkersLayer } from "@/features/map";
 
 type ListsDetailViewProps = {
   listId: string;
@@ -24,6 +26,7 @@ type ListsDetailViewProps = {
 export function ListsDetailView({ listId, onBack, onEdit, onDelete }: ListsDetailViewProps) {
   const tLists = useTranslations("lists");
   const { data } = useList(listId);
+  const mapPois = useListMapPois(listId);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const list = data?.list;
 
@@ -33,6 +36,7 @@ export function ListsDetailView({ listId, onBack, onEdit, onDelete }: ListsDetai
       description={list?.description ?? undefined}
       onBack={onBack}
     >
+      <PoiMarkersLayer pois={mapPois} />
       <ListsListQueryBoundary listId={listId}>
         {(loadedList) => (
           <div className="grid gap-6">

--- a/apps/web/src/features/map/components/index.ts
+++ b/apps/web/src/features/map/components/index.ts
@@ -1,2 +1,3 @@
 export * from "./mapbox-map";
 export * from "./controls";
+export { PoiMarkersLayer } from "./poi-markers-layer";

--- a/apps/web/src/features/map/components/poi-markers-layer.test.tsx
+++ b/apps/web/src/features/map/components/poi-markers-layer.test.tsx
@@ -1,0 +1,118 @@
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { MapPoi } from "@/features/pois";
+
+const fitBounds = vi.fn();
+const useMapMock = vi.fn((): { map: { fitBounds: typeof fitBounds } | null } => ({
+  map: { fitBounds },
+}));
+
+type MarkerMock = {
+  setLngLat: ReturnType<typeof vi.fn>;
+  addTo: ReturnType<typeof vi.fn>;
+  remove: ReturnType<typeof vi.fn>;
+  setPopup: ReturnType<typeof vi.fn>;
+};
+
+const markerInstances: MarkerMock[] = [];
+
+vi.mock("../context", () => ({
+  useMap: () => useMapMock(),
+}));
+
+vi.mock("mapbox-gl", () => {
+  class Marker {
+    setLngLat = vi.fn().mockReturnThis();
+    addTo = vi.fn().mockReturnThis();
+    remove = vi.fn();
+    setPopup = vi.fn().mockReturnThis();
+
+    constructor() {
+      markerInstances.push(this);
+    }
+  }
+
+  class Popup {
+    setText = vi.fn().mockReturnThis();
+  }
+
+  return { default: { Marker, Popup } };
+});
+
+import { PoiMarkersLayer } from "./poi-markers-layer";
+
+const paris: MapPoi = { id: "paris", lat: 48.8566, lng: 2.3522, label: "Paris" };
+const lyon: MapPoi = { id: "lyon", lat: 45.764, lng: 4.8357, label: "Lyon" };
+
+describe("PoiMarkersLayer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    markerInstances.length = 0;
+    useMapMock.mockReturnValue({ map: { fitBounds } });
+  });
+
+  it("creates a marker per POI and fits bounds", () => {
+    render(<PoiMarkersLayer pois={[paris, lyon]} />);
+
+    expect(markerInstances).toHaveLength(2);
+    expect(markerInstances[0].setLngLat).toHaveBeenCalledWith([2.3522, 48.8566]);
+    expect(markerInstances[1].setLngLat).toHaveBeenCalledWith([4.8357, 45.764]);
+    expect(markerInstances[0].addTo).toHaveBeenCalledWith({ fitBounds });
+    expect(markerInstances[1].addTo).toHaveBeenCalledWith({ fitBounds });
+    expect(fitBounds).toHaveBeenCalledWith(
+      [
+        [2.3522, 45.764],
+        [4.8357, 48.8566],
+      ],
+      { padding: 80, maxZoom: 15, duration: 800 }
+    );
+  });
+
+  it("removes markers on unmount", () => {
+    const { unmount } = render(<PoiMarkersLayer pois={[paris]} />);
+
+    unmount();
+
+    expect(markerInstances[0].remove).toHaveBeenCalledTimes(1);
+  });
+
+  it("cleans up markers and skips fitBounds for an empty set", () => {
+    const { rerender } = render(<PoiMarkersLayer pois={[paris]} />);
+
+    expect(markerInstances).toHaveLength(1);
+    expect(fitBounds).toHaveBeenCalledTimes(1);
+
+    rerender(<PoiMarkersLayer pois={[]} />);
+
+    expect(markerInstances[0].remove).toHaveBeenCalledTimes(1);
+    expect(markerInstances).toHaveLength(1);
+    expect(fitBounds).toHaveBeenCalledTimes(1);
+  });
+
+  it("replaces markers and refits when the set changes", () => {
+    const { rerender } = render(<PoiMarkersLayer pois={[paris]} />);
+
+    rerender(<PoiMarkersLayer pois={[lyon]} />);
+
+    expect(markerInstances).toHaveLength(2);
+    expect(markerInstances[0].remove).toHaveBeenCalledTimes(1);
+    expect(markerInstances[1].setLngLat).toHaveBeenCalledWith([4.8357, 45.764]);
+    expect(fitBounds).toHaveBeenLastCalledWith(
+      [
+        [4.8357, 45.764],
+        [4.8357, 45.764],
+      ],
+      { padding: 80, maxZoom: 15, duration: 800 }
+    );
+  });
+
+  it("creates no markers when the map is not ready", () => {
+    useMapMock.mockReturnValue({ map: null });
+
+    render(<PoiMarkersLayer pois={[paris]} />);
+
+    expect(markerInstances).toHaveLength(0);
+    expect(fitBounds).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/features/map/components/poi-markers-layer.test.tsx
+++ b/apps/web/src/features/map/components/poi-markers-layer.test.tsx
@@ -115,4 +115,16 @@ describe("PoiMarkersLayer", () => {
     expect(markerInstances).toHaveLength(0);
     expect(fitBounds).not.toHaveBeenCalled();
   });
+
+  it("does not refit when the same POIs are passed with a new array reference", () => {
+    const { rerender } = render(<PoiMarkersLayer pois={[paris]} />);
+
+    expect(fitBounds).toHaveBeenCalledTimes(1);
+
+    rerender(<PoiMarkersLayer pois={[{ ...paris }]} />);
+
+    expect(fitBounds).toHaveBeenCalledTimes(1);
+    expect(markerInstances).toHaveLength(1);
+    expect(markerInstances[0].remove).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/features/map/components/poi-markers-layer.test.tsx
+++ b/apps/web/src/features/map/components/poi-markers-layer.test.tsx
@@ -1,18 +1,58 @@
 import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { PoiMarkersLayer } from "./poi-markers-layer";
 
 import type { MapPoi } from "@/features/pois";
 
 const fitBounds = vi.fn();
-const useMapMock = vi.fn((): { map: { fitBounds: typeof fitBounds } | null } => ({
-  map: { fitBounds },
-}));
+const flyTo = vi.fn();
+const getZoom = vi.fn(() => 13);
+const mapClickHandlers: Array<() => void> = [];
+
+const useMapMock = vi.fn(
+  (): {
+    map: {
+      fitBounds: typeof fitBounds;
+      flyTo: typeof flyTo;
+      getZoom: typeof getZoom;
+      getContainer: () => HTMLElement;
+      on: (event: string, handler: () => void) => void;
+      off: (event: string, handler: () => void) => void;
+    } | null;
+  } => ({
+    map: {
+      fitBounds,
+      flyTo,
+      getZoom,
+      getContainer: () => ({ clientWidth: 1024 }) as HTMLElement,
+      on: (event, handler) => {
+        if (event === "click") {
+          mapClickHandlers.push(handler);
+        }
+      },
+      off: (event, handler) => {
+        if (event === "click") {
+          const index = mapClickHandlers.indexOf(handler);
+          if (index >= 0) {
+            mapClickHandlers.splice(index, 1);
+          }
+        }
+      },
+    },
+  })
+);
 
 type MarkerMock = {
+  element: HTMLDivElement;
   setLngLat: ReturnType<typeof vi.fn>;
   addTo: ReturnType<typeof vi.fn>;
   remove: ReturnType<typeof vi.fn>;
   setPopup: ReturnType<typeof vi.fn>;
+  getElement: () => HTMLDivElement;
+  getPopup: ReturnType<typeof vi.fn>;
+  togglePopup: ReturnType<typeof vi.fn>;
 };
 
 const markerInstances: MarkerMock[] = [];
@@ -23,13 +63,23 @@ vi.mock("../context", () => ({
 
 vi.mock("mapbox-gl", () => {
   class Marker {
+    element: HTMLDivElement;
     setLngLat = vi.fn().mockReturnThis();
     addTo = vi.fn().mockReturnThis();
     remove = vi.fn();
     setPopup = vi.fn().mockReturnThis();
+    togglePopup = vi.fn();
+    getPopup = vi.fn(() => ({
+      isOpen: () => false,
+    }));
 
-    constructor() {
+    constructor(options?: { element?: HTMLDivElement }) {
+      this.element = options?.element ?? document.createElement("div");
       markerInstances.push(this);
+    }
+
+    getElement() {
+      return this.element;
     }
   }
 
@@ -40,8 +90,6 @@ vi.mock("mapbox-gl", () => {
   return { default: { Marker, Popup } };
 });
 
-import { PoiMarkersLayer } from "./poi-markers-layer";
-
 const paris: MapPoi = { id: "paris", lat: 48.8566, lng: 2.3522, label: "Paris" };
 const lyon: MapPoi = { id: "lyon", lat: 45.764, lng: 4.8357, label: "Lyon" };
 
@@ -49,7 +97,29 @@ describe("PoiMarkersLayer", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     markerInstances.length = 0;
-    useMapMock.mockReturnValue({ map: { fitBounds } });
+    mapClickHandlers.length = 0;
+    getZoom.mockReturnValue(13);
+    useMapMock.mockReturnValue({
+      map: {
+        fitBounds,
+        flyTo,
+        getZoom,
+        getContainer: () => ({ clientWidth: 1024 }) as HTMLElement,
+        on: (event, handler) => {
+          if (event === "click") {
+            mapClickHandlers.push(handler);
+          }
+        },
+        off: (event, handler) => {
+          if (event === "click") {
+            const index = mapClickHandlers.indexOf(handler);
+            if (index >= 0) {
+              mapClickHandlers.splice(index, 1);
+            }
+          }
+        },
+      },
+    });
   });
 
   it("creates a marker per POI and fits bounds", () => {
@@ -58,14 +128,16 @@ describe("PoiMarkersLayer", () => {
     expect(markerInstances).toHaveLength(2);
     expect(markerInstances[0].setLngLat).toHaveBeenCalledWith([2.3522, 48.8566]);
     expect(markerInstances[1].setLngLat).toHaveBeenCalledWith([4.8357, 45.764]);
-    expect(markerInstances[0].addTo).toHaveBeenCalledWith({ fitBounds });
-    expect(markerInstances[1].addTo).toHaveBeenCalledWith({ fitBounds });
     expect(fitBounds).toHaveBeenCalledWith(
       [
         [2.3522, 45.764],
         [4.8357, 48.8566],
       ],
-      { padding: 80, maxZoom: 15, duration: 800 }
+      {
+        padding: { left: 390, top: 80, right: 80, bottom: 80 },
+        maxZoom: 15,
+        duration: 800,
+      }
     );
   });
 
@@ -103,7 +175,11 @@ describe("PoiMarkersLayer", () => {
         [4.8357, 45.764],
         [4.8357, 45.764],
       ],
-      { padding: 80, maxZoom: 15, duration: 800 }
+      {
+        padding: { left: 390, top: 80, right: 80, bottom: 80 },
+        maxZoom: 15,
+        duration: 800,
+      }
     );
   });
 
@@ -126,5 +202,74 @@ describe("PoiMarkersLayer", () => {
     expect(fitBounds).toHaveBeenCalledTimes(1);
     expect(markerInstances).toHaveLength(1);
     expect(markerInstances[0].remove).not.toHaveBeenCalled();
+  });
+
+  it("flies to the selected POI with a zoom floor", () => {
+    render(<PoiMarkersLayer pois={[paris, lyon]} selectedPoiId="lyon" />);
+
+    expect(flyTo).toHaveBeenCalledWith({
+      center: [4.8357, 45.764],
+      zoom: 15,
+      padding: { left: 390, top: 80, right: 80, bottom: 80 },
+      duration: 800,
+    });
+    expect(fitBounds).not.toHaveBeenCalled();
+  });
+
+  it("does not zoom out when the map is already closer than the floor", () => {
+    getZoom.mockReturnValue(16);
+
+    render(<PoiMarkersLayer pois={[paris]} selectedPoiId="paris" />);
+
+    expect(flyTo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        zoom: 16,
+      })
+    );
+  });
+
+  it("calls onSelectPoi when a marker is clicked", async () => {
+    const user = userEvent.setup();
+    const onSelectPoi = vi.fn();
+
+    render(<PoiMarkersLayer pois={[paris]} onSelectPoi={onSelectPoi} />);
+
+    await user.click(markerInstances[0].element);
+
+    expect(onSelectPoi).toHaveBeenCalledWith("paris");
+  });
+
+  it("does not call onDeselect when a marker is clicked", async () => {
+    const user = userEvent.setup();
+    const onDeselect = vi.fn();
+    const onSelectPoi = vi.fn();
+
+    render(<PoiMarkersLayer pois={[paris]} onSelectPoi={onSelectPoi} onDeselect={onDeselect} />);
+
+    await user.click(markerInstances[0].element);
+
+    expect(onSelectPoi).toHaveBeenCalledWith("paris");
+    expect(onDeselect).not.toHaveBeenCalled();
+  });
+
+  it("calls onDeselect when the map is clicked", () => {
+    const onDeselect = vi.fn();
+
+    render(<PoiMarkersLayer pois={[paris]} onDeselect={onDeselect} />);
+
+    mapClickHandlers[0]();
+
+    expect(onDeselect).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onDeselect when the selected POI disappears from the set", () => {
+    const onDeselect = vi.fn();
+    const { rerender } = render(
+      <PoiMarkersLayer pois={[paris, lyon]} selectedPoiId="lyon" onDeselect={onDeselect} />
+    );
+
+    rerender(<PoiMarkersLayer pois={[paris]} selectedPoiId="lyon" onDeselect={onDeselect} />);
+
+    expect(onDeselect).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/features/map/components/poi-markers-layer.tsx
+++ b/apps/web/src/features/map/components/poi-markers-layer.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import mapboxgl from "mapbox-gl";
+import { useEffect } from "react";
+
+import { useMap } from "../context";
+import { getMapPoiBounds } from "../utils/map-bounds";
+
+import type { MapPoi } from "@/features/pois";
+
+type PoiMarkersLayerProps = {
+  pois: MapPoi[];
+};
+
+export function PoiMarkersLayer({ pois }: PoiMarkersLayerProps) {
+  const { map } = useMap();
+
+  useEffect(() => {
+    if (!map) return;
+
+    const markers = pois.map((poi) => {
+      const marker = new mapboxgl.Marker().setLngLat([poi.lng, poi.lat]);
+
+      if (poi.label) {
+        marker.setPopup(new mapboxgl.Popup({ closeButton: false }).setText(poi.label));
+      }
+
+      return marker.addTo(map);
+    });
+
+    const bounds = getMapPoiBounds(pois);
+    if (bounds) {
+      map.fitBounds(bounds, { padding: 80, maxZoom: 15, duration: 800 });
+    }
+
+    return () => {
+      markers.forEach((marker) => marker.remove());
+    };
+  }, [map, pois]);
+
+  return null;
+}

--- a/apps/web/src/features/map/components/poi-markers-layer.tsx
+++ b/apps/web/src/features/map/components/poi-markers-layer.tsx
@@ -5,52 +5,142 @@ import { useEffect, useRef } from "react";
 
 import { useMap } from "../context";
 import { getMapPoiBounds } from "../utils/map-bounds";
+import { getShellViewportPadding, getSelectedPoiZoom } from "../utils/map-camera";
 import { createPoiMarkerElement } from "../utils/poi-marker-element";
 
 import type { MapPoi } from "@/features/pois";
 
 type PoiMarkersLayerProps = {
   pois: MapPoi[];
+  selectedPoiId?: string | null;
+  onSelectPoi?: (id: string) => void;
+  onDeselect?: () => void;
 };
 
 function getPoisKey(pois: MapPoi[]): string {
   return pois.map((poi) => `${poi.id}:${poi.lat}:${poi.lng}`).join("|");
 }
 
-export function PoiMarkersLayer({ pois }: PoiMarkersLayerProps) {
+export function PoiMarkersLayer({
+  pois,
+  selectedPoiId = null,
+  onSelectPoi,
+  onDeselect,
+}: PoiMarkersLayerProps) {
   const { map } = useMap();
   const poisRef = useRef(pois);
   const poisKey = getPoisKey(pois);
+  const markersRef = useRef<Map<string, mapboxgl.Marker>>(new Map());
+  const onSelectPoiRef = useRef(onSelectPoi);
+  const onDeselectRef = useRef(onDeselect);
+  const selectedPoiIdRef = useRef(selectedPoiId);
 
   useEffect(() => {
     poisRef.current = pois;
   }, [pois]);
 
   useEffect(() => {
+    onSelectPoiRef.current = onSelectPoi;
+  }, [onSelectPoi]);
+
+  useEffect(() => {
+    onDeselectRef.current = onDeselect;
+  }, [onDeselect]);
+
+  useEffect(() => {
+    selectedPoiIdRef.current = selectedPoiId;
+  }, [selectedPoiId]);
+
+  useEffect(() => {
     if (!map) return;
 
     const currentPois = poisRef.current;
-    const markers = currentPois.map((poi) => {
-      const marker = new mapboxgl.Marker({
-        element: createPoiMarkerElement(poi.label),
-      }).setLngLat([poi.lng, poi.lat]);
+    const markers = new Map<string, mapboxgl.Marker>();
+
+    currentPois.forEach((poi) => {
+      const element = createPoiMarkerElement(poi.label);
+      element.addEventListener("click", (event) => {
+        event.stopPropagation();
+        onSelectPoiRef.current?.(poi.id);
+      });
+
+      const marker = new mapboxgl.Marker({ element }).setLngLat([poi.lng, poi.lat]);
 
       if (poi.label) {
         marker.setPopup(new mapboxgl.Popup({ closeButton: false, offset: 18 }).setText(poi.label));
       }
 
-      return marker.addTo(map);
+      marker.addTo(map);
+      markers.set(poi.id, marker);
     });
 
+    markersRef.current = markers;
+
     const bounds = getMapPoiBounds(currentPois);
-    if (bounds) {
-      map.fitBounds(bounds, { padding: 80, maxZoom: 15, duration: 800 });
+    if (bounds && !selectedPoiIdRef.current) {
+      const padding = getShellViewportPadding(map.getContainer());
+      map.fitBounds(bounds, { padding, maxZoom: 15, duration: 800 });
     }
 
     return () => {
       markers.forEach((marker) => marker.remove());
+      markersRef.current = new Map();
     };
   }, [map, poisKey]);
+
+  useEffect(() => {
+    if (!map) return;
+
+    const handleMapClick = () => {
+      onDeselectRef.current?.();
+    };
+
+    map.on("click", handleMapClick);
+
+    return () => {
+      map.off("click", handleMapClick);
+    };
+  }, [map]);
+
+  useEffect(() => {
+    if (!map) return;
+
+    markersRef.current.forEach((marker, id) => {
+      const element = marker.getElement();
+      element.classList.toggle("nirby-poi-marker--selected", id === selectedPoiId);
+
+      const popup = marker.getPopup();
+      if (!popup) return;
+
+      if (id === selectedPoiId) {
+        if (!popup.isOpen()) {
+          marker.togglePopup();
+        }
+      } else if (popup.isOpen()) {
+        marker.togglePopup();
+      }
+    });
+  }, [map, selectedPoiId, poisKey]);
+
+  useEffect(() => {
+    if (!map || !selectedPoiId) return;
+
+    const poi = poisRef.current.find((item) => item.id === selectedPoiId);
+    if (!poi) {
+      onDeselectRef.current?.();
+      return;
+    }
+
+    const padding = getShellViewportPadding(map.getContainer());
+    const zoom = getSelectedPoiZoom(map.getZoom());
+
+    map.flyTo({
+      center: [poi.lng, poi.lat],
+      zoom,
+      padding,
+      duration: 800,
+    });
+  }, [map, selectedPoiId, poisKey]);
 
   return null;
 }

--- a/apps/web/src/features/map/components/poi-markers-layer.tsx
+++ b/apps/web/src/features/map/components/poi-markers-layer.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef } from "react";
 
 import { useMap } from "../context";
 import { getMapPoiBounds } from "../utils/map-bounds";
+import { createPoiMarkerElement } from "../utils/poi-marker-element";
 
 import type { MapPoi } from "@/features/pois";
 
@@ -30,10 +31,12 @@ export function PoiMarkersLayer({ pois }: PoiMarkersLayerProps) {
 
     const currentPois = poisRef.current;
     const markers = currentPois.map((poi) => {
-      const marker = new mapboxgl.Marker().setLngLat([poi.lng, poi.lat]);
+      const marker = new mapboxgl.Marker({
+        element: createPoiMarkerElement(poi.label),
+      }).setLngLat([poi.lng, poi.lat]);
 
       if (poi.label) {
-        marker.setPopup(new mapboxgl.Popup({ closeButton: false }).setText(poi.label));
+        marker.setPopup(new mapboxgl.Popup({ closeButton: false, offset: 18 }).setText(poi.label));
       }
 
       return marker.addTo(map);

--- a/apps/web/src/features/map/components/poi-markers-layer.tsx
+++ b/apps/web/src/features/map/components/poi-markers-layer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import mapboxgl from "mapbox-gl";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 import { useMap } from "../context";
 import { getMapPoiBounds } from "../utils/map-bounds";
@@ -12,13 +12,24 @@ type PoiMarkersLayerProps = {
   pois: MapPoi[];
 };
 
+function getPoisKey(pois: MapPoi[]): string {
+  return pois.map((poi) => `${poi.id}:${poi.lat}:${poi.lng}`).join("|");
+}
+
 export function PoiMarkersLayer({ pois }: PoiMarkersLayerProps) {
   const { map } = useMap();
+  const poisRef = useRef(pois);
+  const poisKey = getPoisKey(pois);
+
+  useEffect(() => {
+    poisRef.current = pois;
+  }, [pois]);
 
   useEffect(() => {
     if (!map) return;
 
-    const markers = pois.map((poi) => {
+    const currentPois = poisRef.current;
+    const markers = currentPois.map((poi) => {
       const marker = new mapboxgl.Marker().setLngLat([poi.lng, poi.lat]);
 
       if (poi.label) {
@@ -28,7 +39,7 @@ export function PoiMarkersLayer({ pois }: PoiMarkersLayerProps) {
       return marker.addTo(map);
     });
 
-    const bounds = getMapPoiBounds(pois);
+    const bounds = getMapPoiBounds(currentPois);
     if (bounds) {
       map.fitBounds(bounds, { padding: 80, maxZoom: 15, duration: 800 });
     }
@@ -36,7 +47,7 @@ export function PoiMarkersLayer({ pois }: PoiMarkersLayerProps) {
     return () => {
       markers.forEach((marker) => marker.remove());
     };
-  }, [map, pois]);
+  }, [map, poisKey]);
 
   return null;
 }

--- a/apps/web/src/features/map/index.ts
+++ b/apps/web/src/features/map/index.ts
@@ -1,2 +1,3 @@
 export * from "./context";
 export * from "./components";
+export { getMapPoiBounds } from "./utils/map-bounds";

--- a/apps/web/src/features/map/utils/map-bounds.test.ts
+++ b/apps/web/src/features/map/utils/map-bounds.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { getMapPoiBounds } from "./map-bounds";
+
+describe("getMapPoiBounds", () => {
+  it("returns null for an empty set", () => {
+    expect(getMapPoiBounds([])).toBeNull();
+  });
+
+  it("returns a degenerate bbox for a single POI", () => {
+    expect(getMapPoiBounds([{ id: "paris", lat: 48.8566, lng: 2.3522, label: "Paris" }])).toEqual([
+      [2.3522, 48.8566],
+      [2.3522, 48.8566],
+    ]);
+  });
+
+  it("returns min/max lng/lat for multiple POIs", () => {
+    expect(
+      getMapPoiBounds([
+        { id: "paris", lat: 48.8566, lng: 2.3522 },
+        { id: "lyon", lat: 45.764, lng: 4.8357 },
+      ])
+    ).toEqual([
+      [2.3522, 45.764],
+      [4.8357, 48.8566],
+    ]);
+  });
+});

--- a/apps/web/src/features/map/utils/map-bounds.ts
+++ b/apps/web/src/features/map/utils/map-bounds.ts
@@ -1,0 +1,22 @@
+import type { MapPoi } from "@/features/pois";
+
+export function getMapPoiBounds(pois: MapPoi[]): [[number, number], [number, number]] | null {
+  if (pois.length === 0) return null;
+
+  let minLng = pois[0].lng;
+  let minLat = pois[0].lat;
+  let maxLng = pois[0].lng;
+  let maxLat = pois[0].lat;
+
+  for (const poi of pois) {
+    if (poi.lng < minLng) minLng = poi.lng;
+    if (poi.lat < minLat) minLat = poi.lat;
+    if (poi.lng > maxLng) maxLng = poi.lng;
+    if (poi.lat > maxLat) maxLat = poi.lat;
+  }
+
+  return [
+    [minLng, minLat],
+    [maxLng, maxLat],
+  ];
+}

--- a/apps/web/src/features/map/utils/map-camera.test.ts
+++ b/apps/web/src/features/map/utils/map-camera.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { SELECTED_POI_MIN_ZOOM, getSelectedPoiZoom, getShellViewportPadding } from "./map-camera";
+
+describe("getSelectedPoiZoom", () => {
+  it("raises the zoom to the minimum floor when the map is zoomed out", () => {
+    expect(getSelectedPoiZoom(10)).toBe(SELECTED_POI_MIN_ZOOM);
+  });
+
+  it("keeps the current zoom when already closer than the floor", () => {
+    expect(getSelectedPoiZoom(16)).toBe(16);
+  });
+});
+
+describe("getShellViewportPadding", () => {
+  it("reserves space for the desktop sidebar", () => {
+    const container = { clientWidth: 1024 } as HTMLElement;
+
+    expect(getShellViewportPadding(container)).toEqual({
+      left: 390,
+      top: 80,
+      right: 80,
+      bottom: 80,
+    });
+  });
+
+  it("reserves space for the mobile bottom chrome", () => {
+    const container = { clientWidth: 375 } as HTMLElement;
+
+    expect(getShellViewportPadding(container)).toEqual({
+      bottom: 96,
+      top: 80,
+      left: 24,
+      right: 24,
+    });
+  });
+});

--- a/apps/web/src/features/map/utils/map-camera.ts
+++ b/apps/web/src/features/map/utils/map-camera.ts
@@ -1,0 +1,17 @@
+import type { PaddingOptions } from "mapbox-gl";
+
+export const SELECTED_POI_MIN_ZOOM = 15;
+
+export function getSelectedPoiZoom(currentZoom: number): number {
+  return Math.max(currentZoom, SELECTED_POI_MIN_ZOOM);
+}
+
+export function getShellViewportPadding(container: HTMLElement): PaddingOptions {
+  const isDesktop = container.clientWidth >= 768;
+
+  if (isDesktop) {
+    return { left: 390, top: 80, right: 80, bottom: 80 };
+  }
+
+  return { bottom: 96, top: 80, left: 24, right: 24 };
+}

--- a/apps/web/src/features/map/utils/poi-marker-element.ts
+++ b/apps/web/src/features/map/utils/poi-marker-element.ts
@@ -1,0 +1,10 @@
+export function createPoiMarkerElement(label?: string): HTMLDivElement {
+  const element = document.createElement("div");
+  element.className = "nirby-poi-marker";
+
+  if (label) {
+    element.setAttribute("aria-label", label);
+  }
+
+  return element;
+}

--- a/apps/web/src/features/pois/components/poi-card.test.tsx
+++ b/apps/web/src/features/pois/components/poi-card.test.tsx
@@ -11,6 +11,7 @@ vi.mock("./poi-photo", () => ({
 }));
 
 const poi: PoiDisplayData = {
+  id: "ChIJLU7jZClu5kcR4PcOOO6p3I0",
   name: "Tour Eiffel",
   address: "Champ de Mars, Paris",
   category: null,

--- a/apps/web/src/features/pois/components/poi-card.test.tsx
+++ b/apps/web/src/features/pois/components/poi-card.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { PoiDisplayData } from "../types/poi-display-types";
+
+import { PoiCard } from "./poi-card";
+
+vi.mock("./poi-photo", () => ({
+  PoiPhoto: ({ alt }: { alt: string }) => <div data-testid="poi-photo">{alt}</div>,
+}));
+
+const poi: PoiDisplayData = {
+  name: "Tour Eiffel",
+  address: "Champ de Mars, Paris",
+  category: null,
+  source: "google",
+  photo: { kind: "url", url: "https://example.com/eiffel.jpg" },
+  openingHours: null,
+};
+
+describe("PoiCard", () => {
+  beforeEach(() => {
+    HTMLElement.prototype.scrollIntoView = vi.fn();
+  });
+
+  it("calls onSelect when the overlay button is clicked", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+
+    render(<PoiCard poi={poi} onSelect={onSelect} />);
+
+    await user.click(screen.getByRole("button", { name: "select" }));
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the select overlay above card content so photo clicks work", () => {
+    const { container } = render(<PoiCard poi={poi} onSelect={vi.fn()} />);
+    const article = container.querySelector("article");
+    const button = screen.getByRole("button", { name: "select" });
+
+    expect(article?.lastElementChild).toBe(button);
+    expect(button).toHaveClass("z-10");
+  });
+
+  it("applies the selected ring style", () => {
+    const { container } = render(<PoiCard poi={poi} isSelected onSelect={vi.fn()} />);
+
+    expect(container.querySelector("article")).toHaveClass("ring-2", "ring-primary");
+  });
+
+  it("scrolls the card into view when it becomes selected", () => {
+    const scrollIntoView = vi.mocked(HTMLElement.prototype.scrollIntoView);
+
+    const { rerender } = render(<PoiCard poi={poi} onSelect={vi.fn()} />);
+
+    rerender(<PoiCard poi={poi} isSelected onSelect={vi.fn()} />);
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest", behavior: "smooth" });
+  });
+});

--- a/apps/web/src/features/pois/components/poi-card.tsx
+++ b/apps/web/src/features/pois/components/poi-card.tsx
@@ -2,28 +2,46 @@
 
 import { ClockIcon, MapPinIcon } from "lucide-react";
 import { useTranslations } from "next-intl";
-import type { ReactNode } from "react";
+import { useEffect, useRef, type ReactNode } from "react";
 
 import type { PoiDisplayData } from "../types/poi-display-types";
 
 import { PoiOpeningHours } from "./poi-opening-hours";
 import { PoiPhoto } from "./poi-photo";
 
+import { cn } from "@/lib/utils";
+
 type PoiCardProps = {
   poi: PoiDisplayData;
   actions?: ReactNode;
   badge?: ReactNode;
+  isSelected?: boolean;
+  onSelect?: () => void;
 };
 
-export function PoiCard({ poi, actions, badge }: PoiCardProps) {
+export function PoiCard({ poi, actions, badge, isSelected, onSelect }: PoiCardProps) {
   const tPoi = useTranslations("poi");
+  const cardRef = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    if (isSelected && cardRef.current) {
+      cardRef.current.scrollIntoView({ block: "nearest", behavior: "smooth" });
+    }
+  }, [isSelected]);
 
   return (
-    <article className="group flex flex-col items-start rounded-md border border-border">
+    <article
+      ref={cardRef}
+      className={cn(
+        "group relative flex flex-col items-start rounded-md border border-border",
+        isSelected && "ring-2 ring-primary",
+        onSelect && "cursor-pointer"
+      )}
+    >
       {poi.photo ? (
         <div className="relative overflow-hidden rounded-t-md h-[150px] w-full">
           <PoiPhoto photo={poi.photo} alt={poi.name} />
-          {badge ? <div className="absolute top-2 right-2">{badge}</div> : null}
+          {badge ? <div className="absolute top-2 right-2 z-20">{badge}</div> : null}
         </div>
       ) : null}
       <div className="px-4 py-2 flex flex-col gap-1 w-full">
@@ -31,7 +49,9 @@ export function PoiCard({ poi, actions, badge }: PoiCardProps) {
           <h3 className="min-w-0 font-display text-base font-semibold tracking-tight">
             {poi.name}
           </h3>
-          {actions ? <div className="shrink-0">{actions}</div> : null}
+          {actions ? (
+            <div className="relative z-20 shrink-0 pointer-events-auto">{actions}</div>
+          ) : null}
         </div>
 
         <p className="flex min-w-0 items-center gap-1.5 text-sm text-muted-foreground">
@@ -46,6 +66,15 @@ export function PoiCard({ poi, actions, badge }: PoiCardProps) {
           </div>
         ) : null}
       </div>
+      {onSelect ? (
+        <button
+          type="button"
+          className="absolute inset-0 z-10 rounded-md"
+          aria-label={tPoi("select", { name: poi.name })}
+          aria-pressed={isSelected}
+          onClick={onSelect}
+        />
+      ) : null}
     </article>
   );
 }

--- a/apps/web/src/features/pois/index.ts
+++ b/apps/web/src/features/pois/index.ts
@@ -11,6 +11,7 @@ export {
 export {
   getCoordinatesFromGooglePlace,
   getCoordinatesFromSavedPoi,
+  getSavedPoiMapId,
 } from "./utils/get-poi-coordinates";
 
 export type {

--- a/apps/web/src/features/pois/index.ts
+++ b/apps/web/src/features/pois/index.ts
@@ -8,10 +8,16 @@ export {
   getPoiDisplayDataFromGooglePlace,
 } from "./utils/get-poi-display-data";
 
+export {
+  getCoordinatesFromGooglePlace,
+  getCoordinatesFromSavedPoi,
+} from "./utils/get-poi-coordinates";
+
 export type {
   PoiDisplayData,
   PoiPhoto as PoiPhotoData,
   PoiOpeningHours as PoiOpeningHoursData,
   SavedPoiListItem,
   PoiSource,
+  MapPoi,
 } from "./types/poi-display-types";

--- a/apps/web/src/features/pois/types/poi-display-types.ts
+++ b/apps/web/src/features/pois/types/poi-display-types.ts
@@ -26,4 +26,11 @@ export type PoiDisplayData = {
   openingHours: PoiOpeningHours | null;
 };
 
+export type MapPoi = {
+  id: string;
+  lat: number;
+  lng: number;
+  label?: string;
+};
+
 export type { Poi, GooglePlace };

--- a/apps/web/src/features/pois/utils/get-poi-coordinates.test.ts
+++ b/apps/web/src/features/pois/utils/get-poi-coordinates.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   getCoordinatesFromGooglePlace,
   getCoordinatesFromSavedPoi,
+  getSavedPoiMapId,
 } from "./get-poi-coordinates";
 
 describe("getCoordinatesFromGooglePlace", () => {
@@ -163,5 +164,32 @@ describe("getCoordinatesFromSavedPoi", () => {
       lng: 2.2945,
       label: "Custom fallback",
     });
+  });
+});
+
+describe("getSavedPoiMapId", () => {
+  it("prefers the saved POI id", () => {
+    expect(
+      getSavedPoiMapId({
+        id: "sp-1",
+        googlePlaceCache: { placeId: "ChIJgoogle", name: "Google place" },
+      })
+    ).toBe("sp-1");
+  });
+
+  it("falls back to the Google place id", () => {
+    expect(
+      getSavedPoiMapId({
+        googlePlaceCache: { placeId: "ChIJgoogle", name: "Google place" },
+      })
+    ).toBe("ChIJgoogle");
+  });
+
+  it("falls back to the custom POI id", () => {
+    expect(
+      getSavedPoiMapId({
+        poi: { id: "poi-1", name: "Custom place" },
+      })
+    ).toBe("poi-1");
   });
 });

--- a/apps/web/src/features/pois/utils/get-poi-coordinates.test.ts
+++ b/apps/web/src/features/pois/utils/get-poi-coordinates.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getCoordinatesFromGooglePlace,
+  getCoordinatesFromSavedPoi,
+} from "./get-poi-coordinates";
+
+describe("getCoordinatesFromGooglePlace", () => {
+  it("returns MapPoi for a Google Place with valid coordinates", () => {
+    expect(
+      getCoordinatesFromGooglePlace({
+        placeId: "ChIJLU7jZClu5kcR4PcOOO6p3I0",
+        name: "Tour Eiffel",
+        latitude: 48.8566,
+        longitude: 2.3522,
+      })
+    ).toEqual({
+      id: "ChIJLU7jZClu5kcR4PcOOO6p3I0",
+      lat: 48.8566,
+      lng: 2.3522,
+      label: "Tour Eiffel",
+    });
+  });
+
+  it("returns null for Google (0, 0) sentinel coordinates", () => {
+    expect(
+      getCoordinatesFromGooglePlace({
+        placeId: "ChIJmissing",
+        name: "Unknown place",
+        latitude: 0,
+        longitude: 0,
+      })
+    ).toBeNull();
+  });
+
+  it("returns null when lat/lng are undefined", () => {
+    expect(
+      getCoordinatesFromGooglePlace({
+        placeId: "ChIJno-geo",
+        name: "No coords",
+      })
+    ).toBeNull();
+  });
+
+  it("omits label when the name is empty", () => {
+    expect(
+      getCoordinatesFromGooglePlace({
+        placeId: "ChIJno-name",
+        name: "   ",
+        latitude: 48.8566,
+        longitude: 2.3522,
+      })
+    ).toEqual({
+      id: "ChIJno-name",
+      lat: 48.8566,
+      lng: 2.3522,
+    });
+  });
+});
+
+describe("getCoordinatesFromSavedPoi", () => {
+  it("maps a custom SavedPoi with coordinates", () => {
+    expect(
+      getCoordinatesFromSavedPoi({
+        id: "sp-1",
+        poiId: "poi-1",
+        googlePlaceId: null,
+        poi: {
+          id: "poi-1",
+          name: "Tour Eiffel",
+          latitude: 48.8584,
+          longitude: 2.2945,
+        },
+      })
+    ).toEqual({
+      id: "sp-1",
+      lat: 48.8584,
+      lng: 2.2945,
+      label: "Tour Eiffel",
+    });
+  });
+
+  it("maps a SavedPoi from Google Place cache", () => {
+    expect(
+      getCoordinatesFromSavedPoi({
+        id: "sp-2",
+        googlePlaceCache: {
+          placeId: "ChIJ...",
+          name: "Café de Flore",
+          latitude: 48.8542,
+          longitude: 2.3326,
+        },
+      })
+    ).toEqual({
+      id: "sp-2",
+      lat: 48.8542,
+      lng: 2.3326,
+      label: "Café de Flore",
+    });
+  });
+
+  it("returns null when SavedPoi has no geo", () => {
+    expect(getCoordinatesFromSavedPoi({ id: "sp-4" })).toBeNull();
+  });
+
+  it("returns null when SavedPoi sources have no coordinates", () => {
+    expect(
+      getCoordinatesFromSavedPoi({
+        id: "sp-5",
+        poi: {
+          id: "poi-5",
+          name: "No address POI",
+        },
+      })
+    ).toBeNull();
+  });
+
+  it("prefers googlePlaceCache over poi when both have coordinates", () => {
+    expect(
+      getCoordinatesFromSavedPoi({
+        id: "sp-6",
+        poi: {
+          id: "poi-6",
+          name: "Custom name",
+          latitude: 48.86,
+          longitude: 2.3,
+        },
+        googlePlaceCache: {
+          placeId: "ChIJgoogle",
+          name: "Google name",
+          latitude: 48.8542,
+          longitude: 2.3326,
+        },
+      })
+    ).toEqual({
+      id: "sp-6",
+      lat: 48.8542,
+      lng: 2.3326,
+      label: "Google name",
+    });
+  });
+
+  it("falls back to poi when googlePlaceCache is (0, 0)", () => {
+    expect(
+      getCoordinatesFromSavedPoi({
+        id: "sp-7",
+        poi: {
+          id: "poi-7",
+          name: "Custom fallback",
+          latitude: 48.8584,
+          longitude: 2.2945,
+        },
+        googlePlaceCache: {
+          placeId: "ChIJzero",
+          name: "Missing location",
+          latitude: 0,
+          longitude: 0,
+        },
+      })
+    ).toEqual({
+      id: "sp-7",
+      lat: 48.8584,
+      lng: 2.2945,
+      label: "Custom fallback",
+    });
+  });
+});

--- a/apps/web/src/features/pois/utils/get-poi-coordinates.ts
+++ b/apps/web/src/features/pois/utils/get-poi-coordinates.ts
@@ -1,0 +1,48 @@
+import type { GooglePlace, MapPoi, Poi, SavedPoiListItem } from "../types/poi-display-types";
+
+function parseCoordinates(
+  lat: number | undefined,
+  lng: number | undefined
+): { lat: number; lng: number } | null {
+  if (typeof lat !== "number" || typeof lng !== "number") return null;
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+  if (lat === 0 && lng === 0) return null;
+  return { lat, lng };
+}
+
+function toMapPoi(id: string, lat: number, lng: number, name?: string | null): MapPoi {
+  const label = name?.trim();
+  return label ? { id, lat, lng, label } : { id, lat, lng };
+}
+
+export function getCoordinatesFromGooglePlace(place: GooglePlace): MapPoi | null {
+  const coords = parseCoordinates(place.latitude, place.longitude);
+  if (!coords) return null;
+
+  return toMapPoi(place.placeId ?? "", coords.lat, coords.lng, place.name);
+}
+
+function getCoordinatesFromPoi(poi: Poi, id: string): MapPoi | null {
+  const coords = parseCoordinates(poi.latitude, poi.longitude);
+  if (!coords) return null;
+
+  return toMapPoi(id, coords.lat, coords.lng, poi.name);
+}
+
+export function getCoordinatesFromSavedPoi(savedPoi: SavedPoiListItem): MapPoi | null {
+  if (savedPoi.googlePlaceCache) {
+    const fromCache = getCoordinatesFromGooglePlace(savedPoi.googlePlaceCache);
+    if (fromCache) {
+      return {
+        ...fromCache,
+        id: savedPoi.id ?? savedPoi.googlePlaceCache.placeId ?? fromCache.id,
+      };
+    }
+  }
+
+  if (savedPoi.poi) {
+    return getCoordinatesFromPoi(savedPoi.poi, savedPoi.id ?? savedPoi.poi.id ?? "");
+  }
+
+  return null;
+}

--- a/apps/web/src/features/pois/utils/get-poi-coordinates.ts
+++ b/apps/web/src/features/pois/utils/get-poi-coordinates.ts
@@ -15,6 +15,13 @@ function toMapPoi(id: string, lat: number, lng: number, name?: string | null): M
   return label ? { id, lat, lng, label } : { id, lat, lng };
 }
 
+export function getSavedPoiMapId(savedPoi: SavedPoiListItem): string | null {
+  if (savedPoi.id) return savedPoi.id;
+  if (savedPoi.googlePlaceCache?.placeId) return savedPoi.googlePlaceCache.placeId;
+  if (savedPoi.poi?.id) return savedPoi.poi.id;
+  return null;
+}
+
 export function getCoordinatesFromGooglePlace(place: GooglePlace): MapPoi | null {
   const coords = parseCoordinates(place.latitude, place.longitude);
   if (!coords) return null;
@@ -30,18 +37,20 @@ function getCoordinatesFromPoi(poi: Poi, id: string): MapPoi | null {
 }
 
 export function getCoordinatesFromSavedPoi(savedPoi: SavedPoiListItem): MapPoi | null {
+  const mapId = getSavedPoiMapId(savedPoi);
+
   if (savedPoi.googlePlaceCache) {
     const fromCache = getCoordinatesFromGooglePlace(savedPoi.googlePlaceCache);
     if (fromCache) {
       return {
         ...fromCache,
-        id: savedPoi.id ?? savedPoi.googlePlaceCache.placeId ?? fromCache.id,
+        id: mapId ?? fromCache.id,
       };
     }
   }
 
   if (savedPoi.poi) {
-    return getCoordinatesFromPoi(savedPoi.poi, savedPoi.id ?? savedPoi.poi.id ?? "");
+    return getCoordinatesFromPoi(savedPoi.poi, mapId ?? "");
   }
 
   return null;

--- a/apps/web/src/lib/i18n/locales/en/poi.json
+++ b/apps/web/src/lib/i18n/locales/en/poi.json
@@ -4,6 +4,7 @@
     "google": "Google"
   },
   "addressUnknown": "No address",
+  "select": "Select {name}",
   "openingHours": {
     "openNow": "Open now",
     "closedNow": "Closed",

--- a/apps/web/src/lib/i18n/locales/fr/poi.json
+++ b/apps/web/src/lib/i18n/locales/fr/poi.json
@@ -4,6 +4,7 @@
     "google": "Google"
   },
   "addressUnknown": "Aucune adresse",
+  "select": "Sélectionner {name}",
   "openingHours": {
     "openNow": "Ouvert maintenant",
     "closedNow": "Fermé",


### PR DESCRIPTION
## 📝 Description

Intègre sur la carte les POI issus de la recherche Explore et des listes, avec des markers au style Nirby, puis une sélection synchronisée entre la liste et la carte (centrage, surbrillance, retour à la vue liste sur mobile).

## 🎯 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [x] 🎨 Style/UI update (no functional changes)
- [ ] ♻️ Code refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [x] ✅ Test update

## 🔗 Related Issues

Closes NIR-67  
Related to NIR-83, NIR-72, NIR-73, NIR-71, NIR-70

## 🚀 Changes Made

- Helpers de coordonnées POI (`MapPoi`, `getCoordinatesFromGooglePlace`, `getCoordinatesFromSavedPoi`, `getSavedPoiMapId`)
- Couche réutilisable `PoiMarkersLayer` avec `fitBounds`, markers custom orange et popups thémées
- Affichage des résultats Explore et des POI de liste sur la carte
- Sélection bidirectionnelle liste ↔ marker : centrage `flyTo` avec zoom plancher, `mapMode` mobile, désélection au clic carte
- `PoiCard` cliquable avec surbrillance et scroll automatique vers la carte sélectionnée
- Tests unitaires (shell, map, POI, vues Explore/Listes) et clé i18n `poi.select` (fr/en)

## 🧪 Testing

- [x] Tested locally with `pnpm dev`
- [x] All quality checks pass (`pnpm lint`)
- [ ] Unit tests pass (`pnpm test`)
- [ ] Database migrations applied if needed

## 📸 Screenshots/Videos

Screenshots recommandés : markers sur Explore, détail de liste, sélection d’un POI (desktop + mobile avec sheet replié).

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated if needed
- [x] No console errors or warnings
- [x] Removed any debug code