### PR TITLE
feat(web): add public shared list page (#154)

### DIFF
--- a/apps/web/src/app/shared/[shareToken]/page.tsx
+++ b/apps/web/src/app/shared/[shareToken]/page.tsx
@@ -1,0 +1,11 @@
+import { SharedListView } from "@/features/lists/views/shared-list-view";
+
+type SharedListPageProps = {
+  params: Promise<{ shareToken: string }>;
+};
+
+export default async function SharedListPage({ params }: SharedListPageProps) {
+  const { shareToken } = await params;
+
+  return <SharedListView shareToken={shareToken} />;
+}

--- a/apps/web/src/app/shared/layout.tsx
+++ b/apps/web/src/app/shared/layout.tsx
@@ -1,0 +1,21 @@
+import Link from "next/link";
+
+import { Logo } from "@/components/logo";
+import { LanguageSelector } from "@/components/ui/language-selector";
+
+export default function SharedLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="bg-background text-foreground min-h-screen">
+      <header className="border-b border-border">
+        <div className="mx-auto flex max-w-2xl items-center justify-between px-4 py-4">
+          <Link href="/" className="flex items-center gap-2 text-foreground">
+            <Logo className="h-8 w-8" />
+            <span className="font-display text-xl font-bold">Nirby</span>
+          </Link>
+          <LanguageSelector />
+        </div>
+      </header>
+      <main className="mx-auto max-w-2xl px-4 py-8">{children}</main>
+    </div>
+  );
+}

