### PR TITLE
feat(web): add share and edit-link UI (#152)

### DIFF
--- a/apps/web/src/features/lists/components/share-list-dialog.test.tsx
+++ b/apps/web/src/features/lists/components/share-list-dialog.test.tsx
@@ -1,0 +1,180 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { toast } from "sonner";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useGenerateEditLink } from "../hooks/use-generate-edit-link";
+import { useRevokeEditLink } from "../hooks/use-revoke-edit-link";
+import { useShareList } from "../hooks/use-share-list";
+import { useUnshareList } from "../hooks/use-unshare-list";
+
+import { ShareListDialog } from "./share-list-dialog";
+
+vi.mock("../hooks/use-share-list", () => ({
+  useShareList: vi.fn(),
+}));
+
+vi.mock("../hooks/use-unshare-list", () => ({
+  useUnshareList: vi.fn(),
+}));
+
+vi.mock("../hooks/use-generate-edit-link", () => ({
+  useGenerateEditLink: vi.fn(),
+}));
+
+vi.mock("../hooks/use-revoke-edit-link", () => ({
+  useRevokeEditLink: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-error-message", () => ({
+  useErrorMessage: () => () => "API error message",
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+function mockMutation(mutateAsync: ReturnType<typeof vi.fn>) {
+  return { mutateAsync, isPending: false };
+}
+
+describe("ShareListDialog", () => {
+  const onOpenChange = vi.fn();
+  const shareList = vi.fn();
+  const unshareList = vi.fn();
+  const generateEditLink = vi.fn();
+  const revokeEditLink = vi.fn();
+  const writeText = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    shareList.mockResolvedValue({ shareLink: "https://example.com/shared/new-token" });
+    unshareList.mockResolvedValue({ message: "ok" });
+    generateEditLink.mockResolvedValue({
+      editLink: "https://example.com/list/list-1/join?editToken=new-edit",
+    });
+    revokeEditLink.mockResolvedValue({ message: "ok" });
+    writeText.mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    vi.mocked(useShareList).mockReturnValue(
+      mockMutation(shareList) as unknown as ReturnType<typeof useShareList>
+    );
+    vi.mocked(useUnshareList).mockReturnValue(
+      mockMutation(unshareList) as unknown as ReturnType<typeof useUnshareList>
+    );
+    vi.mocked(useGenerateEditLink).mockReturnValue(
+      mockMutation(generateEditLink) as unknown as ReturnType<typeof useGenerateEditLink>
+    );
+    vi.mocked(useRevokeEditLink).mockReturnValue(
+      mockMutation(revokeEditLink) as unknown as ReturnType<typeof useRevokeEditLink>
+    );
+  });
+
+  it("generates a read link when none exists", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ShareListDialog
+        listId="list-1"
+        shareToken={null}
+        editToken={null}
+        open
+        onOpenChange={onOpenChange}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "share.readLink.generate" }));
+
+    expect(shareList).toHaveBeenCalledWith({ listId: "list-1" });
+    expect(screen.getByDisplayValue("https://example.com/shared/new-token")).toBeInTheDocument();
+  });
+
+  it("generates an edit link when none exists", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ShareListDialog
+        listId="list-1"
+        shareToken={null}
+        editToken={null}
+        open
+        onOpenChange={onOpenChange}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "share.editLink.generate" }));
+
+    expect(generateEditLink).toHaveBeenCalledWith({ listId: "list-1" });
+    expect(
+      screen.getByDisplayValue("https://example.com/list/list-1/join?editToken=new-edit")
+    ).toBeInTheDocument();
+  });
+
+  it("copies an existing read link", async () => {
+    const user = userEvent.setup();
+    const expectedUrl = `${window.location.origin}/shared/abc123`;
+
+    render(
+      <ShareListDialog
+        listId="list-1"
+        shareToken="abc123"
+        editToken={null}
+        open
+        onOpenChange={onOpenChange}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "share.readLink.copy" }));
+
+    expect(writeText).toHaveBeenCalledWith(expectedUrl);
+    expect(toast.success).toHaveBeenCalledWith("share.copySuccess");
+  });
+
+  it("revokes a read link after inline confirmation", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ShareListDialog
+        listId="list-1"
+        shareToken="abc123"
+        editToken={null}
+        open
+        onOpenChange={onOpenChange}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "share.readLink.revoke" }));
+    expect(unshareList).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "share.readLink.revokeConfirm" }));
+
+    expect(unshareList).toHaveBeenCalledWith({ listId: "list-1" });
+    expect(toast.success).toHaveBeenCalledWith("share.revokeSuccess");
+    expect(screen.getByText("share.readLink.empty")).toBeInTheDocument();
+  });
+
+  it("revokes an edit link after inline confirmation", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ShareListDialog
+        listId="list-1"
+        shareToken={null}
+        editToken="edit-1"
+        open
+        onOpenChange={onOpenChange}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "share.editLink.revoke" }));
+    await user.click(screen.getByRole("button", { name: "share.editLink.revokeConfirm" }));
+
+    expect(revokeEditLink).toHaveBeenCalledWith({ listId: "list-1" });
+    expect(toast.success).toHaveBeenCalledWith("share.revokeSuccess");
+    expect(screen.getByText("share.editLink.empty")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/lists/components/share-list-dialog.test.tsx
+++ b/apps/web/src/features/lists/components/share-list-dialog.test.tsx
@@ -58,7 +58,10 @@ describe("ShareListDialog", () => {
     });
     revokeEditLink.mockResolvedValue({ message: "ok" });
     writeText.mockResolvedValue(undefined);
-    Object.assign(navigator, { clipboard: { writeText } });
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
 
     vi.mocked(useShareList).mockReturnValue(
       mockMutation(shareList) as unknown as ReturnType<typeof useShareList>
@@ -116,6 +119,11 @@ describe("ShareListDialog", () => {
 
   it("copies an existing read link", async () => {
     const user = userEvent.setup();
+    const clipboardWrite = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: clipboardWrite },
+    });
     const expectedUrl = `${window.location.origin}/shared/abc123`;
 
     render(
@@ -130,7 +138,7 @@ describe("ShareListDialog", () => {
 
     await user.click(screen.getByRole("button", { name: "share.readLink.copy" }));
 
-    expect(writeText).toHaveBeenCalledWith(expectedUrl);
+    expect(clipboardWrite).toHaveBeenCalledWith(expectedUrl);
     expect(toast.success).toHaveBeenCalledWith("share.copySuccess");
   });
 

--- a/apps/web/src/features/lists/components/share-list-dialog.tsx
+++ b/apps/web/src/features/lists/components/share-list-dialog.tsx
@@ -1,0 +1,340 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { useGenerateEditLink } from "../hooks/use-generate-edit-link";
+import { useRevokeEditLink } from "../hooks/use-revoke-edit-link";
+import { useShareList } from "../hooks/use-share-list";
+import { useUnshareList } from "../hooks/use-unshare-list";
+import { buildEditLinkUrl, buildShareUrl } from "../utils/share-links.utils";
+
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+  Input,
+} from "@/components/ui";
+import { useErrorMessage } from "@/hooks/use-error-message";
+import { useMediaQuery } from "@/hooks/use-media-query";
+
+export type ShareListDialogProps = {
+  listId: string;
+  shareToken: string | null;
+  editToken: string | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+type LinkKind = "read" | "edit";
+
+/** Share dialog: Dialog on desktop, Drawer on mobile (same pattern as AddToListPicker). */
+export function ShareListDialog(props: ShareListDialogProps) {
+  const isMobile = useMediaQuery("(max-width: 768px)");
+
+  return isMobile ? <ShareListDrawer {...props} /> : <ShareListDesktopDialog {...props} />;
+}
+
+function useShareListDialog({ listId, shareToken, editToken, onOpenChange }: ShareListDialogProps) {
+  const tLists = useTranslations("lists");
+  const tCommon = useTranslations("common");
+  const getErrorMessage = useErrorMessage();
+  const [shareUrlOverride, setShareUrlOverride] = useState<string | null>(null);
+  const [editUrlOverride, setEditUrlOverride] = useState<string | null>(null);
+  const [shareCleared, setShareCleared] = useState(false);
+  const [editCleared, setEditCleared] = useState(false);
+  const [confirming, setConfirming] = useState<LinkKind | null>(null);
+
+  const { mutateAsync: shareList, isPending: isSharing } = useShareList();
+  const { mutateAsync: unshareList, isPending: isUnsharing } = useUnshareList();
+  const { mutateAsync: generateEditLink, isPending: isGeneratingEdit } = useGenerateEditLink();
+  const { mutateAsync: revokeEditLink, isPending: isRevokingEdit } = useRevokeEditLink();
+
+  const origin = typeof window === "undefined" ? "" : window.location.origin;
+  const shareUrl = shareCleared
+    ? null
+    : (shareUrlOverride ?? (shareToken ? buildShareUrl(origin, shareToken) : null));
+  const editUrl = editCleared
+    ? null
+    : (editUrlOverride ?? (editToken ? buildEditLinkUrl(origin, listId, editToken) : null));
+
+  function resetLocalState() {
+    setShareUrlOverride(null);
+    setEditUrlOverride(null);
+    setShareCleared(false);
+    setEditCleared(false);
+    setConfirming(null);
+  }
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen) {
+      resetLocalState();
+    }
+    onOpenChange(nextOpen);
+  }
+
+  async function handleGenerate(kind: LinkKind) {
+    try {
+      if (kind === "read") {
+        const data = await shareList({ listId });
+        setShareCleared(false);
+        setShareUrlOverride(data.shareLink);
+      } else {
+        const data = await generateEditLink({ listId });
+        setEditCleared(false);
+        setEditUrlOverride(data.editLink);
+      }
+    } catch (error) {
+      toast.error(tLists("share.generateError"), { description: getErrorMessage(error) });
+    }
+  }
+
+  async function handleCopy(url: string) {
+    try {
+      await navigator.clipboard.writeText(url);
+      toast.success(tLists("share.copySuccess"));
+    } catch {
+      toast.error(tLists("share.copyError"));
+    }
+  }
+
+  async function handleRevoke(kind: LinkKind) {
+    try {
+      if (kind === "read") {
+        await unshareList({ listId });
+        setShareUrlOverride(null);
+        setShareCleared(true);
+      } else {
+        await revokeEditLink({ listId });
+        setEditUrlOverride(null);
+        setEditCleared(true);
+      }
+      setConfirming(null);
+      toast.success(tLists("share.revokeSuccess"));
+    } catch (error) {
+      toast.error(tLists("share.revokeError"), { description: getErrorMessage(error) });
+    }
+  }
+
+  return {
+    tLists,
+    tCommon,
+    shareUrl,
+    editUrl,
+    confirming,
+    setConfirming,
+    isSharing,
+    isUnsharing,
+    isGeneratingEdit,
+    isRevokingEdit,
+    handleGenerate,
+    handleCopy,
+    handleRevoke,
+    handleOpenChange,
+  };
+}
+
+type ShareDialogState = ReturnType<typeof useShareListDialog>;
+
+function ShareListBody({
+  tLists,
+  tCommon,
+  shareUrl,
+  editUrl,
+  confirming,
+  setConfirming,
+  isSharing,
+  isUnsharing,
+  isGeneratingEdit,
+  isRevokingEdit,
+  handleGenerate,
+  handleCopy,
+  handleRevoke,
+}: ShareDialogState) {
+  return (
+    <div className="grid gap-6">
+      <ShareLinkSection
+        title={tLists("share.readLink.title")}
+        description={tLists("share.readLink.description")}
+        emptyLabel={tLists("share.readLink.empty")}
+        generateLabel={tLists("share.readLink.generate")}
+        copyLabel={tLists("share.readLink.copy")}
+        revokeLabel={tLists("share.readLink.revoke")}
+        revokeConfirmLabel={tLists("share.readLink.revokeConfirm")}
+        cancelLabel={tCommon("buttons.cancel")}
+        url={shareUrl}
+        isGenerating={isSharing}
+        isRevoking={isUnsharing}
+        confirming={confirming === "read"}
+        onGenerate={() => handleGenerate("read")}
+        onCopy={() => shareUrl && handleCopy(shareUrl)}
+        onRequestRevoke={() => setConfirming("read")}
+        onCancelRevoke={() => setConfirming(null)}
+        onConfirmRevoke={() => handleRevoke("read")}
+      />
+      <ShareLinkSection
+        title={tLists("share.editLink.title")}
+        description={tLists("share.editLink.description")}
+        emptyLabel={tLists("share.editLink.empty")}
+        generateLabel={tLists("share.editLink.generate")}
+        copyLabel={tLists("share.editLink.copy")}
+        revokeLabel={tLists("share.editLink.revoke")}
+        revokeConfirmLabel={tLists("share.editLink.revokeConfirm")}
+        cancelLabel={tCommon("buttons.cancel")}
+        url={editUrl}
+        isGenerating={isGeneratingEdit}
+        isRevoking={isRevokingEdit}
+        confirming={confirming === "edit"}
+        onGenerate={() => handleGenerate("edit")}
+        onCopy={() => editUrl && handleCopy(editUrl)}
+        onRequestRevoke={() => setConfirming("edit")}
+        onCancelRevoke={() => setConfirming(null)}
+        onConfirmRevoke={() => handleRevoke("edit")}
+      />
+    </div>
+  );
+}
+
+function ShareLinkSection({
+  title,
+  description,
+  emptyLabel,
+  generateLabel,
+  copyLabel,
+  revokeLabel,
+  revokeConfirmLabel,
+  cancelLabel,
+  url,
+  isGenerating,
+  isRevoking,
+  confirming,
+  onGenerate,
+  onCopy,
+  onRequestRevoke,
+  onCancelRevoke,
+  onConfirmRevoke,
+}: {
+  title: string;
+  description: string;
+  emptyLabel: string;
+  generateLabel: string;
+  copyLabel: string;
+  revokeLabel: string;
+  revokeConfirmLabel: string;
+  cancelLabel: string;
+  url: string | null;
+  isGenerating: boolean;
+  isRevoking: boolean;
+  confirming: boolean;
+  onGenerate: () => void;
+  onCopy: () => void;
+  onRequestRevoke: () => void;
+  onCancelRevoke: () => void;
+  onConfirmRevoke: () => void;
+}) {
+  return (
+    <section className="grid gap-3">
+      <div className="grid gap-1">
+        <h3 className="text-sm font-medium">{title}</h3>
+        <p className="text-sm text-muted-foreground">{description}</p>
+      </div>
+
+      {url ? (
+        <div className="grid gap-2">
+          <Input readOnly value={url} aria-label={title} />
+          {confirming ? (
+            <div className="flex flex-wrap gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={onCancelRevoke}
+                disabled={isRevoking}
+              >
+                {cancelLabel}
+              </Button>
+              <Button
+                type="button"
+                variant="destructive"
+                size="sm"
+                loading={isRevoking}
+                disabled={isRevoking}
+                onClick={onConfirmRevoke}
+              >
+                {revokeConfirmLabel}
+              </Button>
+            </div>
+          ) : (
+            <div className="flex flex-wrap gap-2">
+              <Button type="button" variant="outline" size="sm" onClick={onCopy}>
+                {copyLabel}
+              </Button>
+              <Button type="button" variant="destructive" size="sm" onClick={onRequestRevoke}>
+                {revokeLabel}
+              </Button>
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className="grid gap-2">
+          <p className="text-sm text-muted-foreground">{emptyLabel}</p>
+          <Button
+            type="button"
+            size="sm"
+            className="w-fit"
+            loading={isGenerating}
+            disabled={isGenerating}
+            onClick={onGenerate}
+          >
+            {generateLabel}
+          </Button>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function ShareListDesktopDialog(props: ShareListDialogProps) {
+  const tLists = useTranslations("lists");
+  const state = useShareListDialog(props);
+
+  return (
+    <Dialog open={props.open} onOpenChange={state.handleOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{tLists("share.title")}</DialogTitle>
+          <DialogDescription>{tLists("share.description")}</DialogDescription>
+        </DialogHeader>
+        <ShareListBody {...state} />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function ShareListDrawer(props: ShareListDialogProps) {
+  const tLists = useTranslations("lists");
+  const state = useShareListDialog(props);
+
+  return (
+    <Drawer open={props.open} onOpenChange={state.handleOpenChange}>
+      <DrawerContent>
+        <DrawerHeader>
+          <DrawerTitle>{tLists("share.title")}</DrawerTitle>
+          <DrawerDescription>{tLists("share.description")}</DrawerDescription>
+        </DrawerHeader>
+        <div className="px-4 pb-4">
+          <ShareListBody {...state} />
+        </div>
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/apps/web/src/features/lists/constants/lists.constants.test.ts
+++ b/apps/web/src/features/lists/constants/lists.constants.test.ts
@@ -4,6 +4,8 @@ import {
   buildListsNavigationSearchParams,
   canDeleteList,
   canEditList,
+  canManageCollaborators,
+  canManageShareAndEditLinks,
   parseListId,
 } from "./lists.constants";
 
@@ -29,6 +31,32 @@ describe("canDeleteList", () => {
     expect(canDeleteList("EDITOR")).toBe(false);
     expect(canDeleteList("VIEWER")).toBe(false);
     expect(canDeleteList(undefined)).toBe(false);
+  });
+});
+
+describe("canManageShareAndEditLinks", () => {
+  it("allows OWNER and ADMIN", () => {
+    expect(canManageShareAndEditLinks("OWNER")).toBe(true);
+    expect(canManageShareAndEditLinks("ADMIN")).toBe(true);
+  });
+
+  it("denies EDITOR, VIEWER and undefined", () => {
+    expect(canManageShareAndEditLinks("EDITOR")).toBe(false);
+    expect(canManageShareAndEditLinks("VIEWER")).toBe(false);
+    expect(canManageShareAndEditLinks(undefined)).toBe(false);
+  });
+});
+
+describe("canManageCollaborators", () => {
+  it("allows OWNER and ADMIN", () => {
+    expect(canManageCollaborators("OWNER")).toBe(true);
+    expect(canManageCollaborators("ADMIN")).toBe(true);
+  });
+
+  it("denies EDITOR, VIEWER and undefined", () => {
+    expect(canManageCollaborators("EDITOR")).toBe(false);
+    expect(canManageCollaborators("VIEWER")).toBe(false);
+    expect(canManageCollaborators(undefined)).toBe(false);
   });
 });
 

--- a/apps/web/src/features/lists/constants/lists.constants.ts
+++ b/apps/web/src/features/lists/constants/lists.constants.ts
@@ -61,6 +61,12 @@ export const EDITABLE_LIST_ROLES = ["OWNER", "ADMIN", "EDITOR"] as const;
 /** Collaborator / owner roles that may delete a list (mirrors API `canDeleteList`). */
 export const DELETABLE_LIST_ROLES = ["OWNER", "ADMIN"] as const;
 
+/** Roles that may manage share tokens and edit-invite links (mirrors API `canManageShareAndEditLinks`). */
+export const SHARE_MANAGE_ROLES = ["OWNER", "ADMIN"] as const;
+
+/** Roles that may invite, remove, or change collaborator roles (mirrors API `canManageCollaborators`). */
+export const COLLABORATOR_MANAGE_ROLES = ["OWNER", "ADMIN"] as const;
+
 export type ListRole = (typeof EDITABLE_LIST_ROLES)[number] | "VIEWER";
 
 /**
@@ -81,5 +87,26 @@ export function canDeleteList(role?: ListRole): boolean {
 export function canEditList(role?: ListRole): boolean {
   return (
     role !== undefined && EDITABLE_LIST_ROLES.includes(role as (typeof EDITABLE_LIST_ROLES)[number])
+  );
+}
+
+/**
+ * Whether the current user may manage share tokens and edit-invite links.
+ * EDITOR, VIEWER and missing role → no share management.
+ */
+export function canManageShareAndEditLinks(role?: ListRole): boolean {
+  return (
+    role !== undefined && SHARE_MANAGE_ROLES.includes(role as (typeof SHARE_MANAGE_ROLES)[number])
+  );
+}
+
+/**
+ * Whether the current user may invite, remove, or change collaborator roles.
+ * EDITOR, VIEWER and missing role → no collaborator management.
+ */
+export function canManageCollaborators(role?: ListRole): boolean {
+  return (
+    role !== undefined &&
+    COLLABORATOR_MANAGE_ROLES.includes(role as (typeof COLLABORATOR_MANAGE_ROLES)[number])
   );
 }

--- a/apps/web/src/features/lists/hooks/use-collaborators.test.tsx
+++ b/apps/web/src/features/lists/hooks/use-collaborators.test.tsx
@@ -1,0 +1,94 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useCollaborators } from "./use-collaborators";
+
+const getCollaborators = vi.fn();
+const useAuth = vi.fn();
+
+vi.mock("@/features/auth", () => ({
+  useAuth: () => useAuth(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  getCollaborators: (...args: unknown[]) => getCollaborators(...args),
+}));
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe("useCollaborators", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    useAuth.mockReturnValue({ user: { id: "user-1" } });
+    getCollaborators.mockResolvedValue({
+      data: {
+        collaborators: [{ id: "collab-1" }],
+        pagination: { page: 1, totalPages: 1, total: 1 },
+      },
+    });
+  });
+
+  it("does not fetch when listId is undefined", () => {
+    renderHook(() => useCollaborators(undefined), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    expect(getCollaborators).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch when user is absent", () => {
+    useAuth.mockReturnValue({ user: null });
+
+    renderHook(() => useCollaborators("list-1"), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    expect(getCollaborators).not.toHaveBeenCalled();
+  });
+
+  it("fetches collaborators with listId and filters", async () => {
+    const filters = { page: 1, limit: 10 };
+    const { result } = renderHook(() => useCollaborators("list-1", filters), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(getCollaborators).toHaveBeenCalledWith({
+      path: { listId: "list-1" },
+      query: filters,
+    });
+    expect(result.current.data).toEqual({
+      collaborators: [{ id: "collab-1" }],
+      pagination: { page: 1, totalPages: 1, total: 1 },
+    });
+  });
+
+  it("throws API error when response has no data", async () => {
+    const apiError = { message: "Not found" };
+    getCollaborators.mockResolvedValue({ error: apiError });
+
+    const { result } = renderHook(() => useCollaborators("list-1"), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error).toEqual(apiError);
+  });
+});

--- a/apps/web/src/features/lists/hooks/use-collaborators.ts
+++ b/apps/web/src/features/lists/hooks/use-collaborators.ts
@@ -1,0 +1,47 @@
+"use client";
+
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+
+import { useAuth } from "@/features/auth";
+import { getCollaborators } from "@/lib/api";
+import type { GetCollaboratorsData } from "@/lib/api";
+import { queryKeys } from "@/lib/api/query-keys";
+
+/** Query params for `GET /list/:listId/collaborators` (page, limit). */
+export type CollaboratorsFilters = GetCollaboratorsData["query"];
+
+/** Default page size — matches API default (20). */
+export const COLLABORATORS_PAGE_SIZE = 20;
+
+/**
+ * Fetches collaborators for a list with optional pagination.
+ *
+ * The query is disabled until `listId` is defined and the user is authenticated.
+ * API errors are thrown so they can be handled with {@link useErrorMessage}.
+ * Uses `keepPreviousData` to avoid empty UI flashes when paginating.
+ */
+export function useCollaborators(listId: string | undefined, filters?: CollaboratorsFilters) {
+  const { user } = useAuth();
+
+  return useQuery({
+    queryKey: queryKeys.lists.collaborators.list(listId ?? "", filters),
+    enabled: Boolean(listId && user),
+    queryFn: async () => {
+      if (!listId) {
+        throw new Error("listId is required");
+      }
+
+      const response = await getCollaborators({
+        path: { listId },
+        query: filters,
+      });
+
+      if (response.data) {
+        return response.data;
+      }
+
+      throw response.error;
+    },
+    placeholderData: keepPreviousData,
+  });
+}

--- a/apps/web/src/features/lists/hooks/use-generate-edit-link.test.tsx
+++ b/apps/web/src/features/lists/hooks/use-generate-edit-link.test.tsx
@@ -1,0 +1,86 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useGenerateEditLink } from "./use-generate-edit-link";
+
+import { generateEditLink } from "@/lib/api";
+import { queryKeys } from "@/lib/api/query-keys";
+
+vi.mock("@/lib/api", () => ({
+  generateEditLink: vi.fn(),
+}));
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+function apiResponse(value: { data?: unknown; error?: unknown }) {
+  return value as Awaited<ReturnType<typeof generateEditLink>>;
+}
+
+describe("useGenerateEditLink", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+  });
+
+  it("calls generateEditLink and returns data on success", async () => {
+    const data = { editLink: "https://example.com/list/list-1/join?editToken=abc" };
+    vi.mocked(generateEditLink).mockResolvedValue(apiResponse({ data }));
+
+    const { result } = renderHook(() => useGenerateEditLink(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    let resolved: unknown;
+    await act(async () => {
+      resolved = await result.current.mutateAsync({ listId: "list-1" });
+    });
+
+    expect(generateEditLink).toHaveBeenCalledWith({ path: { listId: "list-1" } });
+    expect(resolved).toEqual(data);
+  });
+
+  it("invalidates list caches on success", async () => {
+    vi.mocked(generateEditLink).mockResolvedValue(
+      apiResponse({ data: { editLink: "https://example.com/list/list-1/join?editToken=abc" } })
+    );
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useGenerateEditLink(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ listId: "list-1" });
+    });
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.lists.all });
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.lists.detail("list-1") });
+    });
+  });
+
+  it("throws API error when response has no data", async () => {
+    const apiError = { message: "Forbidden" };
+    vi.mocked(generateEditLink).mockResolvedValue(apiResponse({ error: apiError }));
+
+    const { result } = renderHook(() => useGenerateEditLink(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await expect(
+      act(async () => {
+        await result.current.mutateAsync({ listId: "list-1" });
+      })
+    ).rejects.toEqual(apiError);
+  });
+});

--- a/apps/web/src/features/lists/hooks/use-generate-edit-link.ts
+++ b/apps/web/src/features/lists/hooks/use-generate-edit-link.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { generateEditLink } from "@/lib/api";
+import { queryKeys } from "@/lib/api/query-keys";
+
+/** Payload for `POST /list/:listId/edit-link`. */
+export type GenerateEditLinkInput = {
+  listId: string;
+};
+
+/**
+ * Generates an edit-invite link for a list.
+ *
+ * On success, invalidates the list index and the list detail (`editToken`).
+ * API errors are thrown so they can be handled with {@link useErrorMessage}.
+ */
+export function useGenerateEditLink() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ listId }: GenerateEditLinkInput) => {
+      const response = await generateEditLink({ path: { listId } });
+
+      if (response.data) {
+        return response.data;
+      }
+
+      throw response.error;
+    },
+    onSuccess: (_data, { listId }) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.lists.all });
+      queryClient.invalidateQueries({ queryKey: queryKeys.lists.detail(listId) });
+    },
+  });
+}

