### PR TITLE
feat(web): add collaborators management panel (#153)

### DIFF
--- a/apps/web/src/features/lists/components/list-collaborators-section.test.tsx
+++ b/apps/web/src/features/lists/components/list-collaborators-section.test.tsx
@@ -1,0 +1,247 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { toast } from "sonner";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useCollaborators } from "../hooks/use-collaborators";
+import { useInviteCollaborator } from "../hooks/use-invite-collaborator";
+import { useLeaveList } from "../hooks/use-leave-list";
+import { useRemoveCollaborator } from "../hooks/use-remove-collaborator";
+import { useUpdateCollaboratorRole } from "../hooks/use-update-collaborator-role";
+
+import { ListCollaboratorsSection } from "./list-collaborators-section";
+
+import type { ListRole } from "@/features/lists/constants/lists.constants";
+import type { Collaborator } from "@/lib/api";
+import { getErrorCode } from "@/lib/api/errors";
+
+const useAuth = vi.fn();
+
+vi.mock("@/features/auth", () => ({
+  useAuth: () => useAuth(),
+}));
+
+vi.mock("../hooks/use-collaborators", () => ({
+  useCollaborators: vi.fn(),
+  COLLABORATORS_PAGE_SIZE: 20,
+}));
+
+vi.mock("../hooks/use-invite-collaborator", () => ({
+  useInviteCollaborator: vi.fn(),
+}));
+
+vi.mock("../hooks/use-update-collaborator-role", () => ({
+  useUpdateCollaboratorRole: vi.fn(),
+}));
+
+vi.mock("../hooks/use-remove-collaborator", () => ({
+  useRemoveCollaborator: vi.fn(),
+}));
+
+vi.mock("../hooks/use-leave-list", () => ({
+  useLeaveList: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-error-message", () => ({
+  useErrorMessage: () => () => "API error message",
+}));
+
+vi.mock("@/lib/api/errors", () => ({
+  getErrorCode: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const ownerUser = {
+  id: "user-1",
+  email: "ada@example.com",
+  name: "Ada",
+  avatarUrl: null,
+  emailVerified: true,
+};
+
+const otherCollaborator: Collaborator = {
+  role: "EDITOR",
+  joinedAt: "2024-02-01T00:00:00.000Z",
+  user: {
+    id: "user-2",
+    email: "alex@example.com",
+    name: "Alex",
+    avatarUrl: null,
+  },
+};
+
+const selfAsAdmin: Collaborator = {
+  role: "ADMIN",
+  joinedAt: "2024-01-15T00:00:00.000Z",
+  user: {
+    id: "user-1",
+    email: "ada@example.com",
+    name: "Ada",
+    avatarUrl: null,
+  },
+};
+
+function mockCollaboratorsQuery(
+  overrides: Partial<ReturnType<typeof useCollaborators>> = {},
+  collaborators: Collaborator[] = [otherCollaborator]
+) {
+  vi.mocked(useCollaborators).mockReturnValue({
+    data: {
+      collaborators,
+      pagination: { page: 1, limit: 20, total: collaborators.length, totalPages: 1 },
+    },
+    isPending: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+    ...overrides,
+  } as ReturnType<typeof useCollaborators>);
+}
+
+function renderSection(role: ListRole, onLeft = vi.fn()) {
+  return {
+    onLeft,
+    ...render(
+      <ListCollaboratorsSection listId="list-1" role={role} createdBy="user-1" onLeft={onLeft} />
+    ),
+  };
+}
+
+describe("ListCollaboratorsSection", () => {
+  const inviteMutate = vi.fn();
+  const updateRoleMutate = vi.fn();
+  const removeMutate = vi.fn();
+  const leaveMutate = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAuth.mockReturnValue({ user: ownerUser });
+    vi.mocked(getErrorCode).mockReturnValue(null);
+    mockCollaboratorsQuery();
+    inviteMutate.mockResolvedValue({ inviteLink: "https://example.com/invite", emailSent: true });
+    updateRoleMutate.mockResolvedValue({ message: "ok" });
+    removeMutate.mockResolvedValue({ message: "ok" });
+    leaveMutate.mockResolvedValue({ message: "ok" });
+    vi.mocked(useInviteCollaborator).mockReturnValue({
+      mutateAsync: inviteMutate,
+      isPending: false,
+    } as unknown as ReturnType<typeof useInviteCollaborator>);
+    vi.mocked(useUpdateCollaboratorRole).mockReturnValue({
+      mutateAsync: updateRoleMutate,
+      isPending: false,
+    } as unknown as ReturnType<typeof useUpdateCollaboratorRole>);
+    vi.mocked(useRemoveCollaborator).mockReturnValue({
+      mutateAsync: removeMutate,
+      isPending: false,
+    } as unknown as ReturnType<typeof useRemoveCollaborator>);
+    vi.mocked(useLeaveList).mockReturnValue({
+      mutateAsync: leaveMutate,
+      isPending: false,
+    } as unknown as ReturnType<typeof useLeaveList>);
+  });
+
+  it("shows invite and remove for OWNER, without Leave", () => {
+    renderSection("OWNER");
+
+    expect(
+      screen.getByRole("heading", { name: "collaborators.section.title" })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "collaborators.invite.submit" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "collaborators.remove" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "collaborators.leave" })).not.toBeInTheDocument();
+    expect(screen.getByText("Ada")).toBeInTheDocument();
+    expect(screen.getByText("role.OWNER")).toBeInTheDocument();
+  });
+
+  it("shows invite, remove, and Leave for ADMIN without inventing an owner row", () => {
+    mockCollaboratorsQuery({}, [selfAsAdmin, otherCollaborator]);
+
+    renderSection("ADMIN");
+
+    expect(screen.getByRole("button", { name: "collaborators.invite.submit" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "collaborators.remove" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "collaborators.leave" })).toBeInTheDocument();
+    expect(screen.queryByText("role.OWNER")).not.toBeInTheDocument();
+  });
+
+  it("hides invite and remove for EDITOR and shows Leave", () => {
+    renderSection("EDITOR");
+
+    expect(
+      screen.queryByRole("button", { name: "collaborators.invite.submit" })
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "collaborators.remove" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "collaborators.leave" })).toBeInTheDocument();
+  });
+
+  it("hides invite and remove for VIEWER and shows Leave", () => {
+    renderSection("VIEWER");
+
+    expect(
+      screen.queryByRole("button", { name: "collaborators.invite.submit" })
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "collaborators.remove" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "collaborators.leave" })).toBeInTheDocument();
+  });
+
+  it("invites a collaborator and shows a success toast", async () => {
+    const user = userEvent.setup();
+    renderSection("OWNER");
+
+    await user.type(screen.getByLabelText("collaborators.invite.email"), "sam@example.com");
+    await user.click(screen.getByRole("button", { name: "collaborators.invite.submit" }));
+
+    expect(inviteMutate).toHaveBeenCalledWith({
+      listId: "list-1",
+      body: {
+        email: "sam@example.com",
+        role: "VIEWER",
+        language: "en",
+        sendEmail: true,
+      },
+    });
+    expect(toast.success).toHaveBeenCalledWith("collaborators.invite.success");
+  });
+
+  it("shows an error toast when invite fails", async () => {
+    const user = userEvent.setup();
+    inviteMutate.mockRejectedValue({ error: { code: "COLLABORATOR_ALREADY_EXISTS" } });
+    renderSection("OWNER");
+
+    await user.type(screen.getByLabelText("collaborators.invite.email"), "sam@example.com");
+    await user.click(screen.getByRole("button", { name: "collaborators.invite.submit" }));
+
+    expect(toast.error).toHaveBeenCalledWith("collaborators.invite.error", {
+      description: "API error message",
+    });
+  });
+
+  it("removes a collaborator after confirmation and shows a success toast", async () => {
+    const user = userEvent.setup();
+    renderSection("OWNER");
+
+    await user.click(screen.getByRole("button", { name: "collaborators.remove" }));
+    await user.click(screen.getByRole("button", { name: "collaborators.removeConfirm" }));
+
+    expect(removeMutate).toHaveBeenCalledWith({ listId: "list-1", collaboratorId: "user-2" });
+    expect(toast.success).toHaveBeenCalledWith("collaborators.removeSuccess");
+  });
+
+  it("leaves the list after confirmation, toasts, and calls onLeft", async () => {
+    const user = userEvent.setup();
+    const { onLeft } = renderSection("EDITOR");
+
+    await user.click(screen.getByRole("button", { name: "collaborators.leave" }));
+    await user.click(screen.getByRole("button", { name: "collaborators.leaveConfirm" }));
+
+    expect(leaveMutate).toHaveBeenCalledWith({ listId: "list-1" });
+    expect(toast.success).toHaveBeenCalledWith("collaborators.leaveSuccess");
+    expect(onLeft).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/features/lists/components/list-collaborators-section.tsx
+++ b/apps/web/src/features/lists/components/list-collaborators-section.tsx
@@ -1,0 +1,505 @@
+"use client";
+
+import { standardSchemaResolver } from "@hookform/resolvers/standard-schema";
+import { useLocale, useTranslations } from "next-intl";
+import { useMemo, useState, type ReactNode } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
+
+import { canManageCollaborators, type ListRole } from "../constants/lists.constants";
+import { COLLABORATORS_PAGE_SIZE, useCollaborators } from "../hooks/use-collaborators";
+import { useInviteCollaborator } from "../hooks/use-invite-collaborator";
+import { useLeaveList } from "../hooks/use-leave-list";
+import { useRemoveCollaborator } from "../hooks/use-remove-collaborator";
+import { useUpdateCollaboratorRole } from "../hooks/use-update-collaborator-role";
+
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+  Badge,
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui";
+import { useAuth } from "@/features/auth";
+import { useErrorMessage } from "@/hooks/use-error-message";
+import type { Collaborator } from "@/lib/api";
+import { getErrorCode } from "@/lib/api/errors";
+
+const INVITABLE_ROLES = ["VIEWER", "EDITOR", "ADMIN"] as const;
+type InvitableRole = (typeof INVITABLE_ROLES)[number];
+
+export type ListCollaboratorsSectionProps = {
+  listId: string;
+  role?: ListRole;
+  createdBy: string;
+  onLeft: () => void;
+};
+
+type InviteFormValues = {
+  email: string;
+  role: InvitableRole;
+};
+
+function collaboratorLabel(user: { name?: string | null; email: string }) {
+  return user.name?.trim() || user.email;
+}
+
+function initials(user: { name?: string | null; email: string }) {
+  const source = collaboratorLabel(user);
+  return source.slice(0, 1).toUpperCase();
+}
+
+export function ListCollaboratorsSection({ listId, role, onLeft }: ListCollaboratorsSectionProps) {
+  const tLists = useTranslations("lists");
+  const getErrorMessage = useErrorMessage();
+  const { user } = useAuth();
+  const canManage = canManageCollaborators(role);
+  const canLeave = role !== undefined && role !== "OWNER";
+
+  const { data, isPending, isError, error, refetch } = useCollaborators(listId, {
+    limit: COLLABORATORS_PAGE_SIZE,
+  });
+
+  const collaborators = data?.collaborators ?? [];
+  const showOwnerRow = role === "OWNER" && user;
+
+  return (
+    <section className="border-t border-border pt-6" data-testid="list-collaborators-section">
+      <header className="mb-4">
+        <h2 className="font-display text-base font-semibold tracking-tight">
+          {tLists("collaborators.section.title")}
+        </h2>
+      </header>
+
+      {canManage ? <InviteCollaboratorForm listId={listId} /> : null}
+
+      {isPending ? (
+        <p className="text-sm text-muted-foreground">{tLists("collaborators.loading")}</p>
+      ) : null}
+
+      {!isPending && isError ? (
+        <div className="grid gap-3 py-4" role="alert">
+          <p className="text-sm text-muted-foreground">
+            {getErrorMessage(error) || tLists("collaborators.error.title")}
+          </p>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="w-fit"
+            onClick={() => refetch()}
+          >
+            {tLists("collaborators.error.retry")}
+          </Button>
+        </div>
+      ) : null}
+
+      {!isPending && !isError ? (
+        <ul className="grid gap-3">
+          {showOwnerRow ? (
+            <li>
+              <CollaboratorRow
+                name={collaboratorLabel(user)}
+                email={user.email}
+                avatarUrl={user.avatarUrl}
+                roleLabel={tLists("role.OWNER")}
+                isOwner
+              />
+            </li>
+          ) : null}
+
+          {collaborators.map((collaborator) => (
+            <li key={collaborator.user.id}>
+              <ManagedCollaboratorRow
+                listId={listId}
+                collaborator={collaborator}
+                currentUserId={user?.id}
+                canManage={canManage}
+              />
+            </li>
+          ))}
+
+          {!showOwnerRow && collaborators.length === 0 ? (
+            <li className="text-sm text-muted-foreground">{tLists("collaborators.empty")}</li>
+          ) : null}
+        </ul>
+      ) : null}
+
+      {canLeave ? <LeaveListControl listId={listId} onLeft={onLeft} /> : null}
+    </section>
+  );
+}
+
+function InviteCollaboratorForm({ listId }: { listId: string }) {
+  const tLists = useTranslations("lists");
+  const locale = useLocale();
+  const getErrorMessage = useErrorMessage();
+  const { mutateAsync: invite, isPending } = useInviteCollaborator();
+
+  const schema = useMemo(
+    () =>
+      z.object({
+        email: z
+          .string()
+          .trim()
+          .min(1, tLists("collaborators.invite.requiredEmail"))
+          .email(tLists("collaborators.invite.invalidEmail"))
+          .max(255),
+        role: z.enum(INVITABLE_ROLES),
+      }),
+    [tLists]
+  );
+
+  const form = useForm<InviteFormValues>({
+    resolver: standardSchemaResolver(schema),
+    defaultValues: { email: "", role: "VIEWER" },
+  });
+
+  async function onSubmit(values: InviteFormValues) {
+    try {
+      await invite({
+        listId,
+        body: {
+          email: values.email,
+          role: values.role,
+          language: locale === "fr" ? "fr" : "en",
+          sendEmail: true,
+        },
+      });
+      toast.success(tLists("collaborators.invite.success"));
+      form.reset({ email: "", role: "VIEWER" });
+    } catch (error) {
+      toast.error(tLists("collaborators.invite.error"), {
+        description: getErrorMessage(error),
+      });
+    }
+  }
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit(onSubmit)}
+        className="mb-4 grid gap-3 sm:grid-cols-[1fr_8rem_auto] sm:items-end"
+      >
+        <FormField
+          control={form.control}
+          name="email"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>{tLists("collaborators.invite.email")}</FormLabel>
+              <FormControl>
+                <Input type="email" autoComplete="email" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="role"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>{tLists("collaborators.invite.role")}</FormLabel>
+              <Select value={field.value} onValueChange={field.onChange}>
+                <FormControl>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  {INVITABLE_ROLES.map((value) => (
+                    <SelectItem key={value} value={value}>
+                      {tLists(`role.${value}`)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit" size="sm" loading={isPending} disabled={isPending}>
+          {tLists("collaborators.invite.submit")}
+        </Button>
+      </form>
+    </Form>
+  );
+}
+
+function ManagedCollaboratorRow({
+  listId,
+  collaborator,
+  currentUserId,
+  canManage,
+}: {
+  listId: string;
+  collaborator: Collaborator;
+  currentUserId?: string;
+  canManage: boolean;
+}) {
+  const tLists = useTranslations("lists");
+  const getErrorMessage = useErrorMessage();
+  const { mutateAsync: updateRole, isPending: isUpdating } = useUpdateCollaboratorRole();
+  const isMe = currentUserId === collaborator.user.id;
+  const canEditRow = canManage && !isMe;
+  const [removeOpen, setRemoveOpen] = useState(false);
+
+  async function handleRoleChange(nextRole: string) {
+    if (nextRole === collaborator.role) return;
+
+    try {
+      await updateRole({
+        listId,
+        collaboratorId: collaborator.user.id,
+        body: { role: nextRole as InvitableRole },
+      });
+    } catch (error) {
+      toast.error(tLists("collaborators.updateRoleError"), {
+        description: getErrorMessage(error),
+      });
+    }
+  }
+
+  return (
+    <>
+      <CollaboratorRow
+        name={collaboratorLabel(collaborator.user)}
+        email={collaborator.user.email}
+        avatarUrl={collaborator.user.avatarUrl}
+        roleLabel={tLists(`role.${collaborator.role}`)}
+        roleSelect={
+          canEditRow ? (
+            <Select
+              value={collaborator.role}
+              onValueChange={handleRoleChange}
+              disabled={isUpdating}
+            >
+              <SelectTrigger aria-label={tLists("collaborators.invite.role")} className="w-32">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {INVITABLE_ROLES.map((value) => (
+                  <SelectItem key={value} value={value}>
+                    {tLists(`role.${value}`)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          ) : undefined
+        }
+        actions={
+          canEditRow ? (
+            <Button
+              type="button"
+              variant="destructive"
+              size="sm"
+              onClick={() => setRemoveOpen(true)}
+            >
+              {tLists("collaborators.remove")}
+            </Button>
+          ) : null
+        }
+      />
+      {canEditRow ? (
+        <RemoveCollaboratorDialog
+          listId={listId}
+          collaboratorId={collaborator.user.id}
+          name={collaboratorLabel(collaborator.user)}
+          open={removeOpen}
+          onOpenChange={setRemoveOpen}
+        />
+      ) : null}
+    </>
+  );
+}
+
+function CollaboratorRow({
+  name,
+  email,
+  avatarUrl,
+  roleLabel,
+  isOwner = false,
+  roleSelect,
+  actions,
+}: {
+  name: string;
+  email: string;
+  avatarUrl?: string | null;
+  roleLabel: string;
+  isOwner?: boolean;
+  roleSelect?: ReactNode;
+  actions?: ReactNode;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-3 rounded-md border border-border px-3 py-2">
+      <Avatar>
+        {avatarUrl ? <AvatarImage src={avatarUrl} alt="" /> : null}
+        <AvatarFallback>{initials({ name, email })}</AvatarFallback>
+      </Avatar>
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium">{name}</p>
+        <p className="truncate text-xs text-muted-foreground">{email}</p>
+      </div>
+      {roleSelect ?? <Badge variant="secondary">{roleLabel}</Badge>}
+      {isOwner ? null : actions}
+    </div>
+  );
+}
+
+function RemoveCollaboratorDialog({
+  listId,
+  collaboratorId,
+  name,
+  open,
+  onOpenChange,
+}: {
+  listId: string;
+  collaboratorId: string;
+  name: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const tLists = useTranslations("lists");
+  const tCommon = useTranslations("common");
+  const getErrorMessage = useErrorMessage();
+  const { mutateAsync: removeCollaborator, isPending } = useRemoveCollaborator();
+
+  async function handleRemove() {
+    if (isPending) return;
+
+    try {
+      await removeCollaborator({ listId, collaboratorId });
+      toast.success(tLists("collaborators.removeSuccess"));
+      onOpenChange(false);
+    } catch (error) {
+      if (getErrorCode(error) === "COLLABORATOR_NOT_FOUND") {
+        onOpenChange(false);
+        return;
+      }
+      toast.error(tLists("collaborators.removeError"), {
+        description: getErrorMessage(error),
+      });
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{tLists("collaborators.removeTitle")}</DialogTitle>
+          <DialogDescription>
+            {tLists("collaborators.removeDescription", { name })}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isPending}
+          >
+            {tCommon("buttons.cancel")}
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            loading={isPending}
+            disabled={isPending}
+            onClick={handleRemove}
+          >
+            {tLists("collaborators.removeConfirm")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function LeaveListControl({ listId, onLeft }: { listId: string; onLeft: () => void }) {
+  const tLists = useTranslations("lists");
+  const tCommon = useTranslations("common");
+  const getErrorMessage = useErrorMessage();
+  const { mutateAsync: leaveList, isPending } = useLeaveList();
+  const [open, setOpen] = useState(false);
+
+  async function handleLeave() {
+    if (isPending) return;
+
+    try {
+      await leaveList({ listId });
+      toast.success(tLists("collaborators.leaveSuccess"));
+      setOpen(false);
+      onLeft();
+    } catch (error) {
+      if (getErrorCode(error) === "LIST_OWNER_CANNOT_LEAVE") {
+        toast.error(tLists("collaborators.leaveError"), {
+          description: getErrorMessage(error),
+        });
+        return;
+      }
+      toast.error(tLists("collaborators.leaveError"), {
+        description: getErrorMessage(error),
+      });
+    }
+  }
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="mt-4 w-fit"
+        onClick={() => setOpen(true)}
+      >
+        {tLists("collaborators.leave")}
+      </Button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{tLists("collaborators.leaveTitle")}</DialogTitle>
+            <DialogDescription>{tLists("collaborators.leaveDescription")}</DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setOpen(false)}
+              disabled={isPending}
+            >
+              {tCommon("buttons.cancel")}
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              loading={isPending}
+              disabled={isPending}
+              onClick={handleLeave}
+            >
+              {tLists("collaborators.leaveConfirm")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/web/src/features/lists/views/lists-detail-view.test.tsx
+++ b/apps/web/src/features/lists/views/lists-detail-view.test.tsx
@@ -70,6 +70,25 @@ vi.mock("../components/list-pois-section", () => ({
   ),
 }));
 
+vi.mock("../components/list-collaborators-section", () => ({
+  ListCollaboratorsSection: ({
+    listId,
+    role,
+    createdBy,
+  }: {
+    listId: string;
+    role?: string;
+    createdBy: string;
+  }) => (
+    <div
+      data-testid="list-collaborators-section"
+      data-list-id={listId}
+      data-role={role ?? ""}
+      data-created-by={createdBy}
+    />
+  ),
+}));
+
 vi.mock("../components/share-list-dialog", () => ({
   ShareListDialog: ({ open }: { open: boolean }) =>
     open ? <div data-testid="share-list-dialog" /> : null,
@@ -183,6 +202,12 @@ describe("ListsDetailView", () => {
     expect(poisSection).toBeInTheDocument();
     expect(poisSection).toHaveAttribute("data-list-id", "list-1");
     expect(poisSection).toHaveAttribute("data-role", "OWNER");
+
+    const collaboratorsSection = screen.getByTestId("list-collaborators-section");
+    expect(collaboratorsSection).toBeInTheDocument();
+    expect(collaboratorsSection).toHaveAttribute("data-list-id", "list-1");
+    expect(collaboratorsSection).toHaveAttribute("data-role", "OWNER");
+    expect(collaboratorsSection).toHaveAttribute("data-created-by", "user-1");
   });
 
   it("shows edit button for OWNER and calls onEdit", async () => {
@@ -208,6 +233,7 @@ describe("ListsDetailView", () => {
 
     expect(screen.queryByRole("button", { name: "edit.action" })).not.toBeInTheDocument();
     expect(screen.queryByText("edit.readOnly")).not.toBeInTheDocument();
+    expect(screen.getByTestId("list-collaborators-section")).toHaveAttribute("data-role", "VIEWER");
   });
 
   it("hides delete button for VIEWER", () => {

--- a/apps/web/src/features/lists/views/lists-detail-view.tsx
+++ b/apps/web/src/features/lists/views/lists-detail-view.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from "next-intl";
 import { useState } from "react";
 
 import { DeleteListDialog } from "../components/delete-list-dialog";
+import { ListCollaboratorsSection } from "../components/list-collaborators-section";
 import { ListPoisSection } from "../components/list-pois-section";
 import { ListsDetailMetadata } from "../components/lists-detail-metadata";
 import { ListsListQueryBoundary } from "../components/lists-list-query-boundary";
@@ -103,6 +104,12 @@ export function ListsDetailView({ listId, onBack, onEdit, onDelete }: ListsDetai
                 onDeleted={onDelete}
               />
             )}
+            <ListCollaboratorsSection
+              listId={listId}
+              role={loadedList.role}
+              createdBy={loadedList.createdBy}
+              onLeft={onBack}
+            />
             <ListPoisSection
               listId={listId}
               role={loadedList.role}

--- a/apps/web/src/lib/i18n/locales-parity.test.tsx
+++ b/apps/web/src/lib/i18n/locales-parity.test.tsx
@@ -46,6 +46,9 @@ const NEW_LISTS_KEYS = [
   "share.readLink.generate",
   "share.editLink.revokeConfirm",
   "share.copySuccess",
+  "collaborators.section.title",
+  "collaborators.invite.submit",
+  "collaborators.leaveConfirm",
 ] as const;
 
 const NEW_EXPLORE_KEYS = [

--- a/apps/web/src/lib/i18n/locales/en/lists.json
+++ b/apps/web/src/lib/i18n/locales/en/lists.json
@@ -138,5 +138,38 @@
     "generateError": "Could not create the link",
     "revokeSuccess": "Link revoked",
     "revokeError": "Could not revoke the link"
+  },
+  "collaborators": {
+    "section": {
+      "title": "Collaborators"
+    },
+    "empty": "No collaborators yet",
+    "loading": "Loading collaborators…",
+    "error": {
+      "title": "Could not load collaborators",
+      "retry": "Retry"
+    },
+    "invite": {
+      "email": "Email",
+      "role": "Role",
+      "submit": "Invite",
+      "success": "Invitation sent",
+      "error": "Could not invite this person",
+      "requiredEmail": "Email is required",
+      "invalidEmail": "Invalid email"
+    },
+    "remove": "Remove",
+    "removeTitle": "Remove collaborator",
+    "removeDescription": "\"{name}\" will lose access to this list.",
+    "removeConfirm": "Remove",
+    "removeSuccess": "Collaborator removed",
+    "removeError": "Could not remove the collaborator",
+    "updateRoleError": "Could not update the role",
+    "leave": "Leave list",
+    "leaveTitle": "Leave this list",
+    "leaveDescription": "You will lose access until you are invited again.",
+    "leaveConfirm": "Leave",
+    "leaveSuccess": "You left the list",
+    "leaveError": "Could not leave the list"
   }
 }

--- a/apps/web/src/lib/i18n/locales/fr/lists.json
+++ b/apps/web/src/lib/i18n/locales/fr/lists.json
@@ -138,5 +138,38 @@
     "generateError": "Impossible de créer le lien",
     "revokeSuccess": "Lien révoqué",
     "revokeError": "Impossible de révoquer le lien"
+  },
+  "collaborators": {
+    "section": {
+      "title": "Collaborateurs"
+    },
+    "empty": "Aucun collaborateur pour l'instant",
+    "loading": "Chargement des collaborateurs…",
+    "error": {
+      "title": "Impossible de charger les collaborateurs",
+      "retry": "Réessayer"
+    },
+    "invite": {
+      "email": "Email",
+      "role": "Rôle",
+      "submit": "Inviter",
+      "success": "Invitation envoyée",
+      "error": "Impossible d'inviter cette personne",
+      "requiredEmail": "L'email est requis",
+      "invalidEmail": "Email invalide"
+    },
+    "remove": "Retirer",
+    "removeTitle": "Retirer le collaborateur",
+    "removeDescription": "« {name} » n'aura plus accès à cette liste.",
+    "removeConfirm": "Retirer",
+    "removeSuccess": "Collaborateur retiré",
+    "removeError": "Impossible de retirer le collaborateur",
+    "updateRoleError": "Impossible de modifier le rôle",
+    "leave": "Quitter la liste",
+    "leaveTitle": "Quitter cette liste",
+    "leaveDescription": "Tu perdras l'accès tant que tu ne seras pas réinvité.",
+    "leaveConfirm": "Quitter",
+    "leaveSuccess": "Tu as quitté la liste",
+    "leaveError": "Impossible de quitter la liste"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Description

Adds a collaborators management panel on the list detail view (NIR-76 / GitHub #153). Members can see who has access; OWNER/ADMIN can invite, change roles, and remove collaborators; everyone except OWNER can leave.

Does not recreate the Share dialog (already on this epic via #169). Unique work is the panel only — sharing hooks from #168 are already on `nir-68`.

## 🎯 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] ✅ Test update

## 🔗 Related Issues

Closes #153
Related to NIR-68 / NIR-76

## 🚀 Changes Made

- i18n `lists.collaborators.*` in en + fr (invite, remove, leave, loading/error)
- `ListCollaboratorsSection` on list detail (after actions, before places)
- OWNER gets a read-only owner row from `useAuth()`; ADMIN does not invent an owner row
- Invite form (email + EDITOR/VIEWER/ADMIN, `sendEmail: true`, locale language)
- Role select + remove confirm for managers (not on self / OWNER)
- Leave confirm for non-OWNER → `onBack`
- Tests for role visibility, invite/remove/leave hooks + toasts, and i18n parity

## 🧪 Testing

- [ ] Tested locally with `pnpm dev`
- [x] All quality checks pass (`pnpm --filter @nirby/web lint`)
- [x] Unit tests pass (`pnpm --filter @nirby/web test` — 287 tests)
- [ ] Database migrations applied if needed

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated if needed
- [x] No console errors or warnings
- [x] Removed any debug code

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffb89-2207-7758-8794-ec303f733868?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffb89-2207-7758-8794-ec303f733868&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