--- a/apps/web/src/features/lists/components/shared-list-pois-section.tsx
+++ b/apps/web/src/features/lists/components/shared-list-pois-section.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { Loader2Icon, MapPinOffIcon, OctagonXIcon } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useCallback } from "react";
+
+import { useInfiniteScroll } from "../hooks/use-infinite-scroll";
+import { useSharedListPoisInfinite } from "../hooks/use-shared-list-pois-infinite";
+
+import { ListPoisSkeleton } from "./list-pois-skeleton";
+
+import { Button } from "@/components/ui";
+import { PoiCard, getPoiDisplayDataFromSharedPoi } from "@/features/pois";
+import { useErrorMessage } from "@/hooks/use-error-message";
+
+type SharedListPoisSectionProps = {
+  shareToken: string;
+};
+
+export function SharedListPoisSection({ shareToken }: SharedListPoisSectionProps) {
+  const tLists = useTranslations("lists");
+  const getErrorMessage = useErrorMessage();
+
+  const {
+    data,
+    isPending,
+    isLoading,
+    isError,
+    error,
+    refetch,
+    isFetchingNextPage,
+    hasNextPage,
+    fetchNextPage,
+  } = useSharedListPoisInfinite(shareToken);
+
+  const items = data?.pages.flatMap((page) => page.pois) ?? [];
+  const total = data?.pages[0]?.pagination.total;
+  const isInitialLoading = (isPending || isLoading) && items.length === 0;
+
+  const loadMore = useCallback(() => {
+    if (hasNextPage && !isFetchingNextPage) {
+      void fetchNextPage();
+    }
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  const sentinelRef = useInfiniteScroll(loadMore, {
+    enabled: hasNextPage === true && !isError && items.length > 0,
+  });
+
+  return (
+    <section className="border-t border-border pt-6">
+      <header className="mb-4 grid gap-1">
+        <h2 className="font-display text-base font-semibold tracking-tight">
+          {tLists("pois.section.title")}
+        </h2>
+        {!isInitialLoading && !isError && total !== undefined ? (
+          <p className="text-sm text-muted-foreground">{tLists("pois.section.total", { total })}</p>
+        ) : null}
+      </header>
+
+      {isInitialLoading && <ListPoisSkeleton />}
+
+      {!isInitialLoading && isError && (
+        <div className="flex flex-col items-center gap-4 py-8 text-center" role="alert">
+          <span className="grid size-12 place-items-center rounded-full bg-destructive/10 text-destructive">
+            <OctagonXIcon className="size-6" aria-hidden />
+          </span>
+          <div className="grid max-w-sm gap-1">
+            <h3 className="font-display text-base font-semibold tracking-tight">
+              {tLists("pois.error.title")}
+            </h3>
+            <p className="text-sm text-muted-foreground">{getErrorMessage(error)}</p>
+          </div>
+          <Button type="button" variant="outline" size="sm" onClick={() => refetch()}>
+            {tLists("pois.error.retry")}
+          </Button>
+        </div>
+      )}
+
+      {!isInitialLoading && !isError && items.length === 0 && (
+        <div className="flex flex-col items-center gap-4 py-8 text-center">
+          <span className="grid size-12 place-items-center rounded-full bg-primary/10 text-primary">
+            <MapPinOffIcon className="size-6" aria-hidden />
+          </span>
+          <div className="grid max-w-sm gap-1">
+            <h3 className="font-display text-base font-semibold tracking-tight">
+              {tLists("pois.empty.title")}
+            </h3>
+            <p className="text-sm text-muted-foreground">{tLists("pois.empty.description")}</p>
+          </div>
+        </div>
+      )}
+
+      {!isInitialLoading && !isError && items.length > 0 && (
+        <>
+          <ul className="flex w-full min-w-0 flex-col gap-3">
+            {items.map((poi, index) => {
+              const display = getPoiDisplayDataFromSharedPoi(poi);
+              if (!display) {
+                return null;
+              }
+
+              return (
+                <li key={display.id || `shared-poi-${index}`}>
+                  <PoiCard poi={display} />
+                </li>
+              );
+            })}
+          </ul>
+
+          <div ref={sentinelRef} className="h-1 w-full" aria-hidden />
+
+          {isFetchingNextPage && (
+            <div
+              className="flex items-center justify-center gap-2 py-4 text-sm text-muted-foreground"
+              aria-busy="true"
+              aria-live="polite"
+            >
+              <Loader2Icon className="size-4 animate-spin" />
+              {tLists("pois.loadingMore")}
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/features/lists/hooks/use-shared-list-pois-infinite.test.tsx
+++ b/apps/web/src/features/lists/hooks/use-shared-list-pois-infinite.test.tsx
@@ -1,0 +1,77 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  SHARED_LIST_POIS_PAGE_SIZE,
+  useSharedListPoisInfinite,
+} from "./use-shared-list-pois-infinite";
+
+const getSharedListPois = vi.fn();
+
+vi.mock("@/lib/api", () => ({
+  getSharedListPois: (...args: unknown[]) => getSharedListPois(...args),
+}));
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe("useSharedListPoisInfinite", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    getSharedListPois.mockResolvedValue({
+      data: { pois: [{ id: "poi-1" }], pagination: { page: 1, totalPages: 1, total: 1 } },
+    });
+  });
+
+  it("does not fetch when shareToken is undefined", () => {
+    renderHook(() => useSharedListPoisInfinite(undefined), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    expect(getSharedListPois).not.toHaveBeenCalled();
+  });
+
+  it("fetches first page without requiring a signed-in user", async () => {
+    const { result } = renderHook(() => useSharedListPoisInfinite("demo-share-token"), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(getSharedListPois).toHaveBeenCalledWith({
+      path: { shareToken: "demo-share-token" },
+      query: { page: 1, limit: SHARED_LIST_POIS_PAGE_SIZE },
+    });
+    expect(result.current.data?.pages[0]).toEqual({
+      pois: [{ id: "poi-1" }],
+      pagination: { page: 1, totalPages: 1, total: 1 },
+    });
+  });
+
+  it("throws API error when response has no data", async () => {
+    const apiError = { success: false, error: { code: "SHARE_TOKEN_EXPIRED" } };
+    getSharedListPois.mockResolvedValue({ error: apiError });
+
+    const { result } = renderHook(() => useSharedListPoisInfinite("expired-token"), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error).toEqual(apiError);
+  });
+});

--- a/apps/web/src/features/lists/hooks/use-shared-list-pois-infinite.ts
+++ b/apps/web/src/features/lists/hooks/use-shared-list-pois-infinite.ts
@@ -1,0 +1,62 @@
+"use client";
+
+import { useInfiniteQuery } from "@tanstack/react-query";
+
+import type { GetSharedListPoisData } from "@/lib/api";
+import { getSharedListPois } from "@/lib/api";
+import { queryKeys } from "@/lib/api/query-keys";
+
+export type SharedListPoisInfiniteFilters = Omit<
+  NonNullable<GetSharedListPoisData["query"]>,
+  "page"
+>;
+
+/** Default page size — matches API default (20). */
+export const SHARED_LIST_POIS_PAGE_SIZE = 20;
+
+async function fetchSharedListPoisPage(
+  shareToken: string,
+  filters: SharedListPoisInfiniteFilters | undefined,
+  page: number
+) {
+  const response = await getSharedListPois({
+    path: { shareToken },
+    query: {
+      ...filters,
+      page,
+      limit: filters?.limit ?? SHARED_LIST_POIS_PAGE_SIZE,
+    },
+  });
+
+  if (response.data) {
+    return response.data;
+  }
+
+  throw response.error;
+}
+
+/**
+ * Paginated public POIs for a shared list (GET /shared/:shareToken/pois).
+ * No auth gate. API errors are thrown for {@link useErrorMessage}.
+ */
+export function useSharedListPoisInfinite(
+  shareToken: string | undefined,
+  filters?: SharedListPoisInfiniteFilters
+) {
+  return useInfiniteQuery({
+    queryKey: queryKeys.shared.pois.infinite(shareToken ?? "", filters),
+    enabled: Boolean(shareToken),
+    initialPageParam: 1,
+    queryFn: ({ pageParam }) => {
+      if (!shareToken) {
+        throw new Error("shareToken is required");
+      }
+
+      return fetchSharedListPoisPage(shareToken, filters, pageParam);
+    },
+    getNextPageParam: (lastPage) => {
+      const { page, totalPages } = lastPage.pagination;
+      return page < totalPages ? page + 1 : undefined;
+    },
+  });
+}

--- a/apps/web/src/features/lists/hooks/use-shared-list.test.tsx
+++ b/apps/web/src/features/lists/hooks/use-shared-list.test.tsx
@@ -1,0 +1,68 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useSharedList } from "./use-shared-list";
+
+const getSharedList = vi.fn();
+
+vi.mock("@/lib/api", () => ({
+  getSharedList: (...args: unknown[]) => getSharedList(...args),
+}));
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe("useSharedList", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    getSharedList.mockResolvedValue({
+      data: { list: { id: "list-1", name: "Paris spots" } },
+    });
+  });
+
+  it("does not fetch when shareToken is undefined", () => {
+    renderHook(() => useSharedList(undefined), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    expect(getSharedList).not.toHaveBeenCalled();
+  });
+
+  it("fetches a shared list without requiring a signed-in user", async () => {
+    const { result } = renderHook(() => useSharedList("demo-share-token"), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(getSharedList).toHaveBeenCalledWith({ path: { shareToken: "demo-share-token" } });
+    expect(result.current.data).toEqual({ list: { id: "list-1", name: "Paris spots" } });
+  });
+
+  it("throws API error when response has no data", async () => {
+    const apiError = { success: false, error: { code: "LIST_NOT_FOUND" } };
+    getSharedList.mockResolvedValue({ error: apiError });
+
+    const { result } = renderHook(() => useSharedList("missing-token"), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error).toEqual(apiError);
+  });
+});

--- a/apps/web/src/features/lists/hooks/use-shared-list.ts
+++ b/apps/web/src/features/lists/hooks/use-shared-list.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import { getSharedList } from "@/lib/api";
+import { queryKeys } from "@/lib/api/query-keys";
+
+/**
+ * Fetches a public shared list by share token. No auth gate — `GET /shared/:shareToken` is public.
+ *
+ * The query is disabled until `shareToken` is defined.
+ * API errors are thrown so they can be handled with {@link useErrorMessage}.
+ */
+export function useSharedList(shareToken: string | undefined) {
+  return useQuery({
+    queryKey: queryKeys.shared.detail(shareToken ?? ""),
+    enabled: Boolean(shareToken),
+    queryFn: async () => {
+      if (!shareToken) {
+        throw new Error("shareToken is required");
+      }
+
+      const response = await getSharedList({ path: { shareToken } });
+
+      if (response.data) {
+        return response.data;
+      }
+
+      throw response.error;
+    },
+  });
+}

--- a/apps/web/src/features/lists/index.ts
+++ b/apps/web/src/features/lists/index.ts
@@ -20,6 +20,11 @@ export { useRemoveCollaborator } from "./hooks/use-remove-collaborator";
 export { useLeaveList } from "./hooks/use-leave-list";
 export { useJoinListByEditLink } from "./hooks/use-join-list-by-edit-link";
 export { useJoinListByInvite } from "./hooks/use-join-list-by-invite";
+export { useSharedList } from "./hooks/use-shared-list";
+export {
+  useSharedListPoisInfinite,
+  SHARED_LIST_POIS_PAGE_SIZE,
+} from "./hooks/use-shared-list-pois-infinite";
 export { createListFormSchema } from "./schemas/lists.schema";
 export {
   listConstraints,
@@ -58,6 +63,7 @@ export type { RemoveCollaboratorInput } from "./hooks/use-remove-collaborator";
 export type { LeaveListInput } from "./hooks/use-leave-list";
 export type { JoinListByEditLinkInput } from "./hooks/use-join-list-by-edit-link";
 export type { JoinListByInviteInput } from "./hooks/use-join-list-by-invite";
+export type { SharedListPoisInfiniteFilters } from "./hooks/use-shared-list-pois-infinite";
 export type { CreateListFormMessages, CreateListFormData } from "./schemas/lists.schema";
 export type { ListVisibility, ListRole } from "./constants/lists.constants";
 export type { ListsSection } from "./types/lists-section.types";

--- a/apps/web/src/features/lists/views/shared-list-view.test.tsx
+++ b/apps/web/src/features/lists/views/shared-list-view.test.tsx
@@ -112,7 +112,7 @@ describe("SharedListView", () => {
     mockSharedListQuery({
       data: undefined,
       isError: true,
-      error: { success: false, error: { code: "LIST_NOT_FOUND" } },
+      error: new Error("LIST_NOT_FOUND"),
     });
 
     render(<SharedListView shareToken="missing-token" />);
@@ -126,7 +126,7 @@ describe("SharedListView", () => {
     mockSharedListQuery({
       data: undefined,
       isError: true,
-      error: { success: false, error: { code: "SHARE_TOKEN_EXPIRED" } },
+      error: new Error("SHARE_TOKEN_EXPIRED"),
     });
 
     render(<SharedListView shareToken="expired-token" />);

--- a/apps/web/src/features/lists/views/shared-list-view.test.tsx
+++ b/apps/web/src/features/lists/views/shared-list-view.test.tsx
@@ -1,0 +1,156 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useSharedList } from "../hooks/use-shared-list";
+import { useSharedListPoisInfinite } from "../hooks/use-shared-list-pois-infinite";
+
+import { SharedListView } from "./shared-list-view";
+
+import { getErrorCode } from "@/lib/api/errors";
+
+vi.mock("../hooks/use-shared-list", () => ({
+  useSharedList: vi.fn(),
+}));
+
+vi.mock("../hooks/use-shared-list-pois-infinite", () => ({
+  useSharedListPoisInfinite: vi.fn(),
+}));
+
+vi.mock("../hooks/use-infinite-scroll", () => ({
+  useInfiniteScroll: () => ({ current: null }),
+}));
+
+vi.mock("@/hooks/use-error-message", () => ({
+  useErrorMessage: () => () => "API error message",
+}));
+
+vi.mock("@/lib/api/errors", () => ({
+  getErrorCode: vi.fn(),
+}));
+
+const sharedList = {
+  id: "list-1",
+  name: "Paris spots",
+  description: "My favorite places",
+  creator: {
+    name: "Ada",
+    avatarUrl: null,
+  },
+};
+
+function mockSharedListQuery(overrides: Partial<ReturnType<typeof useSharedList>> = {}) {
+  vi.mocked(useSharedList).mockReturnValue({
+    data: { list: sharedList },
+    isPending: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+    ...overrides,
+  } as ReturnType<typeof useSharedList>);
+}
+
+function mockSharedPoisQuery(
+  overrides: Partial<ReturnType<typeof useSharedListPoisInfinite>> = {}
+) {
+  vi.mocked(useSharedListPoisInfinite).mockReturnValue({
+    data: {
+      pages: [
+        {
+          pois: [
+            {
+              id: "poi-1",
+              name: "Fraktion",
+              address: "16 rue de la Grange Batelière, Paris",
+              category: "landmark",
+            },
+            {
+              placeId: "ChIJxYJUC2lv5kcRlhdpWba_aGU",
+              name: "Le Tout-Paris",
+              address: "8 Quai du Louvre, Paris",
+              categoryDisplayName: "French Restaurant",
+            },
+          ],
+          pagination: { page: 1, limit: 20, total: 2, totalPages: 1 },
+        },
+      ],
+    },
+    isPending: false,
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+    isFetchingNextPage: false,
+    hasNextPage: false,
+    fetchNextPage: vi.fn(),
+    ...overrides,
+  } as ReturnType<typeof useSharedListPoisInfinite>);
+}
+
+describe("SharedListView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getErrorCode).mockReturnValue(null);
+    mockSharedListQuery();
+    mockSharedPoisQuery();
+  });
+
+  it("renders list name, creator, and POI cards", () => {
+    render(<SharedListView shareToken="demo-share-token" />);
+
+    expect(screen.getByRole("heading", { name: "Paris spots" })).toBeInTheDocument();
+    expect(screen.getByText("My favorite places")).toBeInTheDocument();
+    expect(screen.getByText("shared.creator.by")).toBeInTheDocument();
+    expect(screen.getByText("Fraktion")).toBeInTheDocument();
+    expect(screen.getByText("Le Tout-Paris")).toBeInTheDocument();
+    expect(screen.queryByText("demo-share-token")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "removePoi.action" })).not.toBeInTheDocument();
+  });
+
+  it("shows not found for LIST_NOT_FOUND without retry", () => {
+    vi.mocked(getErrorCode).mockReturnValue("LIST_NOT_FOUND");
+    mockSharedListQuery({
+      data: undefined,
+      isError: true,
+      error: { success: false, error: { code: "LIST_NOT_FOUND" } },
+    });
+
+    render(<SharedListView shareToken="missing-token" />);
+
+    expect(screen.getByText("shared.notFound")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "shared.error.retry" })).not.toBeInTheDocument();
+  });
+
+  it("shows expired for SHARE_TOKEN_EXPIRED without retry", () => {
+    vi.mocked(getErrorCode).mockReturnValue("SHARE_TOKEN_EXPIRED");
+    mockSharedListQuery({
+      data: undefined,
+      isError: true,
+      error: { success: false, error: { code: "SHARE_TOKEN_EXPIRED" } },
+    });
+
+    render(<SharedListView shareToken="expired-token" />);
+
+    expect(screen.getByText("shared.expired")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "shared.error.retry" })).not.toBeInTheDocument();
+  });
+
+  it("shows retry for other API errors", async () => {
+    const user = userEvent.setup();
+    const refetch = vi.fn();
+    mockSharedListQuery({
+      data: undefined,
+      isError: true,
+      error: new Error("fail"),
+      refetch,
+    });
+
+    render(<SharedListView shareToken="demo-share-token" />);
+
+    expect(screen.getByText("API error message")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "shared.error.retry" }));
+
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/features/lists/views/shared-list-view.tsx
+++ b/apps/web/src/features/lists/views/shared-list-view.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+
+import { SharedListPoisSection } from "../components/shared-list-pois-section";
+import { useSharedList } from "../hooks/use-shared-list";
+
+import { Avatar, AvatarFallback, AvatarImage, Button } from "@/components/ui";
+import { useErrorMessage } from "@/hooks/use-error-message";
+import { getErrorCode } from "@/lib/api/errors";
+
+type SharedListViewProps = {
+  shareToken: string;
+};
+
+function creatorInitial(name: string | null | undefined) {
+  const trimmed = name?.trim();
+  return trimmed ? trimmed.slice(0, 1).toUpperCase() : "?";
+}
+
+export function SharedListView({ shareToken }: SharedListViewProps) {
+  const tLists = useTranslations("lists");
+  const getErrorMessage = useErrorMessage();
+  const { data, isPending, isError, error, refetch } = useSharedList(shareToken);
+
+  const list = data?.list;
+  const errorCode = isError ? getErrorCode(error) : null;
+  const isNotFound = errorCode === "LIST_NOT_FOUND";
+  const isExpired = errorCode === "SHARE_TOKEN_EXPIRED";
+
+  if (isPending) {
+    return <p className="text-sm text-muted-foreground">{tLists("shared.loading")}</p>;
+  }
+
+  if (isError) {
+    return (
+      <div className="grid gap-3 py-4" role="alert">
+        <p className="text-sm text-muted-foreground">
+          {isNotFound
+            ? tLists("shared.notFound")
+            : isExpired
+              ? tLists("shared.expired")
+              : getErrorMessage(error)}
+        </p>
+        {!isNotFound && !isExpired ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="w-fit"
+            onClick={() => refetch()}
+          >
+            {tLists("shared.error.retry")}
+          </Button>
+        ) : null}
+      </div>
+    );
+  }
+
+  if (!list) {
+    return null;
+  }
+
+  const creatorName = list.creator?.name?.trim() || null;
+  const creatorAvatarUrl = list.creator?.avatarUrl;
+
+  return (
+    <div className="grid gap-6">
+      <header className="grid gap-3">
+        <h1 className="font-display text-2xl font-semibold tracking-tight">
+          {list.name?.trim() || tLists("shared.title")}
+        </h1>
+        {list.description?.trim() ? (
+          <p className="text-sm text-muted-foreground">{list.description}</p>
+        ) : null}
+        <div className="flex items-center gap-2">
+          <Avatar>
+            {creatorAvatarUrl ? <AvatarImage src={creatorAvatarUrl} alt="" /> : null}
+            <AvatarFallback>{creatorInitial(creatorName)}</AvatarFallback>
+          </Avatar>
+          <p className="text-sm text-muted-foreground">
+            {creatorName
+              ? tLists("shared.creator.by", { name: creatorName })
+              : tLists("shared.creator.unknown")}
+          </p>
+        </div>
+      </header>
+      <SharedListPoisSection shareToken={shareToken} />
+    </div>
+  );
+}