--- a/apps/web/src/features/lists/hooks/use-invite-collaborator.test.tsx
+++ b/apps/web/src/features/lists/hooks/use-invite-collaborator.test.tsx
@@ -1,0 +1,96 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useInviteCollaborator } from "./use-invite-collaborator";
+
+import { inviteCollaborator } from "@/lib/api";
+import { queryKeys } from "@/lib/api/query-keys";
+
+vi.mock("@/lib/api", () => ({
+  inviteCollaborator: vi.fn(),
+}));
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+function apiResponse(value: { data?: unknown; error?: unknown }) {
+  return value as Awaited<ReturnType<typeof inviteCollaborator>>;
+}
+
+describe("useInviteCollaborator", () => {
+  let queryClient: QueryClient;
+  const input = {
+    listId: "list-1",
+    body: { email: "alex@example.com", role: "EDITOR" as const },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+  });
+
+  it("calls inviteCollaborator and returns data on success", async () => {
+    const data = { inviteLink: "https://example.com/accept?token=abc", emailSent: true };
+    vi.mocked(inviteCollaborator).mockResolvedValue(apiResponse({ data }));
+
+    const { result } = renderHook(() => useInviteCollaborator(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    let resolved: unknown;
+    await act(async () => {
+      resolved = await result.current.mutateAsync(input);
+    });
+
+    expect(inviteCollaborator).toHaveBeenCalledWith({
+      path: { listId: "list-1" },
+      body: input.body,
+    });
+    expect(resolved).toEqual(data);
+  });
+
+  it("invalidates collaborator and list caches on success", async () => {
+    vi.mocked(inviteCollaborator).mockResolvedValue(
+      apiResponse({ data: { inviteLink: "https://example.com/accept", emailSent: true } })
+    );
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useInviteCollaborator(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync(input);
+    });
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: queryKeys.lists.collaborators.all("list-1"),
+      });
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.lists.detail("list-1") });
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.lists.all });
+    });
+  });
+
+  it("throws API error when response has no data", async () => {
+    const apiError = { message: "Forbidden" };
+    vi.mocked(inviteCollaborator).mockResolvedValue(apiResponse({ error: apiError }));
+
+    const { result } = renderHook(() => useInviteCollaborator(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await expect(
+      act(async () => {
+        await result.current.mutateAsync(input);
+      })
+    ).rejects.toEqual(apiError);
+  });
+});

