### PR TITLE
feat(web): add join and invite accept flows (#155)

### DIFF
--- a/apps/web/src/app/(auth)/login/page.test.tsx
+++ b/apps/web/src/app/(auth)/login/page.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import LoginPage from "./page";
+
+const push = vi.fn();
+const login = vi.fn();
+let searchParams = new URLSearchParams();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push,
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+    back: vi.fn(),
+  }),
+  useSearchParams: () => searchParams,
+}));
+
+vi.mock("@/features/auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/auth")>();
+  return {
+    ...actual,
+    useAuth: () => ({ login }),
+  };
+});
+
+vi.mock("@/hooks/use-error-message", () => ({
+  useErrorMessage: () => () => "API error message",
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+describe("LoginPage returnUrl", () => {
+  beforeEach(() => {
+    push.mockClear();
+    login.mockReset();
+    login.mockResolvedValue(undefined);
+    searchParams = new URLSearchParams();
+  });
+
+  async function submitValidCredentials() {
+    const user = userEvent.setup();
+    await user.type(screen.getByRole("textbox"), "user@example.com");
+    await user.type(screen.getByPlaceholderText("••••••••"), "password1");
+    await user.click(screen.getByRole("button", { name: "auth.login.login" }));
+  }
+
+  it("redirects to a safe returnUrl after login", async () => {
+    searchParams = new URLSearchParams("returnUrl=/list/list-1/join?editToken=edit-token");
+    render(<LoginPage />);
+
+    await submitValidCredentials();
+
+    await waitFor(() => {
+      expect(login).toHaveBeenCalledWith("user@example.com", "password1");
+      expect(push).toHaveBeenCalledWith("/list/list-1/join?editToken=edit-token");
+    });
+  });
+
+  it("redirects to / when returnUrl is missing", async () => {
+    render(<LoginPage />);
+
+    await submitValidCredentials();
+
+    await waitFor(() => {
+      expect(push).toHaveBeenCalledWith("/");
+    });
+  });
+
+  it("redirects to / when returnUrl is unsafe", async () => {
+    searchParams = new URLSearchParams("returnUrl=https://evil.example");
+    render(<LoginPage />);
+
+    await submitValidCredentials();
+
+    await waitFor(() => {
+      expect(push).toHaveBeenCalledWith("/");
+    });
+  });
+
+  it("keeps returnUrl on the signup link", () => {
+    searchParams = new URLSearchParams("returnUrl=/list/list-1/join?editToken=edit-token");
+    render(<LoginPage />);
+
+    expect(screen.getByRole("link", { name: "auth.login.signup" })).toHaveAttribute(
+      "href",
+      "/signup?returnUrl=%2Flist%2Flist-1%2Fjoin%3FeditToken%3Dedit-token"
+    );
+  });
+});

--- a/apps/web/src/app/(auth)/login/page.tsx
+++ b/apps/web/src/app/(auth)/login/page.tsx
@@ -3,7 +3,7 @@
 import { standardSchemaResolver } from "@hookform/resolvers/standard-schema";
 import { Eye, EyeOff } from "lucide-react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useState, useMemo } from "react";
 import { useForm } from "react-hook-form";
@@ -21,13 +21,20 @@ import {
 import { Input } from "@/components/ui/input";
 import { useAuth, type LoginSignupFormData, createLoginSignupSchema } from "@/features/auth";
 import { useErrorMessage } from "@/hooks/use-error-message";
+import {
+  RETURN_URL_PARAM,
+  buildSignupHref,
+  getSafeReturnPath,
+} from "@/lib/navigation/auth-redirect";
 
 export default function LoginPage() {
   const [showPassword, setShowPassword] = useState(false);
   const { login } = useAuth();
   const router = useRouter();
+  const searchParams = useSearchParams();
   const t = useTranslations();
   const getErrorMessage = useErrorMessage();
+  const safeReturnPath = getSafeReturnPath(searchParams.get(RETURN_URL_PARAM));
 
   const loginSchema = useMemo(
     () =>
@@ -50,7 +57,7 @@ export default function LoginPage() {
   async function onSubmit(values: LoginSignupFormData) {
     try {
       await login(values.email, values.password);
-      router.push("/");
+      router.push(safeReturnPath ?? "/");
     } catch (error) {
       toast.error(t("auth.login.loginError"), {
         description: getErrorMessage(error),
@@ -146,7 +153,10 @@ export default function LoginPage() {
 
         <div className="text-center text-base lg:text-sm pt-4">
           <span className="text-muted-foreground">{t("auth.login.noAccount")} </span>
-          <Link href="/signup" className="font-semibold text-primary hover:underline">
+          <Link
+            href={safeReturnPath ? buildSignupHref(safeReturnPath) : "/signup"}
+            className="font-semibold text-primary hover:underline"
+          >
             {t("auth.login.signup")}
           </Link>
         </div>

--- a/apps/web/src/app/(auth)/signup/page.tsx
+++ b/apps/web/src/app/(auth)/signup/page.tsx
@@ -3,6 +3,7 @@
 import { standardSchemaResolver } from "@hookform/resolvers/standard-schema";
 import { ArrowLeft, Eye, EyeOff, Mail } from "lucide-react";
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
@@ -20,14 +21,21 @@ import {
 import { Input } from "@/components/ui/input";
 import { useAuth, type LoginSignupFormData, createLoginSignupSchema } from "@/features/auth";
 import { useErrorMessage } from "@/hooks/use-error-message";
+import {
+  RETURN_URL_PARAM,
+  buildLoginHref,
+  getSafeReturnPath,
+} from "@/lib/navigation/auth-redirect";
 
 export default function SignupPage() {
   const [showPassword, setShowPassword] = useState(false);
   const [emailSent, setEmailSent] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const { signup, resendEmail } = useAuth();
+  const searchParams = useSearchParams();
   const t = useTranslations();
   const getErrorMessage = useErrorMessage();
+  const safeReturnPath = getSafeReturnPath(searchParams.get(RETURN_URL_PARAM));
 
   const signupSchema = useMemo(
     () =>
@@ -190,7 +198,10 @@ export default function SignupPage() {
 
             <div className="text-center text-base lg:text-sm pt-4">
               <span className="text-muted-foreground">{t("auth.signup.noAccount")} </span>
-              <Link href="/login" className="font-semibold text-primary hover:underline">
+              <Link
+                href={safeReturnPath ? buildLoginHref(safeReturnPath) : "/login"}
+                className="font-semibold text-primary hover:underline"
+              >
                 {t("auth.signup.login")}
               </Link>
             </div>

--- a/apps/web/src/app/list/[listId]/collaborators/accept/page.tsx
+++ b/apps/web/src/app/list/[listId]/collaborators/accept/page.tsx
@@ -1,0 +1,24 @@
+import { AcceptInviteView } from "@/features/lists/views/accept-invite-view";
+
+type AcceptInvitePageProps = {
+  params: Promise<{ listId: string }>;
+  searchParams: Promise<{ token?: string | string[] }>;
+};
+
+function firstParam(value: string | string[] | undefined): string | null {
+  const raw = Array.isArray(value) ? value[0] : value;
+  return raw && raw.length > 0 ? raw : null;
+}
+
+export default async function AcceptInvitePage({ params, searchParams }: AcceptInvitePageProps) {
+  const { listId } = await params;
+  const token = firstParam((await searchParams).token);
+  const query = new URLSearchParams();
+  if (token) {
+    query.set("token", token);
+  }
+  const qs = query.toString();
+  const returnPath = `/list/${listId}/collaborators/accept${qs ? `?${qs}` : ""}`;
+
+  return <AcceptInviteView listId={listId} token={token} returnPath={returnPath} />;
+}

--- a/apps/web/src/app/list/[listId]/join/page.tsx
+++ b/apps/web/src/app/list/[listId]/join/page.tsx
@@ -1,0 +1,24 @@
+import { JoinListView } from "@/features/lists/views/join-list-view";
+
+type JoinListPageProps = {
+  params: Promise<{ listId: string }>;
+  searchParams: Promise<{ editToken?: string | string[] }>;
+};
+
+function firstParam(value: string | string[] | undefined): string | null {
+  const raw = Array.isArray(value) ? value[0] : value;
+  return raw && raw.length > 0 ? raw : null;
+}
+
+export default async function JoinListPage({ params, searchParams }: JoinListPageProps) {
+  const { listId } = await params;
+  const editToken = firstParam((await searchParams).editToken);
+  const query = new URLSearchParams();
+  if (editToken) {
+    query.set("editToken", editToken);
+  }
+  const qs = query.toString();
+  const returnPath = `/list/${listId}/join${qs ? `?${qs}` : ""}`;
+
+  return <JoinListView editToken={editToken} returnPath={returnPath} />;
+}

--- a/apps/web/src/app/list/layout.tsx
+++ b/apps/web/src/app/list/layout.tsx
@@ -1,0 +1,21 @@
+import Link from "next/link";
+
+import { Logo } from "@/components/logo";
+import { LanguageSelector } from "@/components/ui/language-selector";
+
+export default function ListJoinLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="bg-background text-foreground min-h-screen">
+      <header className="border-b border-border">
+        <div className="mx-auto flex max-w-2xl items-center justify-between px-4 py-4">
+          <Link href="/" className="flex items-center gap-2 text-foreground">
+            <Logo className="h-8 w-8" />
+            <span className="font-display text-xl font-bold">Nirby</span>
+          </Link>
+          <LanguageSelector />
+        </div>
+      </header>
+      <main className="mx-auto max-w-2xl px-4 py-8">{children}</main>
+    </div>
+  );
+}

--- a/apps/web/src/features/auth/components/auth-required-prompt.component.tsx
+++ b/apps/web/src/features/auth/components/auth-required-prompt.component.tsx
@@ -5,9 +5,16 @@ import Link from "next/link";
 import { useTranslations } from "next-intl";
 
 import { Button, Card, CardInset } from "@/components/ui";
+import { buildLoginHref, buildSignupHref } from "@/lib/navigation/auth-redirect";
 
-export function AuthRequiredPrompt() {
+type AuthRequiredPromptProps = {
+  returnPath?: string;
+};
+
+export function AuthRequiredPrompt({ returnPath }: AuthRequiredPromptProps) {
   const t = useTranslations("auth.required");
+  const loginHref = returnPath ? buildLoginHref(returnPath) : "/login";
+  const signupHref = returnPath ? buildSignupHref(returnPath) : "/signup";
 
   return (
     <div className="flex min-h-56 flex-col items-center justify-center py-8">
@@ -21,11 +28,11 @@ export function AuthRequiredPrompt() {
             <p className="text-sm text-muted-foreground">{t("description")}</p>
           </div>
           <Button asChild className="w-full">
-            <Link href="/login">{t("login")}</Link>
+            <Link href={loginHref}>{t("login")}</Link>
           </Button>
           <p className="text-sm text-muted-foreground">
             {t("noAccount")}{" "}
-            <Link href="/signup" className="font-semibold text-primary hover:underline">
+            <Link href={signupHref} className="font-semibold text-primary hover:underline">
               {t("signup")}
             </Link>
           </p>

--- a/apps/web/src/features/lists/views/accept-invite-view.test.tsx
+++ b/apps/web/src/features/lists/views/accept-invite-view.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useJoinListByInvite } from "../hooks/use-join-list-by-invite";
+
+import { AcceptInviteView } from "./accept-invite-view";
+
+const push = vi.fn();
+const mutate = vi.fn();
+const useAuth = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push,
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+    back: vi.fn(),
+  }),
+}));
+
+vi.mock("@/features/auth", () => ({
+  useAuth: () => useAuth(),
+}));
+
+vi.mock("../hooks/use-join-list-by-invite", () => ({
+  useJoinListByInvite: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-error-message", () => ({
+  useErrorMessage: () => (error: unknown) => {
+    if (
+      typeof error === "object" &&
+      error !== null &&
+      "error" in error &&
+      typeof error.error === "object" &&
+      error.error !== null &&
+      "code" in error.error
+    ) {
+      return String(error.error.code);
+    }
+    return "API error message";
+  },
+}));
+
+const returnPath = "/list/list-1/collaborators/accept?token=invite-token";
+
+function mockMutation(overrides: Partial<ReturnType<typeof useJoinListByInvite>> = {}) {
+  vi.mocked(useJoinListByInvite).mockReturnValue({
+    mutate,
+    error: null,
+    isPending: false,
+    isError: false,
+    ...overrides,
+  } as ReturnType<typeof useJoinListByInvite>);
+}
+
+describe("AcceptInviteView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mutate.mockReset();
+    useAuth.mockReturnValue({
+      user: { id: "user-1", email: "ada@example.com" },
+      isLoading: false,
+    });
+    mockMutation();
+  });
+
+  it("shows COLLABORATOR_ALREADY_EXISTS and does not redirect", () => {
+    const apiError = { success: false, error: { code: "COLLABORATOR_ALREADY_EXISTS" } };
+    mockMutation({
+      isError: true,
+      error: apiError,
+    });
+
+    render(<AcceptInviteView listId="list-1" token="invite-token" returnPath={returnPath} />);
+
+    expect(screen.getByRole("alert")).toHaveTextContent("COLLABORATOR_ALREADY_EXISTS");
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("joins once and navigates using the joined list id", () => {
+    mutate.mockImplementation((_vars, options) => {
+      options?.onSuccess?.({ list: { id: "joined-list" } });
+    });
+
+    render(<AcceptInviteView listId="url-list" token="invite-token" returnPath={returnPath} />);
+
+    expect(mutate).toHaveBeenCalledWith(
+      { listId: "url-list", token: "invite-token" },
+      expect.objectContaining({ onSuccess: expect.any(Function) })
+    );
+    expect(push).toHaveBeenCalledWith("/?view=lists&listId=joined-list");
+  });
+});

--- a/apps/web/src/features/lists/views/accept-invite-view.test.tsx
+++ b/apps/web/src/features/lists/views/accept-invite-view.test.tsx
@@ -27,19 +27,8 @@ vi.mock("../hooks/use-join-list-by-invite", () => ({
 }));
 
 vi.mock("@/hooks/use-error-message", () => ({
-  useErrorMessage: () => (error: unknown) => {
-    if (
-      typeof error === "object" &&
-      error !== null &&
-      "error" in error &&
-      typeof error.error === "object" &&
-      error.error !== null &&
-      "code" in error.error
-    ) {
-      return String(error.error.code);
-    }
-    return "API error message";
-  },
+  useErrorMessage: () => (error: unknown) =>
+    error instanceof Error ? error.message : "API error message",
 }));
 
 const returnPath = "/list/list-1/collaborators/accept?token=invite-token";
@@ -66,10 +55,9 @@ describe("AcceptInviteView", () => {
   });
 
   it("shows COLLABORATOR_ALREADY_EXISTS and does not redirect", () => {
-    const apiError = { success: false, error: { code: "COLLABORATOR_ALREADY_EXISTS" } };
     mockMutation({
       isError: true,
-      error: apiError,
+      error: new Error("COLLABORATOR_ALREADY_EXISTS"),
     });
 
     render(<AcceptInviteView listId="list-1" token="invite-token" returnPath={returnPath} />);

--- a/apps/web/src/features/lists/views/accept-invite-view.tsx
+++ b/apps/web/src/features/lists/views/accept-invite-view.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect, useRef } from "react";
+
+import { buildListsNavigationSearchParams } from "../constants/lists.constants";
+import { useJoinListByInvite } from "../hooks/use-join-list-by-invite";
+
+import { JoinFlowView } from "./join-flow-view";
+
+import { useAuth } from "@/features/auth";
+
+type AcceptInviteViewProps = {
+  listId: string;
+  token: string | null;
+  returnPath: string;
+};
+
+export function AcceptInviteView({ listId, token, returnPath }: AcceptInviteViewProps) {
+  const { user, isLoading } = useAuth();
+  const router = useRouter();
+  const { mutate, error, isPending, isError } = useJoinListByInvite();
+  const didJoin = useRef(false);
+  const isAuthenticated = Boolean(user);
+
+  useEffect(() => {
+    if (!isAuthenticated || !token || didJoin.current) {
+      return;
+    }
+    didJoin.current = true;
+    mutate(
+      { listId, token },
+      {
+        onSuccess: (data) => {
+          router.push(`/${buildListsNavigationSearchParams(new URLSearchParams(), data.list.id)}`);
+        },
+      }
+    );
+  }, [isAuthenticated, listId, mutate, router, token]);
+
+  return (
+    <JoinFlowView
+      mode="accept"
+      returnPath={returnPath}
+      token={token}
+      isAuthLoading={isLoading}
+      isAuthenticated={isAuthenticated}
+      isJoining={isPending}
+      error={isError ? error : null}
+    />
+  );
+}

--- a/apps/web/src/features/lists/views/join-flow-view.tsx
+++ b/apps/web/src/features/lists/views/join-flow-view.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+import { AuthRequiredPrompt } from "@/features/auth/components/auth-required-prompt.component";
+import { useErrorMessage } from "@/hooks/use-error-message";
+
+type JoinFlowMode = "edit" | "accept";
+
+type JoinFlowViewProps = {
+  mode: JoinFlowMode;
+  returnPath: string;
+  token: string | null;
+  isAuthLoading: boolean;
+  isAuthenticated: boolean;
+  isJoining: boolean;
+  error: unknown;
+};
+
+export function JoinFlowView({
+  mode,
+  returnPath,
+  token,
+  isAuthLoading,
+  isAuthenticated,
+  isJoining,
+  error,
+}: JoinFlowViewProps) {
+  const tLists = useTranslations("lists");
+  const getErrorMessage = useErrorMessage();
+  const title = tLists(`join.${mode}.title`);
+  const description = tLists(`join.${mode}.description`);
+
+  if (isAuthLoading) {
+    return (
+      <div
+        className="flex min-h-56 items-center justify-center py-8"
+        aria-busy="true"
+        aria-label="Loading"
+      >
+        <Loader2 className="size-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-4">
+      <header className="grid gap-2">
+        <h1 className="font-display text-2xl font-semibold tracking-tight">{title}</h1>
+        {!isAuthenticated ? <p className="text-sm text-muted-foreground">{description}</p> : null}
+      </header>
+      {!isAuthenticated ? <AuthRequiredPrompt returnPath={returnPath} /> : null}
+      {isAuthenticated && !token ? (
+        <p className="text-sm text-muted-foreground" role="alert">
+          {tLists("join.missingToken")}
+        </p>
+      ) : null}
+      {isAuthenticated && token && error ? (
+        <p className="text-sm text-muted-foreground" role="alert">
+          {getErrorMessage(error)}
+        </p>
+      ) : null}
+      {isAuthenticated && token && !error ? (
+        <div
+          className="flex items-center gap-2 text-sm text-muted-foreground"
+          aria-busy={isJoining}
+          aria-label={tLists("join.joining")}
+        >
+          <Loader2 className="size-4 animate-spin" />
+          <p>{tLists("join.joining")}</p>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/features/lists/views/join-list-view.test.tsx
+++ b/apps/web/src/features/lists/views/join-list-view.test.tsx
@@ -27,19 +27,8 @@ vi.mock("../hooks/use-join-list-by-edit-link", () => ({
 }));
 
 vi.mock("@/hooks/use-error-message", () => ({
-  useErrorMessage: () => (error: unknown) => {
-    if (
-      typeof error === "object" &&
-      error !== null &&
-      "error" in error &&
-      typeof error.error === "object" &&
-      error.error !== null &&
-      "code" in error.error
-    ) {
-      return String(error.error.code);
-    }
-    return "API error message";
-  },
+  useErrorMessage: () => (error: unknown) =>
+    error instanceof Error ? error.message : "API error message",
 }));
 
 const returnPath = "/list/url-list/join?editToken=edit-token";
@@ -95,10 +84,9 @@ describe("JoinListView", () => {
   });
 
   it("shows an API error and does not redirect when the token is invalid", () => {
-    const apiError = { success: false, error: { code: "LIST_NOT_FOUND" } };
     mockMutation({
       isError: true,
-      error: apiError,
+      error: new Error("LIST_NOT_FOUND"),
     });
 
     render(<JoinListView editToken="bad-token" returnPath={returnPath} />);

--- a/apps/web/src/features/lists/views/join-list-view.test.tsx
+++ b/apps/web/src/features/lists/views/join-list-view.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useJoinListByEditLink } from "../hooks/use-join-list-by-edit-link";
+
+import { JoinListView } from "./join-list-view";
+
+const push = vi.fn();
+const mutate = vi.fn();
+const useAuth = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push,
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+    back: vi.fn(),
+  }),
+}));
+
+vi.mock("@/features/auth", () => ({
+  useAuth: () => useAuth(),
+}));
+
+vi.mock("../hooks/use-join-list-by-edit-link", () => ({
+  useJoinListByEditLink: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-error-message", () => ({
+  useErrorMessage: () => (error: unknown) => {
+    if (
+      typeof error === "object" &&
+      error !== null &&
+      "error" in error &&
+      typeof error.error === "object" &&
+      error.error !== null &&
+      "code" in error.error
+    ) {
+      return String(error.error.code);
+    }
+    return "API error message";
+  },
+}));
+
+const returnPath = "/list/url-list/join?editToken=edit-token";
+
+function mockMutation(overrides: Partial<ReturnType<typeof useJoinListByEditLink>> = {}) {
+  vi.mocked(useJoinListByEditLink).mockReturnValue({
+    mutate,
+    error: null,
+    isPending: false,
+    isError: false,
+    ...overrides,
+  } as ReturnType<typeof useJoinListByEditLink>);
+}
+
+describe("JoinListView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mutate.mockReset();
+    useAuth.mockReturnValue({
+      user: { id: "user-1", email: "ada@example.com" },
+      isLoading: false,
+    });
+    mockMutation();
+  });
+
+  it("links to login with returnUrl containing editToken when logged out", () => {
+    useAuth.mockReturnValue({ user: null, isLoading: false });
+
+    render(<JoinListView editToken="edit-token" returnPath={returnPath} />);
+
+    expect(screen.getByRole("heading", { name: "join.edit.title" })).toBeInTheDocument();
+    expect(screen.getByText("join.edit.description")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "login" })).toHaveAttribute(
+      "href",
+      "/login?returnUrl=%2Flist%2Furl-list%2Fjoin%3FeditToken%3Dedit-token"
+    );
+    expect(mutate).not.toHaveBeenCalled();
+  });
+
+  it("joins once and navigates to the lists detail using the joined list id", () => {
+    mutate.mockImplementation((_vars, options) => {
+      options?.onSuccess?.({ list: { id: "joined-list" } });
+    });
+
+    render(<JoinListView editToken="edit-token" returnPath={returnPath} />);
+
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(mutate).toHaveBeenCalledWith(
+      { editToken: "edit-token" },
+      expect.objectContaining({ onSuccess: expect.any(Function) })
+    );
+    expect(push).toHaveBeenCalledWith("/?view=lists&listId=joined-list");
+  });
+
+  it("shows an API error and does not redirect when the token is invalid", () => {
+    const apiError = { success: false, error: { code: "LIST_NOT_FOUND" } };
+    mockMutation({
+      isError: true,
+      error: apiError,
+    });
+
+    render(<JoinListView editToken="bad-token" returnPath={returnPath} />);
+
+    expect(screen.getByRole("alert")).toHaveTextContent("LIST_NOT_FOUND");
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("shows missingToken and does not call the API when the token is absent", () => {
+    render(<JoinListView editToken={null} returnPath="/list/url-list/join" />);
+
+    expect(screen.getByRole("alert")).toHaveTextContent("join.missingToken");
+    expect(mutate).not.toHaveBeenCalled();
+    expect(push).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/features/lists/views/join-list-view.tsx
+++ b/apps/web/src/features/lists/views/join-list-view.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect, useRef } from "react";
+
+import { buildListsNavigationSearchParams } from "../constants/lists.constants";
+import { useJoinListByEditLink } from "../hooks/use-join-list-by-edit-link";
+
+import { JoinFlowView } from "./join-flow-view";
+
+import { useAuth } from "@/features/auth";
+
+type JoinListViewProps = {
+  editToken: string | null;
+  returnPath: string;
+};
+
+export function JoinListView({ editToken, returnPath }: JoinListViewProps) {
+  const { user, isLoading } = useAuth();
+  const router = useRouter();
+  const { mutate, error, isPending, isError } = useJoinListByEditLink();
+  const didJoin = useRef(false);
+  const isAuthenticated = Boolean(user);
+
+  useEffect(() => {
+    if (!isAuthenticated || !editToken || didJoin.current) {
+      return;
+    }
+    didJoin.current = true;
+    mutate(
+      { editToken },
+      {
+        onSuccess: (data) => {
+          router.push(`/${buildListsNavigationSearchParams(new URLSearchParams(), data.list.id)}`);
+        },
+      }
+    );
+  }, [editToken, isAuthenticated, mutate, router]);
+
+  return (
+    <JoinFlowView
+      mode="edit"
+      returnPath={returnPath}
+      token={editToken}
+      isAuthLoading={isLoading}
+      isAuthenticated={isAuthenticated}
+      isJoining={isPending}
+      error={isError ? error : null}
+    />
+  );
+}

--- a/apps/web/src/lib/i18n/locales-parity.test.tsx
+++ b/apps/web/src/lib/i18n/locales-parity.test.tsx
@@ -52,6 +52,12 @@ const NEW_LISTS_KEYS = [
   "shared.title",
   "shared.notFound",
   "shared.expired",
+  "join.edit.title",
+  "join.edit.description",
+  "join.accept.title",
+  "join.accept.description",
+  "join.missingToken",
+  "join.joining",
 ] as const;
 
 const NEW_EXPLORE_KEYS = [

--- a/apps/web/src/lib/i18n/locales/en/lists.json
+++ b/apps/web/src/lib/i18n/locales/en/lists.json
@@ -184,5 +184,17 @@
       "by": "By {name}",
       "unknown": "Shared list"
     }
+  },
+  "join": {
+    "edit": {
+      "title": "Join this list",
+      "description": "Sign in to join this list as an editor."
+    },
+    "accept": {
+      "title": "Accept invitation",
+      "description": "Sign in with the email address this invitation was sent to."
+    },
+    "missingToken": "This invite link is missing a token.",
+    "joining": "Joining the list…"
   }
 }

--- a/apps/web/src/lib/i18n/locales/fr/lists.json
+++ b/apps/web/src/lib/i18n/locales/fr/lists.json
@@ -184,5 +184,17 @@
       "by": "Par {name}",
       "unknown": "Liste partagée"
     }
+  },
+  "join": {
+    "edit": {
+      "title": "Rejoindre cette liste",
+      "description": "Connecte-toi pour rejoindre cette liste en tant qu'éditeur."
+    },
+    "accept": {
+      "title": "Accepter l'invitation",
+      "description": "Connecte-toi avec l'adresse e-mail à laquelle cette invitation a été envoyée."
+    },
+    "missingToken": "Ce lien d'invitation n'a pas de jeton.",
+    "joining": "Rejoindre la liste…"
   }
 }

--- a/apps/web/src/lib/navigation/auth-redirect.test.ts
+++ b/apps/web/src/lib/navigation/auth-redirect.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { buildLoginHref, buildSignupHref, getSafeReturnPath } from "./auth-redirect";
+
+describe("getSafeReturnPath", () => {
+  it("accepts relative paths that start with a single slash", () => {
+    expect(getSafeReturnPath("/")).toBe("/");
+    expect(getSafeReturnPath("/list/abc/join?editToken=tok")).toBe("/list/abc/join?editToken=tok");
+    expect(getSafeReturnPath("/list/abc/collaborators/accept?token=inv")).toBe(
+      "/list/abc/collaborators/accept?token=inv"
+    );
+  });
+
+  it("rejects protocol-relative, absolute, and encoded unsafe URLs", () => {
+    expect(getSafeReturnPath("//evil.example")).toBeNull();
+    expect(getSafeReturnPath("https://evil.example")).toBeNull();
+    expect(getSafeReturnPath("http://evil.example/phish")).toBeNull();
+    expect(getSafeReturnPath("/\\evil.example")).toBeNull();
+    expect(getSafeReturnPath("/foo://bar")).toBeNull();
+    expect(getSafeReturnPath("%2F%2Fevil.example")).toBeNull();
+  });
+
+  it("returns null for missing values", () => {
+    expect(getSafeReturnPath(null)).toBeNull();
+    expect(getSafeReturnPath(undefined)).toBeNull();
+    expect(getSafeReturnPath("")).toBeNull();
+    expect(getSafeReturnPath("list/abc")).toBeNull();
+  });
+});
+
+describe("buildLoginHref / buildSignupHref", () => {
+  it("appends a safe returnUrl", () => {
+    expect(buildLoginHref("/list/1/join?editToken=abc")).toBe(
+      "/login?returnUrl=%2Flist%2F1%2Fjoin%3FeditToken%3Dabc"
+    );
+    expect(buildSignupHref("/list/1/join?editToken=abc")).toBe(
+      "/signup?returnUrl=%2Flist%2F1%2Fjoin%3FeditToken%3Dabc"
+    );
+  });
+
+  it("falls back when the path is unsafe", () => {
+    expect(buildLoginHref("//evil.example")).toBe("/login");
+    expect(buildSignupHref("https://evil.example")).toBe("/signup");
+  });
+});

--- a/apps/web/src/lib/navigation/auth-redirect.ts
+++ b/apps/web/src/lib/navigation/auth-redirect.ts
@@ -1,0 +1,46 @@
+/** Query param used to resume a path after login or signup. */
+export const RETURN_URL_PARAM = "returnUrl";
+
+/**
+ * Returns a same-origin relative path, or `null` if `raw` is missing or unsafe
+ * (absolute URL, protocol-relative `//`, backslashes).
+ */
+export function getSafeReturnPath(raw: string | null | undefined): string | null {
+  if (!raw) {
+    return null;
+  }
+
+  let path = raw;
+  try {
+    path = decodeURIComponent(raw);
+  } catch {
+    path = raw;
+  }
+
+  if (
+    !path.startsWith("/") ||
+    path.startsWith("//") ||
+    path.includes("\\") ||
+    path.includes("://")
+  ) {
+    return null;
+  }
+
+  return path;
+}
+
+export function buildLoginHref(returnPath: string): string {
+  const safe = getSafeReturnPath(returnPath);
+  if (!safe) {
+    return "/login";
+  }
+  return `/login?${RETURN_URL_PARAM}=${encodeURIComponent(safe)}`;
+}
+
+export function buildSignupHref(returnPath: string): string {
+  const safe = getSafeReturnPath(returnPath);
+  if (!safe) {
+    return "/signup";
+  }
+  return `/signup?${RETURN_URL_PARAM}=${encodeURIComponent(safe)}`;
+}

--- a/apps/web/src/lib/navigation/index.ts
+++ b/apps/web/src/lib/navigation/index.ts
@@ -1,2 +1,3 @@
+export * from "./auth-redirect";
 export * from "./search-params";
 export * from "./use-url-param-state";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Description

Adds the join (edit-link) and invite-accept flows for list sharing. Unauthenticated visitors are sent to login/signup with a safe `returnUrl`; authenticated users join via the existing hooks and land on `/?view=lists&listId=`.

Closes #155 (NIR-78).

## 🎯 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] ✅ Test update

## 🔗 Related Issues

Closes #155
Related to NIR-68

## 🚀 Changes Made

- Safe `returnUrl` helper (`getSafeReturnPath`, `buildLoginHref`, `buildSignupHref`) wired into login, signup, and `AuthRequiredPrompt`
- Public routes (outside `(app)` / `(auth)`): `/list/[listId]/join` and `/list/[listId]/collaborators/accept`
- Join/accept views: auth loading, missing token, one-shot mutation, success redirect, API errors via `useErrorMessage`
- i18n `lists.join.*` (en + fr)

## 🧪 Testing

- [ ] Tested locally with `pnpm dev`
- [x] All quality checks pass (`pnpm lint`)
- [x] Unit tests pass (`pnpm test`)
- [ ] Database migrations applied if needed

`pnpm --filter @nirby/web test` — 315 passed  
`pnpm --filter @nirby/web lint` — pass  
`pnpm -C apps/web exec tsc --noEmit` — pass

## 📸 Screenshots/Videos

N/A

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated if needed
- [x] No console errors or warnings
- [x] Removed any debug code

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffb89-2207-7758-8794-ec303f733868?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffb89-2207-7758-8794-ec303f733868&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