--- a/apps/web/src/features/pois/index.ts
+++ b/apps/web/src/features/pois/index.ts
@@ -6,6 +6,7 @@ export {
   getPoiDisplayDataFromSavedPoi,
   getPoiDisplayDataFromPoi,
   getPoiDisplayDataFromGooglePlace,
+  getPoiDisplayDataFromSharedPoi,
 } from "./utils/get-poi-display-data";
 
 export {

--- a/apps/web/src/features/pois/utils/get-poi-display-data.test.ts
+++ b/apps/web/src/features/pois/utils/get-poi-display-data.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { getPoiDisplayDataFromSavedPoi } from "./get-poi-display-data";
+import {
+  getPoiDisplayDataFromSavedPoi,
+  getPoiDisplayDataFromSharedPoi,
+} from "./get-poi-display-data";
 
 import type { Poi } from "@/lib/api";
 
@@ -104,5 +107,48 @@ describe("getPoiDisplayDataFromSavedPoi", () => {
       name: "Google name",
       source: "google",
     });
+  });
+});
+
+describe("getPoiDisplayDataFromSharedPoi", () => {
+  it("maps a flattened custom POI", () => {
+    expect(
+      getPoiDisplayDataFromSharedPoi({
+        id: "poi-1",
+        name: "Tour Eiffel",
+        address: "Champ de Mars, Paris",
+        category: "monument",
+        photoUrls: ["https://example.com/eiffel.jpg"],
+      })
+    ).toMatchObject({
+      id: "poi-1",
+      name: "Tour Eiffel",
+      address: "Champ de Mars, Paris",
+      category: "monument",
+      source: "custom",
+      photo: { kind: "url", url: "https://example.com/eiffel.jpg" },
+    });
+  });
+
+  it("maps a flattened Google Place when placeId is present", () => {
+    expect(
+      getPoiDisplayDataFromSharedPoi({
+        placeId: "ChIJ...",
+        name: "Café de Flore",
+        address: "172 Bd Saint-Germain, Paris",
+        categoryDisplayName: "Café",
+        photoReferences: ["places/abc/photos/ref1"],
+      })
+    ).toMatchObject({
+      id: "ChIJ...",
+      name: "Café de Flore",
+      source: "google",
+      photo: { kind: "google-ref", photoRef: "places/abc/photos/ref1" },
+    });
+  });
+
+  it("returns null for non-objects", () => {
+    expect(getPoiDisplayDataFromSharedPoi(null)).toBeNull();
+    expect(getPoiDisplayDataFromSharedPoi(undefined)).toBeNull();
   });
 });