--- a/apps/web/src/features/lists/hooks/use-invite-collaborator.ts
+++ b/apps/web/src/features/lists/hooks/use-invite-collaborator.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { inviteCollaborator } from "@/lib/api";
+import type { InviteCollaboratorData } from "@/lib/api";
+import { queryKeys } from "@/lib/api/query-keys";
+
+/** Payload for `POST /list/:listId/collaborators/invite`. */
+export type InviteCollaboratorInput = {
+  listId: string;
+  body: InviteCollaboratorData["body"];
+};
+
+/**
+ * Invites a collaborator to a list by email.
+ *
+ * On success, invalidates collaborators, list detail, and the list index.
+ * API errors are thrown so they can be handled with {@link useErrorMessage}.
+ */
+export function useInviteCollaborator() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ listId, body }: InviteCollaboratorInput) => {
+      const response = await inviteCollaborator({ path: { listId }, body });
+
+      if (response.data) {
+        return response.data;
+      }
+
+      throw response.error;
+    },
+    onSuccess: (_data, { listId }) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.lists.collaborators.all(listId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.lists.detail(listId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.lists.all });
+    },
+  });
+}

--- a/apps/web/src/features/lists/hooks/use-join-list-by-edit-link.test.tsx
+++ b/apps/web/src/features/lists/hooks/use-join-list-by-edit-link.test.tsx
@@ -1,0 +1,85 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useJoinListByEditLink } from "./use-join-list-by-edit-link";
+
+import { joinListByEditLink } from "@/lib/api";
+import { queryKeys } from "@/lib/api/query-keys";
+
+vi.mock("@/lib/api", () => ({
+  joinListByEditLink: vi.fn(),
+}));
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+function apiResponse(value: { data?: unknown; error?: unknown }) {
+  return value as Awaited<ReturnType<typeof joinListByEditLink>>;
+}
+
+describe("useJoinListByEditLink", () => {
+  let queryClient: QueryClient;
+  const joinedList = { id: "list-1", name: "Paris" };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+  });
+
+  it("calls joinListByEditLink and returns data on success", async () => {
+    const data = { list: joinedList };
+    vi.mocked(joinListByEditLink).mockResolvedValue(apiResponse({ data }));
+
+    const { result } = renderHook(() => useJoinListByEditLink(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    let resolved: unknown;
+    await act(async () => {
+      resolved = await result.current.mutateAsync({ editToken: "edit-token" });
+    });
+
+    expect(joinListByEditLink).toHaveBeenCalledWith({ query: { editToken: "edit-token" } });
+    expect(resolved).toEqual(data);
+  });
+
+  it("invalidates list caches on success", async () => {
+    vi.mocked(joinListByEditLink).mockResolvedValue(apiResponse({ data: { list: joinedList } }));
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useJoinListByEditLink(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ editToken: "edit-token" });
+    });
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.lists.all });
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.lists.detail("list-1") });
+    });
+  });
+
+  it("throws API error when response has no data", async () => {
+    const apiError = { message: "Invalid token" };
+    vi.mocked(joinListByEditLink).mockResolvedValue(apiResponse({ error: apiError }));
+
+    const { result } = renderHook(() => useJoinListByEditLink(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await expect(
+      act(async () => {
+        await result.current.mutateAsync({ editToken: "bad-token" });
+      })
+    ).rejects.toEqual(apiError);
+  });
+});