--- a/apps/web/src/features/pois/utils/get-poi-display-data.ts
+++ b/apps/web/src/features/pois/utils/get-poi-display-data.ts
@@ -109,3 +109,29 @@ export function getPoiDisplayDataFromSavedPoi(savedPoi: SavedPoiListItem): PoiDi
 
   return null;
 }
+
+function isGooglePlace(value: unknown): value is GooglePlace {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "placeId" in value &&
+    typeof (value as { placeId?: unknown }).placeId === "string" &&
+    Boolean((value as { placeId: string }).placeId)
+  );
+}
+
+/**
+ * Maps a flattened public shared POI (`Poi` or `GooglePlace`) to display data.
+ * `placeId` identifies a Google Place; everything else is treated as a custom POI.
+ */
+export function getPoiDisplayDataFromSharedPoi(poi: unknown): PoiDisplayData | null {
+  if (!poi || typeof poi !== "object") {
+    return null;
+  }
+
+  if (isGooglePlace(poi)) {
+    return getPoiDisplayDataFromGooglePlace(poi);
+  }
+
+  return getPoiDisplayDataFromPoi(poi as Poi);
+}

--- a/apps/web/src/lib/api/query-keys.ts
+++ b/apps/web/src/lib/api/query-keys.ts
@@ -1,4 +1,9 @@
-import { GetCollaboratorsData, GetListPoisData, GetListsData } from "./generated/types.gen";
+import {
+  GetCollaboratorsData,
+  GetListPoisData,
+  GetListsData,
+  GetSharedListPoisData,
+} from "./generated/types.gen";
 
 import { ListPoisInfiniteFilters } from "@/features/lists/hooks/use-list-pois-infinite";
 import type { ListsInfiniteFilters } from "@/features/lists/hooks/use-lists-infinite";