--- a/apps/web/src/features/lists/hooks/use-join-list-by-edit-link.ts
+++ b/apps/web/src/features/lists/hooks/use-join-list-by-edit-link.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { joinListByEditLink } from "@/lib/api";
+import { queryKeys } from "@/lib/api/query-keys";
+
+/** Payload for `POST /list/join?editToken=`. */
+export type JoinListByEditLinkInput = {
+  editToken: string;
+};
+
+/**
+ * Joins a list using an edit-invite token.
+ *
+ * On success, invalidates the list index and the joined list detail.
+ * API errors are thrown so they can be handled with {@link useErrorMessage}.
+ */
+export function useJoinListByEditLink() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ editToken }: JoinListByEditLinkInput) => {
+      const response = await joinListByEditLink({ query: { editToken } });
+
+      if (response.data) {
+        return response.data;
+      }
+
+      throw response.error;
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.lists.all });
+      queryClient.invalidateQueries({ queryKey: queryKeys.lists.detail(data.list.id) });
+    },
+  });
+}

--- a/apps/web/src/features/lists/hooks/use-join-list-by-invite.test.tsx
+++ b/apps/web/src/features/lists/hooks/use-join-list-by-invite.test.tsx
@@ -1,0 +1,89 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useJoinListByInvite } from "./use-join-list-by-invite";
+
+import { joinListByInvite } from "@/lib/api";
+import { queryKeys } from "@/lib/api/query-keys";
+
+vi.mock("@/lib/api", () => ({
+  joinListByInvite: vi.fn(),
+}));
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+function apiResponse(value: { data?: unknown; error?: unknown }) {
+  return value as Awaited<ReturnType<typeof joinListByInvite>>;
+}
+
+describe("useJoinListByInvite", () => {
+  let queryClient: QueryClient;
+  const joinedList = { id: "list-1", name: "Paris" };
+  const input = { listId: "list-1", token: "invite-token" };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+  });
+
+  it("calls joinListByInvite and returns data on success", async () => {
+    const data = { list: joinedList };
+    vi.mocked(joinListByInvite).mockResolvedValue(apiResponse({ data }));
+
+    const { result } = renderHook(() => useJoinListByInvite(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    let resolved: unknown;
+    await act(async () => {
+      resolved = await result.current.mutateAsync(input);
+    });
+
+    expect(joinListByInvite).toHaveBeenCalledWith({
+      path: { listId: "list-1" },
+      query: { token: "invite-token" },
+    });
+    expect(resolved).toEqual(data);
+  });
+
+  it("invalidates list caches on success", async () => {
+    vi.mocked(joinListByInvite).mockResolvedValue(apiResponse({ data: { list: joinedList } }));
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useJoinListByInvite(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync(input);
+    });
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.lists.all });
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.lists.detail("list-1") });
+    });
+  });
+
+  it("throws API error when response has no data", async () => {
+    const apiError = { message: "Invalid token" };
+    vi.mocked(joinListByInvite).mockResolvedValue(apiResponse({ error: apiError }));
+
+    const { result } = renderHook(() => useJoinListByInvite(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await expect(
+      act(async () => {
+        await result.current.mutateAsync(input);
+      })
+    ).rejects.toEqual(apiError);
+  });
+});

--- a/apps/web/src/features/lists/hooks/use-join-list-by-invite.ts
+++ b/apps/web/src/features/lists/hooks/use-join-list-by-invite.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { joinListByInvite } from "@/lib/api";
+import { queryKeys } from "@/lib/api/query-keys";
+
+/** Payload for `POST /list/:listId/collaborators/join?token=`. */
+export type JoinListByInviteInput = {
+  listId: string;
+  token: string;
+};
+
+/**
+ * Accepts an email invitation and joins a list.
+ *
+ * On success, invalidates the list index and the joined list detail.
+ * API errors are thrown so they can be handled with {@link useErrorMessage}.
+ */
+export function useJoinListByInvite() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ listId, token }: JoinListByInviteInput) => {
+      const response = await joinListByInvite({
+        path: { listId },
+        query: { token },
+      });
+
+      if (response.data) {
+        return response.data;
+      }
+
+      throw response.error;
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.lists.all });
+      queryClient.invalidateQueries({ queryKey: queryKeys.lists.detail(data.list.id) });
+    },
+  });
+}