@@ -7,9 +12,11 @@ import type { ListsInfiniteFilters } from "@/features/lists/hooks/use-lists-infi
 // initializer makes TypeScript infer `any`, which silently widens every `useQuery` result.
 const GOOGLE_PLACES_ROOT = ["google-places"] as const;
 const LISTS_ROOT = ["lists"] as const;
+const SHARED_ROOT = ["shared"] as const;
 
 const listPoisRoot = (listId: string) => [...LISTS_ROOT, "pois", listId] as const;
 const listCollaboratorsRoot = (listId: string) => [...LISTS_ROOT, "collaborators", listId] as const;
+const sharedPoisRoot = (shareToken: string) => [...SHARED_ROOT, "pois", shareToken] as const;
 
 export const queryKeys = {
   googlePlaces: {
@@ -38,6 +45,16 @@ export const queryKeys = {
       all: listCollaboratorsRoot,
       list: (listId: string, filters?: GetCollaboratorsData["query"]) =>
         [...listCollaboratorsRoot(listId), filters] as const,
+    },
+  },
+  shared: {
+    all: SHARED_ROOT,
+    detail: (shareToken: string) => [...SHARED_ROOT, "detail", shareToken] as const,
+    pois: {
+      infinite: (
+        shareToken: string,
+        filters?: Omit<NonNullable<GetSharedListPoisData["query"]>, "page">
+      ) => [...sharedPoisRoot(shareToken), "infinite", filters] as const,
     },
   },
 };

--- a/apps/web/src/lib/i18n/locales-parity.test.tsx
+++ b/apps/web/src/lib/i18n/locales-parity.test.tsx
@@ -49,6 +49,9 @@ const NEW_LISTS_KEYS = [
   "collaborators.section.title",
   "collaborators.invite.submit",
   "collaborators.leaveConfirm",
+  "shared.title",
+  "shared.notFound",
+  "shared.expired",
 ] as const;
 
 const NEW_EXPLORE_KEYS = [

--- a/apps/web/src/lib/i18n/locales/en/lists.json
+++ b/apps/web/src/lib/i18n/locales/en/lists.json
@@ -171,5 +171,18 @@
     "leaveConfirm": "Leave",
     "leaveSuccess": "You left the list",
     "leaveError": "Could not leave the list"
+  },
+  "shared": {
+    "title": "Shared list",
+    "loading": "Loading shared list…",
+    "notFound": "This shared list was not found",
+    "expired": "This share link has expired",
+    "error": {
+      "retry": "Retry"
+    },
+    "creator": {
+      "by": "By {name}",
+      "unknown": "Shared list"
+    }
   }
 }

--- a/apps/web/src/lib/i18n/locales/fr/lists.json
+++ b/apps/web/src/lib/i18n/locales/fr/lists.json
@@ -171,5 +171,18 @@
     "leaveConfirm": "Quitter",
     "leaveSuccess": "Tu as quitté la liste",
     "leaveError": "Impossible de quitter la liste"