--- a/apps/web/src/features/lists/hooks/use-leave-list.test.tsx
+++ b/apps/web/src/features/lists/hooks/use-leave-list.test.tsx
@@ -1,0 +1,89 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useLeaveList } from "./use-leave-list";
+
+import { leaveList } from "@/lib/api";
+import { queryKeys } from "@/lib/api/query-keys";
+
+vi.mock("@/lib/api", () => ({
+  leaveList: vi.fn(),
+}));
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+function apiResponse(value: { data?: unknown; error?: unknown }) {
+  return value as Awaited<ReturnType<typeof leaveList>>;
+}
+
+describe("useLeaveList", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+  });
+
+  it("calls leaveList and returns data on success", async () => {
+    const data = { message: "List left successfully" };
+    vi.mocked(leaveList).mockResolvedValue(apiResponse({ data }));
+
+    const { result } = renderHook(() => useLeaveList(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    let resolved: unknown;
+    await act(async () => {
+      resolved = await result.current.mutateAsync({ listId: "list-1" });
+    });
+
+    expect(leaveList).toHaveBeenCalledWith({ path: { listId: "list-1" } });
+    expect(resolved).toEqual(data);
+  });
+
+  it("invalidates collaborator and list caches on success", async () => {
+    vi.mocked(leaveList).mockResolvedValue(
+      apiResponse({ data: { message: "List left successfully" } })
+    );
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useLeaveList(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ listId: "list-1" });
+    });
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: queryKeys.lists.collaborators.all("list-1"),
+      });
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.lists.detail("list-1") });
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.lists.all });
+    });
+  });
+
+  it("throws API error when response has no data", async () => {
+    const apiError = { message: "Forbidden" };
+    vi.mocked(leaveList).mockResolvedValue(apiResponse({ error: apiError }));
+
+    const { result } = renderHook(() => useLeaveList(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await expect(
+      act(async () => {
+        await result.current.mutateAsync({ listId: "list-1" });
+      })
+    ).rejects.toEqual(apiError);
+  });
+});

--- a/apps/web/src/features/lists/hooks/use-leave-list.ts
+++ b/apps/web/src/features/lists/hooks/use-leave-list.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { leaveList } from "@/lib/api";
+import { queryKeys } from "@/lib/api/query-keys";
+
+/** Payload for `DELETE /list/:listId/collaborators/me`. */
+export type LeaveListInput = {
+  listId: string;
+};
+
+/**
+ * Leaves a list as the current collaborator.
+ *
+ * On success, invalidates collaborators, list detail, and the list index.
+ * API errors are thrown so they can be handled with {@link useErrorMessage}.
+ */
+export function useLeaveList() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ listId }: LeaveListInput) => {
+      const response = await leaveList({ path: { listId } });
+
+      if (response.data) {
+        return response.data;
+      }
+
+      throw response.error;
+    },
+    onSuccess: (_data, { listId }) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.lists.collaborators.all(listId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.lists.detail(listId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.lists.all });
+    },
+  });
+}

--- a/apps/web/src/features/lists/hooks/use-remove-collaborator.test.tsx
+++ b/apps/web/src/features/lists/hooks/use-remove-collaborator.test.tsx
@@ -1,0 +1,92 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useRemoveCollaborator } from "./use-remove-collaborator";
+
+import { removeCollaborator } from "@/lib/api";
+import { queryKeys } from "@/lib/api/query-keys";
+
+vi.mock("@/lib/api", () => ({
+  removeCollaborator: vi.fn(),
+}));
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+function apiResponse(value: { data?: unknown; error?: unknown }) {
+  return value as Awaited<ReturnType<typeof removeCollaborator>>;
+}
+
+describe("useRemoveCollaborator", () => {
+  let queryClient: QueryClient;
+  const input = { listId: "list-1", collaboratorId: "collab-1" };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+  });
+
+  it("calls removeCollaborator and returns data on success", async () => {
+    const data = { message: "Collaborator removed successfully" };
+    vi.mocked(removeCollaborator).mockResolvedValue(apiResponse({ data }));
+
+    const { result } = renderHook(() => useRemoveCollaborator(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    let resolved: unknown;
+    await act(async () => {
+      resolved = await result.current.mutateAsync(input);
+    });
+
+    expect(removeCollaborator).toHaveBeenCalledWith({
+      path: { listId: "list-1", collaboratorId: "collab-1" },
+    });
+    expect(resolved).toEqual(data);
+  });
+
+  it("invalidates collaborator and list caches on success", async () => {
+    vi.mocked(removeCollaborator).mockResolvedValue(
+      apiResponse({ data: { message: "Collaborator removed successfully" } })
+    );
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useRemoveCollaborator(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync(input);
+    });
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: queryKeys.lists.collaborators.all("list-1"),
+      });
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.lists.detail("list-1") });
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.lists.all });
+    });
+  });
+
+  it("throws API error when response has no data", async () => {
+    const apiError = { message: "Forbidden" };
+    vi.mocked(removeCollaborator).mockResolvedValue(apiResponse({ error: apiError }));
+
+    const { result } = renderHook(() => useRemoveCollaborator(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await expect(
+      act(async () => {
+        await result.current.mutateAsync(input);
+      })
+    ).rejects.toEqual(apiError);
+  });
+});

--- a/apps/web/src/features/lists/hooks/use-remove-collaborator.ts
+++ b/apps/web/src/features/lists/hooks/use-remove-collaborator.ts
@@ -1,0 +1,39 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { removeCollaborator } from "@/lib/api";
+import { queryKeys } from "@/lib/api/query-keys";
+
+/** Payload for `DELETE /list/:listId/collaborators/:collaboratorId`. */
+export type RemoveCollaboratorInput = {
+  listId: string;
+  collaboratorId: string;
+};
+
+/**
+ * Removes a collaborator from a list.
+ *
+ * On success, invalidates collaborators, list detail, and the list index.
+ * API errors are thrown so they can be handled with {@link useErrorMessage}.
+ */
+export function useRemoveCollaborator() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ listId, collaboratorId }: RemoveCollaboratorInput) => {
+      const response = await removeCollaborator({ path: { listId, collaboratorId } });
+
+      if (response.data) {
+        return response.data;
+      }
+
+      throw response.error;
+    },
+    onSuccess: (_data, { listId }) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.lists.collaborators.all(listId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.lists.detail(listId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.lists.all });
+    },
+  });
+}

--- a/apps/web/src/features/lists/hooks/use-revoke-edit-link.test.tsx
+++ b/apps/web/src/features/lists/hooks/use-revoke-edit-link.test.tsx
@@ -1,0 +1,86 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useRevokeEditLink } from "./use-revoke-edit-link";
+
+import { revokeEditLink } from "@/lib/api";
+import { queryKeys } from "@/lib/api/query-keys";
+
+vi.mock("@/lib/api", () => ({
+  revokeEditLink: vi.fn(),
+}));
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+function apiResponse(value: { data?: unknown; error?: unknown }) {
+  return value as Awaited<ReturnType<typeof revokeEditLink>>;
+}
+
+describe("useRevokeEditLink", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+  });
+
+  it("calls revokeEditLink and returns data on success", async () => {
+    const data = { message: "Edit link revoked successfully" };
+    vi.mocked(revokeEditLink).mockResolvedValue(apiResponse({ data }));
+
+    const { result } = renderHook(() => useRevokeEditLink(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    let resolved: unknown;
+    await act(async () => {
+      resolved = await result.current.mutateAsync({ listId: "list-1" });
+    });
+
+    expect(revokeEditLink).toHaveBeenCalledWith({ path: { listId: "list-1" } });
+    expect(resolved).toEqual(data);
+  });
+
+  it("invalidates list caches on success", async () => {
+    vi.mocked(revokeEditLink).mockResolvedValue(
+      apiResponse({ data: { message: "Edit link revoked successfully" } })
+    );
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useRevokeEditLink(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ listId: "list-1" });
+    });
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.lists.all });
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.lists.detail("list-1") });
+    });
+  });
+
+  it("throws API error when response has no data", async () => {
+    const apiError = { message: "Forbidden" };
+    vi.mocked(revokeEditLink).mockResolvedValue(apiResponse({ error: apiError }));
+
+    const { result } = renderHook(() => useRevokeEditLink(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await expect(
+      act(async () => {
+        await result.current.mutateAsync({ listId: "list-1" });
+      })
+    ).rejects.toEqual(apiError);
+  });
+});

--- a/apps/web/src/features/lists/hooks/use-revoke-edit-link.ts
+++ b/apps/web/src/features/lists/hooks/use-revoke-edit-link.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { revokeEditLink } from "@/lib/api";
+import { queryKeys } from "@/lib/api/query-keys";
+
+/** Payload for `DELETE /list/:listId/edit-link`. */
+export type RevokeEditLinkInput = {
+  listId: string;
+};
+
+/**
+ * Revokes the edit-invite link for a list.
+ *
+ * On success, invalidates the list index and the list detail (`editToken`).
+ * API errors are thrown so they can be handled with {@link useErrorMessage}.
+ */
+export function useRevokeEditLink() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ listId }: RevokeEditLinkInput) => {
+      const response = await revokeEditLink({ path: { listId } });
+
+      if (response.data) {
+        return response.data;
+      }
+
+      throw response.error;
+    },
+    onSuccess: (_data, { listId }) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.lists.all });
+      queryClient.invalidateQueries({ queryKey: queryKeys.lists.detail(listId) });
+    },
+  });
+}

--- a/apps/web/src/features/lists/hooks/use-share-list.test.tsx
+++ b/apps/web/src/features/lists/hooks/use-share-list.test.tsx
@@ -1,0 +1,86 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useShareList } from "./use-share-list";
+
+import { shareList } from "@/lib/api";
+import { queryKeys } from "@/lib/api/query-keys";
+
+vi.mock("@/lib/api", () => ({
+  shareList: vi.fn(),
+}));
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+function apiResponse(value: { data?: unknown; error?: unknown }) {
+  return value as Awaited<ReturnType<typeof shareList>>;
+}
+
+describe("useShareList", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+  });
+
+  it("calls shareList and returns data on success", async () => {
+    const data = { shareLink: "https://example.com/shared/token" };
+    vi.mocked(shareList).mockResolvedValue(apiResponse({ data }));
+
+    const { result } = renderHook(() => useShareList(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    let resolved: unknown;
+    await act(async () => {
+      resolved = await result.current.mutateAsync({ listId: "list-1" });
+    });
+
+    expect(shareList).toHaveBeenCalledWith({ path: { listId: "list-1" } });
+    expect(resolved).toEqual(data);
+  });
+
+  it("invalidates list caches on success", async () => {
+    vi.mocked(shareList).mockResolvedValue(
+      apiResponse({ data: { shareLink: "https://example.com/shared/token" } })
+    );
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useShareList(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ listId: "list-1" });
+    });
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.lists.all });
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.lists.detail("list-1") });
+    });
+  });
+
+  it("throws API error when response has no data", async () => {
+    const apiError = { message: "Forbidden" };
+    vi.mocked(shareList).mockResolvedValue(apiResponse({ error: apiError }));
+
+    const { result } = renderHook(() => useShareList(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await expect(
+      act(async () => {
+        await result.current.mutateAsync({ listId: "list-1" });
+      })
+    ).rejects.toEqual(apiError);
+  });
+});

--- a/apps/web/src/features/lists/hooks/use-share-list.ts
+++ b/apps/web/src/features/lists/hooks/use-share-list.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { shareList } from "@/lib/api";
+import { queryKeys } from "@/lib/api/query-keys";
+
+/** Payload for `POST /list/:listId/share`. */
+export type ShareListInput = {
+  listId: string;
+};
+
+/**
+ * Generates a public share link for a list.
+ *
+ * On success, invalidates the list index and the list detail (`shareToken`).
+ * API errors are thrown so they can be handled with {@link useErrorMessage}.
+ */
+export function useShareList() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ listId }: ShareListInput) => {
+      const response = await shareList({ path: { listId } });
+
+      if (response.data) {
+        return response.data;
+      }
+
+      throw response.error;
+    },
+    onSuccess: (_data, { listId }) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.lists.all });
+      queryClient.invalidateQueries({ queryKey: queryKeys.lists.detail(listId) });
+    },
+  });
+}

--- a/apps/web/src/features/lists/hooks/use-unshare-list.test.tsx
+++ b/apps/web/src/features/lists/hooks/use-unshare-list.test.tsx
@@ -1,0 +1,86 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useUnshareList } from "./use-unshare-list";
+
+import { unshareList } from "@/lib/api";
+import { queryKeys } from "@/lib/api/query-keys";
+
+vi.mock("@/lib/api", () => ({
+  unshareList: vi.fn(),
+}));
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+function apiResponse(value: { data?: unknown; error?: unknown }) {
+  return value as Awaited<ReturnType<typeof unshareList>>;
+}
+
+describe("useUnshareList", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+  });
+
+  it("calls unshareList and returns data on success", async () => {
+    const data = { message: "List unshared successfully" };
+    vi.mocked(unshareList).mockResolvedValue(apiResponse({ data }));
+
+    const { result } = renderHook(() => useUnshareList(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    let resolved: unknown;
+    await act(async () => {
+      resolved = await result.current.mutateAsync({ listId: "list-1" });
+    });
+
+    expect(unshareList).toHaveBeenCalledWith({ path: { listId: "list-1" } });
+    expect(resolved).toEqual(data);
+  });
+
+  it("invalidates list caches on success", async () => {
+    vi.mocked(unshareList).mockResolvedValue(
+      apiResponse({ data: { message: "List unshared successfully" } })
+    );
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useUnshareList(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ listId: "list-1" });
+    });
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.lists.all });
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.lists.detail("list-1") });
+    });
+  });
+
+  it("throws API error when response has no data", async () => {
+    const apiError = { message: "Forbidden" };
+    vi.mocked(unshareList).mockResolvedValue(apiResponse({ error: apiError }));
+
+    const { result } = renderHook(() => useUnshareList(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await expect(
+      act(async () => {
+        await result.current.mutateAsync({ listId: "list-1" });
+      })
+    ).rejects.toEqual(apiError);
+  });
+});

--- a/apps/web/src/features/lists/hooks/use-unshare-list.ts
+++ b/apps/web/src/features/lists/hooks/use-unshare-list.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { unshareList } from "@/lib/api";
+import { queryKeys } from "@/lib/api/query-keys";
+
+/** Payload for `DELETE /list/:listId/share`. */
+export type UnshareListInput = {
+  listId: string;
+};
+
+/**
+ * Revokes the public share link for a list.
+ *
+ * On success, invalidates the list index and the list detail (`shareToken`).
+ * API errors are thrown so they can be handled with {@link useErrorMessage}.
+ */
+export function useUnshareList() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ listId }: UnshareListInput) => {
+      const response = await unshareList({ path: { listId } });
+
+      if (response.data) {
+        return response.data;
+      }
+
+      throw response.error;
+    },
+    onSuccess: (_data, { listId }) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.lists.all });
+      queryClient.invalidateQueries({ queryKey: queryKeys.lists.detail(listId) });
+    },
+  });
+}

--- a/apps/web/src/features/lists/hooks/use-update-collaborator-role.test.tsx
+++ b/apps/web/src/features/lists/hooks/use-update-collaborator-role.test.tsx
@@ -1,0 +1,97 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useUpdateCollaboratorRole } from "./use-update-collaborator-role";
+
+import { updateCollaboratorRole } from "@/lib/api";
+import { queryKeys } from "@/lib/api/query-keys";
+
+vi.mock("@/lib/api", () => ({
+  updateCollaboratorRole: vi.fn(),
+}));
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+function apiResponse(value: { data?: unknown; error?: unknown }) {
+  return value as Awaited<ReturnType<typeof updateCollaboratorRole>>;
+}
+
+describe("useUpdateCollaboratorRole", () => {
+  let queryClient: QueryClient;
+  const input = {
+    listId: "list-1",
+    collaboratorId: "collab-1",
+    body: { role: "ADMIN" as const },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+  });
+
+  it("calls updateCollaboratorRole and returns data on success", async () => {
+    const data = { message: "Collaborator role updated successfully" };
+    vi.mocked(updateCollaboratorRole).mockResolvedValue(apiResponse({ data }));
+
+    const { result } = renderHook(() => useUpdateCollaboratorRole(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    let resolved: unknown;
+    await act(async () => {
+      resolved = await result.current.mutateAsync(input);
+    });
+
+    expect(updateCollaboratorRole).toHaveBeenCalledWith({
+      path: { listId: "list-1", collaboratorId: "collab-1" },
+      body: input.body,
+    });
+    expect(resolved).toEqual(data);
+  });
+
+  it("invalidates collaborator and list caches on success", async () => {
+    vi.mocked(updateCollaboratorRole).mockResolvedValue(
+      apiResponse({ data: { message: "Collaborator role updated successfully" } })
+    );
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useUpdateCollaboratorRole(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync(input);
+    });
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: queryKeys.lists.collaborators.all("list-1"),
+      });
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.lists.detail("list-1") });
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.lists.all });
+    });
+  });
+
+  it("throws API error when response has no data", async () => {
+    const apiError = { message: "Forbidden" };
+    vi.mocked(updateCollaboratorRole).mockResolvedValue(apiResponse({ error: apiError }));
+
+    const { result } = renderHook(() => useUpdateCollaboratorRole(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await expect(
+      act(async () => {
+        await result.current.mutateAsync(input);
+      })
+    ).rejects.toEqual(apiError);
+  });
+});