+  },
+  "shared": {
+    "title": "Liste partagée",
+    "loading": "Chargement de la liste partagée…",
+    "notFound": "Cette liste partagée est introuvable",
+    "expired": "Ce lien de partage a expiré",
+    "error": {
+      "retry": "Réessayer"
+    },
+    "creator": {
+      "by": "Par {name}",
+      "unknown": "Liste partagée"
+    }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Description

Adds the public read-only shared list page at `/shared/[shareToken]` (NIR-77 / GitHub #154). Visitors can open a share link without signing in. Invalid and expired tokens show dedicated states.

The route lives outside the map shell and `AuthGate`. Sharing hooks from #168 and Share UI from #169 are unchanged.

## 🎯 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] ✅ Test update

## 🔗 Related Issues

Closes #154
Related to NIR-68 / NIR-77

## 🚀 Changes Made

- Query keys `shared.detail` / `shared.pois.infinite`
- `useSharedList` and `useSharedListPoisInfinite` (no auth gate)
- Mapper `getPoiDisplayDataFromSharedPoi` for flattened public POIs (`placeId` → Google)
- Route `app/shared/[shareToken]` with Logo + language layout
- Read-only view: name, creator, `PoiCard` list, infinite scroll
- Token states: `LIST_NOT_FOUND`, `SHARE_TOKEN_EXPIRED`, other errors + retry
- i18n `lists.shared.*` (en + fr)
- CI typecheck: mock query errors as `Error` (React Query `error` type)

## 🧪 Testing

- [ ] Tested locally with `pnpm dev`
- [x] All quality checks pass (`pnpm --filter @nirby/web lint` and `tsc --noEmit`)
- [x] Unit tests pass (`pnpm --filter @nirby/web test` — 300 tests)
- [ ] Database migrations applied if needed

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated if needed
- [x] No console errors or warnings
- [x] Removed any debug code

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffb89-2207-7758-8794-ec303f733868?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffb89-2207-7758-8794-ec303f733868&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