--- a/apps/web/src/features/lists/hooks/use-update-collaborator-role.ts
+++ b/apps/web/src/features/lists/hooks/use-update-collaborator-role.ts
@@ -1,0 +1,44 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { updateCollaboratorRole } from "@/lib/api";
+import type { UpdateCollaboratorRoleData } from "@/lib/api";
+import { queryKeys } from "@/lib/api/query-keys";
+
+/** Payload for `PUT /list/:listId/collaborators/:collaboratorId`. */
+export type UpdateCollaboratorRoleInput = {
+  listId: string;
+  collaboratorId: string;
+  body: UpdateCollaboratorRoleData["body"];
+};
+
+/**
+ * Updates a collaborator's role on a list.
+ *
+ * On success, invalidates collaborators, list detail, and the list index.
+ * API errors are thrown so they can be handled with {@link useErrorMessage}.
+ */
+export function useUpdateCollaboratorRole() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ listId, collaboratorId, body }: UpdateCollaboratorRoleInput) => {
+      const response = await updateCollaboratorRole({
+        path: { listId, collaboratorId },
+        body,
+      });
+
+      if (response.data) {
+        return response.data;
+      }
+
+      throw response.error;
+    },
+    onSuccess: (_data, { listId }) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.lists.collaborators.all(listId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.lists.detail(listId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.lists.all });
+    },
+  });
+}

--- a/apps/web/src/features/lists/index.ts
+++ b/apps/web/src/features/lists/index.ts
@@ -9,6 +9,17 @@ export { useAddPoiToList } from "./hooks/use-add-poi-to-list";
 export { useRemovePoiFromList } from "./hooks/use-remove-poi-from-list";
 export { useListSectionUrl } from "./hooks/use-list-section-url";
 export { useListPoisInfinite } from "./hooks/use-list-pois-infinite";
+export { useShareList } from "./hooks/use-share-list";
+export { useUnshareList } from "./hooks/use-unshare-list";
+export { useGenerateEditLink } from "./hooks/use-generate-edit-link";
+export { useRevokeEditLink } from "./hooks/use-revoke-edit-link";
+export { useCollaborators, COLLABORATORS_PAGE_SIZE } from "./hooks/use-collaborators";
+export { useInviteCollaborator } from "./hooks/use-invite-collaborator";
+export { useUpdateCollaboratorRole } from "./hooks/use-update-collaborator-role";
+export { useRemoveCollaborator } from "./hooks/use-remove-collaborator";
+export { useLeaveList } from "./hooks/use-leave-list";
+export { useJoinListByEditLink } from "./hooks/use-join-list-by-edit-link";
+export { useJoinListByInvite } from "./hooks/use-join-list-by-invite";
 export { createListFormSchema } from "./schemas/lists.schema";
 export {
   listConstraints,
@@ -16,8 +27,12 @@ export {
   DEFAULT_LIST_VISIBILITY,
   EDITABLE_LIST_ROLES,
   DELETABLE_LIST_ROLES,
+  SHARE_MANAGE_ROLES,
+  COLLABORATOR_MANAGE_ROLES,
   canEditList,
   canDeleteList,
+  canManageShareAndEditLinks,
+  canManageCollaborators,
   buildListsNavigationSearchParams,
 } from "./constants/lists.constants";
 export { ListsShellView } from "./navigation/lists-shell-view";
@@ -32,6 +47,17 @@ export type { ListPoisFilters } from "./hooks/use-list-pois";
 export type { AddPoiToListInput } from "./hooks/use-add-poi-to-list";
 export type { RemovePoiFromListInput } from "./hooks/use-remove-poi-from-list";
 export type { ListPoisInfiniteFilters } from "./hooks/use-list-pois-infinite";
+export type { ShareListInput } from "./hooks/use-share-list";
+export type { UnshareListInput } from "./hooks/use-unshare-list";
+export type { GenerateEditLinkInput } from "./hooks/use-generate-edit-link";
+export type { RevokeEditLinkInput } from "./hooks/use-revoke-edit-link";
+export type { CollaboratorsFilters } from "./hooks/use-collaborators";
+export type { InviteCollaboratorInput } from "./hooks/use-invite-collaborator";
+export type { UpdateCollaboratorRoleInput } from "./hooks/use-update-collaborator-role";
+export type { RemoveCollaboratorInput } from "./hooks/use-remove-collaborator";
+export type { LeaveListInput } from "./hooks/use-leave-list";
+export type { JoinListByEditLinkInput } from "./hooks/use-join-list-by-edit-link";
+export type { JoinListByInviteInput } from "./hooks/use-join-list-by-invite";
 export type { CreateListFormMessages, CreateListFormData } from "./schemas/lists.schema";
 export type { ListVisibility, ListRole } from "./constants/lists.constants";
 export type { ListsSection } from "./types/lists-section.types";

--- a/apps/web/src/features/lists/utils/share-links.utils.test.ts
+++ b/apps/web/src/features/lists/utils/share-links.utils.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { buildEditLinkUrl, buildShareUrl } from "./share-links.utils";
+
+describe("buildShareUrl", () => {
+  it("builds the public shared list path", () => {
+    expect(buildShareUrl("https://nirby.app", "abc123")).toBe("https://nirby.app/shared/abc123");
+  });
+});
+
+describe("buildEditLinkUrl", () => {
+  it("builds the join path with editToken query", () => {
+    expect(buildEditLinkUrl("https://nirby.app", "list-1", "tok-9")).toBe(
+      "https://nirby.app/list/list-1/join?editToken=tok-9"
+    );
+  });
+});

--- a/apps/web/src/features/lists/utils/share-links.utils.ts
+++ b/apps/web/src/features/lists/utils/share-links.utils.ts
@@ -1,0 +1,9 @@
+/** Builds the public read-only share URL for a list. */
+export function buildShareUrl(origin: string, shareToken: string): string {
+  return `${origin}/shared/${shareToken}`;
+}
+
+/** Builds the edit-invite join URL for a list. */
+export function buildEditLinkUrl(origin: string, listId: string, editToken: string): string {
+  return `${origin}/list/${listId}/join?editToken=${editToken}`;
+}

--- a/apps/web/src/features/lists/views/lists-detail-view.test.tsx
+++ b/apps/web/src/features/lists/views/lists-detail-view.test.tsx
@@ -70,6 +70,11 @@ vi.mock("../components/list-pois-section", () => ({
   ),
 }));
 
+vi.mock("../components/share-list-dialog", () => ({
+  ShareListDialog: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="share-list-dialog" /> : null,
+}));
+
 vi.mock("sonner", () => ({
   toast: {
     success: vi.fn(),
@@ -224,6 +229,52 @@ describe("ListsDetailView", () => {
 
     expect(screen.getByRole("button", { name: "edit.action" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "delete.submit" })).not.toBeInTheDocument();
+  });
+
+  it("shows share button for OWNER and opens the dialog", async () => {
+    const user = userEvent.setup();
+    mockListQuery();
+
+    render(<ListsDetailView listId="list-1" onBack={onBack} onEdit={onEdit} onDelete={onDelete} />);
+
+    const shareButton = screen.getByRole("button", { name: "share.action" });
+    expect(shareButton).toBeInTheDocument();
+    expect(screen.queryByTestId("share-list-dialog")).not.toBeInTheDocument();
+
+    await user.click(shareButton);
+
+    expect(screen.getByTestId("share-list-dialog")).toBeInTheDocument();
+  });
+
+  it("shows share button for ADMIN", () => {
+    mockListQuery({
+      data: { list: { ...mockList, role: "ADMIN" } },
+    });
+
+    render(<ListsDetailView listId="list-1" onBack={onBack} onEdit={onEdit} onDelete={onDelete} />);
+
+    expect(screen.getByRole("button", { name: "share.action" })).toBeInTheDocument();
+  });
+
+  it("hides share button for VIEWER", () => {
+    mockListQuery({
+      data: { list: { ...mockList, role: "VIEWER" } },
+    });
+
+    render(<ListsDetailView listId="list-1" onBack={onBack} onEdit={onEdit} onDelete={onDelete} />);
+
+    expect(screen.queryByRole("button", { name: "share.action" })).not.toBeInTheDocument();
+  });
+
+  it("hides share button for EDITOR", () => {
+    mockListQuery({
+      data: { list: { ...mockList, role: "EDITOR" } },
+    });
+
+    render(<ListsDetailView listId="list-1" onBack={onBack} onEdit={onEdit} onDelete={onDelete} />);
+
+    expect(screen.getByRole("button", { name: "edit.action" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "share.action" })).not.toBeInTheDocument();
   });
 
   it("shows delete button for OWNER", () => {

--- a/apps/web/src/features/lists/views/lists-detail-view.tsx
+++ b/apps/web/src/features/lists/views/lists-detail-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { PencilIcon, Trash2Icon } from "lucide-react";
+import { PencilIcon, Share2Icon, Trash2Icon } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
 
@@ -9,7 +9,12 @@ import { ListPoisSection } from "../components/list-pois-section";
 import { ListsDetailMetadata } from "../components/lists-detail-metadata";
 import { ListsListQueryBoundary } from "../components/lists-list-query-boundary";
 import { ListsSectionLayout } from "../components/lists-section-layout";
-import { canDeleteList, canEditList } from "../constants/lists.constants";
+import { ShareListDialog } from "../components/share-list-dialog";
+import {
+  canDeleteList,
+  canEditList,
+  canManageShareAndEditLinks,
+} from "../constants/lists.constants";
 import { useList } from "../hooks/use-list";
 import { useListMapPois } from "../hooks/use-list-map-pois";
 
@@ -30,6 +35,7 @@ export function ListsDetailView({ listId, onBack, onEdit, onDelete }: ListsDetai
   const { data } = useList(listId);
   const mapPois = useListMapPois(listId);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [shareDialogOpen, setShareDialogOpen] = useState(false);
   const list = data?.list;
 
   return (
@@ -50,6 +56,17 @@ export function ListsDetailView({ listId, onBack, onEdit, onDelete }: ListsDetai
             <ListsDetailMetadata list={loadedList} />
             {(canEditList(loadedList.role) || canDeleteList(loadedList.role)) && (
               <div className="flex flex-wrap gap-2">
+                {canManageShareAndEditLinks(loadedList.role) && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setShareDialogOpen(true)}
+                  >
+                    <Share2Icon className="size-4" />
+                    {tLists("share.action")}
+                  </Button>
+                )}
                 {canEditList(loadedList.role) && (
                   <Button type="button" variant="outline" size="sm" onClick={onEdit}>
                     <PencilIcon className="size-4" />
@@ -68,6 +85,15 @@ export function ListsDetailView({ listId, onBack, onEdit, onDelete }: ListsDetai
                   </Button>
                 )}
               </div>
+            )}
+            {canManageShareAndEditLinks(loadedList.role) && (
+              <ShareListDialog
+                listId={listId}
+                shareToken={loadedList.shareToken}
+                editToken={loadedList.editToken}
+                open={shareDialogOpen}
+                onOpenChange={setShareDialogOpen}
+              />
             )}
             {canDeleteList(loadedList.role) && (
               <DeleteListDialog

--- a/apps/web/src/lib/api/query-keys.test.ts
+++ b/apps/web/src/lib/api/query-keys.test.ts
@@ -62,6 +62,35 @@ describe("queryKeys.lists", () => {
     ]);
   });
 
+  it("collaborators.all includes listId", () => {
+    expect(queryKeys.lists.collaborators.all("list-1")).toEqual([
+      "lists",
+      "collaborators",
+      "list-1",
+    ]);
+  });
+
+  it("collaborators.list includes listId and filters", () => {
+    expect(queryKeys.lists.collaborators.list("list-1")).toEqual([
+      "lists",
+      "collaborators",
+      "list-1",
+      undefined,
+    ]);
+
+    expect(queryKeys.lists.collaborators.list("list-1", { page: 1 })).toEqual([
+      "lists",
+      "collaborators",
+      "list-1",
+      { page: 1 },
+    ]);
+  });
+
+  it("collaborators keys are prefixed by lists root", () => {
+    expect(queryKeys.lists.collaborators.all("list-1")[0]).toBe(queryKeys.lists.all[0]);
+    expect(queryKeys.lists.collaborators.list("list-1")[0]).toBe(queryKeys.lists.all[0]);
+  });
+
   it("poiMembership keys are prefixed by lists root", () => {
     expect(queryKeys.lists.poiMembership.all).toEqual(["lists", "poi-membership"]);
     expect(queryKeys.lists.poiMembership.byPlaces(["a", "b"])).toEqual([

--- a/apps/web/src/lib/api/query-keys.ts
+++ b/apps/web/src/lib/api/query-keys.ts
@@ -1,4 +1,4 @@
-import { GetListPoisData, GetListsData } from "./generated/types.gen";
+import { GetCollaboratorsData, GetListPoisData, GetListsData } from "./generated/types.gen";
 
 import { ListPoisInfiniteFilters } from "@/features/lists/hooks/use-list-pois-infinite";
 import type { ListsInfiniteFilters } from "@/features/lists/hooks/use-lists-infinite";
@@ -9,6 +9,7 @@ const GOOGLE_PLACES_ROOT = ["google-places"] as const;
 const LISTS_ROOT = ["lists"] as const;
 
 const listPoisRoot = (listId: string) => [...LISTS_ROOT, "pois", listId] as const;
+const listCollaboratorsRoot = (listId: string) => [...LISTS_ROOT, "collaborators", listId] as const;
 
 export const queryKeys = {
   googlePlaces: {
@@ -32,6 +33,11 @@ export const queryKeys = {
         [...listPoisRoot(listId), filters] as const,
       infinite: (listId: string, filters?: ListPoisInfiniteFilters) =>
         [...listPoisRoot(listId), "infinite", filters] as const,
+    },
+    collaborators: {
+      all: listCollaboratorsRoot,
+      list: (listId: string, filters?: GetCollaboratorsData["query"]) =>
+        [...listCollaboratorsRoot(listId), filters] as const,
     },
   },
 };

--- a/apps/web/src/lib/i18n/locales-parity.test.tsx
+++ b/apps/web/src/lib/i18n/locales-parity.test.tsx
@@ -42,6 +42,10 @@ const NEW_LISTS_KEYS = [
   "pois.error.retry",
   "poi.source.custom",
   "removePoi.success",
+  "share.action",
+  "share.readLink.generate",
+  "share.editLink.revokeConfirm",
+  "share.copySuccess",
 ] as const;
 
 const NEW_EXPLORE_KEYS = [

--- a/apps/web/src/lib/i18n/locales/en/lists.json
+++ b/apps/web/src/lib/i18n/locales/en/lists.json
@@ -110,5 +110,33 @@
     "confirmSubmit": "Remove",
     "success": "Place removed from list",
     "error": "Could not remove the place"
+  },
+  "share": {
+    "action": "Share",
+    "title": "Share list",
+    "description": "Create a read-only link or an edit invite link for this list.",
+    "readLink": {
+      "title": "Read-only link",
+      "description": "Anyone with this link can view the list.",
+      "generate": "Create link",
+      "copy": "Copy",
+      "revoke": "Revoke",
+      "revokeConfirm": "Revoke link",
+      "empty": "No link yet"
+    },
+    "editLink": {
+      "title": "Edit invite link",
+      "description": "Anyone with this link can join the list as an editor.",
+      "generate": "Create link",
+      "copy": "Copy",
+      "revoke": "Revoke",
+      "revokeConfirm": "Revoke link",
+      "empty": "No link yet"
+    },
+    "copySuccess": "Link copied",
+    "copyError": "Could not copy the link",
+    "generateError": "Could not create the link",
+    "revokeSuccess": "Link revoked",
+    "revokeError": "Could not revoke the link"
   }
 }

--- a/apps/web/src/lib/i18n/locales/fr/lists.json
+++ b/apps/web/src/lib/i18n/locales/fr/lists.json
@@ -110,5 +110,33 @@
     "confirmSubmit": "Retirer",
     "success": "Lieu retiré de la liste",
     "error": "Impossible de retirer le lieu"
+  },
+  "share": {
+    "action": "Partager",
+    "title": "Partager la liste",
+    "description": "Crée un lien de lecture ou un lien d'invitation à éditer pour cette liste.",
+    "readLink": {
+      "title": "Lien en lecture seule",
+      "description": "Toute personne avec ce lien peut consulter la liste.",
+      "generate": "Créer le lien",
+      "copy": "Copier",
+      "revoke": "Révoquer",
+      "revokeConfirm": "Révoquer le lien",
+      "empty": "Aucun lien pour l'instant"
+    },
+    "editLink": {
+      "title": "Lien d'invitation à éditer",
+      "description": "Toute personne avec ce lien peut rejoindre la liste en tant qu'éditeur.",
+      "generate": "Créer le lien",
+      "copy": "Copier",
+      "revoke": "Révoquer",
+      "revokeConfirm": "Révoquer le lien",
+      "empty": "Aucun lien pour l'instant"
+    },
+    "copySuccess": "Lien copié",
+    "copyError": "Impossible de copier le lien",
+    "generateError": "Impossible de créer le lien",
+    "revokeSuccess": "Lien révoqué",
+    "revokeError": "Impossible de révoquer le lien"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Description

Adds the Share dialog on list detail (NIR-75 / #152) so OWNER/ADMIN can generate, copy, and revoke read-only and edit-invite links.

This branch is stacked on [NIR-74 / #168](https://github.com/brissboss/Nirby/pull/168). Merge #168 first; this PR’s unique diff is the Share UI.

## 🎯 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## 🔗 Related Issues

Closes #152
Related to #151 (NIR-74)
Related to #145 (NIR-68)

## 🚀 Changes Made

- Share button on list detail, visible only for OWNER/ADMIN (`canManageShareAndEditLinks`)
- Dialog (desktop) / Drawer (mobile) with read-only and edit-invite sections
- Generate, copy to clipboard, and inline revoke confirmation
- i18n keys in `lists.json` (en/fr)
- URL helpers matching API link shapes (`/shared/{token}`, `/list/{id}/join?editToken=`)

## 🧪 Testing

- [ ] Tested locally with `pnpm dev`
- [x] All quality checks pass (`pnpm lint`)
- [x] Unit tests pass (`pnpm test`)
- [ ] Database migrations applied if needed

## 📸 Screenshots/Videos

N/A (UI added; screenshots after local review)

## ✅ Checklist

- [x] Code follows project style guidelines
- [ ] Documentation updated if needed
- [x] No console errors or warnings
- [x] Removed any debug code

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffb89-2207-7758-8794-ec303f733868?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffb89-2207-7758-8794-ec303f733868&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

