### PR TITLE
feat(web): move collaborators into share dialog (#173)

### DIFF
--- a/apps/web/src/features/lists/components/leave-list-control.test.tsx
+++ b/apps/web/src/features/lists/components/leave-list-control.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { toast } from "sonner";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useLeaveList } from "../hooks/use-leave-list";
+
+import { LeaveListControl } from "./leave-list-control";
+
+import { getErrorCode } from "@/lib/api/errors";
+
+vi.mock("../hooks/use-leave-list", () => ({
+  useLeaveList: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-error-message", () => ({
+  useErrorMessage: () => () => "API error message",
+}));
+
+vi.mock("@/lib/api/errors", () => ({
+  getErrorCode: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("LeaveListControl", () => {
+  const onLeft = vi.fn();
+  const leaveMutate = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getErrorCode).mockReturnValue(null);
+    leaveMutate.mockResolvedValue({ message: "ok" });
+    vi.mocked(useLeaveList).mockReturnValue({
+      mutateAsync: leaveMutate,
+      isPending: false,
+    } as unknown as ReturnType<typeof useLeaveList>);
+  });
+
+  it("leaves the list after confirmation, toasts, and calls onLeft", async () => {
+    const user = userEvent.setup();
+    render(<LeaveListControl listId="list-1" onLeft={onLeft} />);
+
+    await user.click(screen.getByRole("button", { name: "collaborators.leave" }));
+    await user.click(screen.getByRole("button", { name: "collaborators.leaveConfirm" }));
+
+    expect(leaveMutate).toHaveBeenCalledWith({ listId: "list-1" });
+    expect(toast.success).toHaveBeenCalledWith("collaborators.leaveSuccess");
+    expect(onLeft).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows an error toast when leave fails", async () => {
+    const user = userEvent.setup();
+    leaveMutate.mockRejectedValue(new Error("LIST_OWNER_CANNOT_LEAVE"));
+    vi.mocked(getErrorCode).mockReturnValue("LIST_OWNER_CANNOT_LEAVE");
+    render(<LeaveListControl listId="list-1" onLeft={onLeft} />);
+
+    await user.click(screen.getByRole("button", { name: "collaborators.leave" }));
+    await user.click(screen.getByRole("button", { name: "collaborators.leaveConfirm" }));
+
+    expect(toast.error).toHaveBeenCalledWith("collaborators.leaveError", {
+      description: "API error message",
+    });
+    expect(onLeft).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/features/lists/components/leave-list-control.tsx
+++ b/apps/web/src/features/lists/components/leave-list-control.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { useLeaveList } from "../hooks/use-leave-list";
+
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui";
+import { useErrorMessage } from "@/hooks/use-error-message";
+import { getErrorCode } from "@/lib/api/errors";
+
+type LeaveListControlProps = {
+  listId: string;
+  onLeft: () => void;
+};
+
+export function LeaveListControl({ listId, onLeft }: LeaveListControlProps) {
+  const tLists = useTranslations("lists");
+  const tCommon = useTranslations("common");
+  const getErrorMessage = useErrorMessage();
+  const { mutateAsync: leaveList, isPending } = useLeaveList();
+  const [open, setOpen] = useState(false);
+
+  async function handleLeave() {
+    if (isPending) return;
+
+    try {
+      await leaveList({ listId });
+      toast.success(tLists("collaborators.leaveSuccess"));
+      setOpen(false);
+      onLeft();
+    } catch (error) {
+      toast.error(tLists("collaborators.leaveError"), {
+        description: getErrorMessage(error),
+      });
+      if (getErrorCode(error) === "LIST_OWNER_CANNOT_LEAVE") {
+        return;
+      }
+    }
+  }
+
+  return (
+    <>
+      <Button type="button" variant="outline" size="sm" onClick={() => setOpen(true)}>
+        {tLists("collaborators.leave")}
+      </Button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{tLists("collaborators.leaveTitle")}</DialogTitle>
+            <DialogDescription>{tLists("collaborators.leaveDescription")}</DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setOpen(false)}
+              disabled={isPending}
+            >
+              {tCommon("buttons.cancel")}
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              loading={isPending}
+              disabled={isPending}
+              onClick={handleLeave}
+            >
+              {tLists("collaborators.leaveConfirm")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/web/src/features/lists/components/list-collaborators-section.test.tsx
+++ b/apps/web/src/features/lists/components/list-collaborators-section.test.tsx
@@ -5,7 +5,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useCollaborators } from "../hooks/use-collaborators";
 import { useInviteCollaborator } from "../hooks/use-invite-collaborator";
-import { useLeaveList } from "../hooks/use-leave-list";
 import { useRemoveCollaborator } from "../hooks/use-remove-collaborator";
 import { useUpdateCollaboratorRole } from "../hooks/use-update-collaborator-role";
 
@@ -36,10 +35,6 @@ vi.mock("../hooks/use-update-collaborator-role", () => ({
 
 vi.mock("../hooks/use-remove-collaborator", () => ({
   useRemoveCollaborator: vi.fn(),
-}));
-
-vi.mock("../hooks/use-leave-list", () => ({
-  useLeaveList: vi.fn(),
 }));
 
 vi.mock("@/hooks/use-error-message", () => ({
@@ -104,20 +99,16 @@ function mockCollaboratorsQuery(
   } as ReturnType<typeof useCollaborators>);
 }
 
-function renderSection(role: ListRole, onLeft = vi.fn()) {
-  return {
-    onLeft,
-    ...render(
-      <ListCollaboratorsSection listId="list-1" role={role} createdBy="user-1" onLeft={onLeft} />
-    ),
-  };
+function renderSection(role: ListRole) {
+  return render(
+    <ListCollaboratorsSection listId="list-1" role={role} createdBy="user-1" embedded />
+  );
 }
 
 describe("ListCollaboratorsSection", () => {
   const inviteMutate = vi.fn();
   const updateRoleMutate = vi.fn();
   const removeMutate = vi.fn();
-  const leaveMutate = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -127,7 +118,6 @@ describe("ListCollaboratorsSection", () => {
     inviteMutate.mockResolvedValue({ inviteLink: "https://example.com/invite", emailSent: true });
     updateRoleMutate.mockResolvedValue({ message: "ok" });
     removeMutate.mockResolvedValue({ message: "ok" });
-    leaveMutate.mockResolvedValue({ message: "ok" });
     vi.mocked(useInviteCollaborator).mockReturnValue({
       mutateAsync: inviteMutate,
       isPending: false,
@@ -140,10 +130,6 @@ describe("ListCollaboratorsSection", () => {
       mutateAsync: removeMutate,
       isPending: false,
     } as unknown as ReturnType<typeof useRemoveCollaborator>);
-    vi.mocked(useLeaveList).mockReturnValue({
-      mutateAsync: leaveMutate,
-      isPending: false,
-    } as unknown as ReturnType<typeof useLeaveList>);
   });
 
   it("shows invite and remove for OWNER, without Leave", () => {
@@ -159,35 +145,35 @@ describe("ListCollaboratorsSection", () => {
     expect(screen.getByText("role.OWNER")).toBeInTheDocument();
   });
 
-  it("shows invite, remove, and Leave for ADMIN without inventing an owner row", () => {
+  it("shows invite and remove for ADMIN without inventing an owner row or Leave", () => {
     mockCollaboratorsQuery({}, [selfAsAdmin, otherCollaborator]);
 
     renderSection("ADMIN");
 
     expect(screen.getByRole("button", { name: "collaborators.invite.submit" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "collaborators.remove" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "collaborators.leave" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "collaborators.leave" })).not.toBeInTheDocument();
     expect(screen.queryByText("role.OWNER")).not.toBeInTheDocument();
   });
 
-  it("hides invite and remove for EDITOR and shows Leave", () => {
+  it("hides invite, remove, and Leave for EDITOR", () => {
     renderSection("EDITOR");
 
     expect(
       screen.queryByRole("button", { name: "collaborators.invite.submit" })
     ).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "collaborators.remove" })).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "collaborators.leave" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "collaborators.leave" })).not.toBeInTheDocument();
   });
 
-  it("hides invite and remove for VIEWER and shows Leave", () => {
+  it("hides invite, remove, and Leave for VIEWER", () => {
     renderSection("VIEWER");
 
     expect(
       screen.queryByRole("button", { name: "collaborators.invite.submit" })
     ).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "collaborators.remove" })).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "collaborators.leave" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "collaborators.leave" })).not.toBeInTheDocument();
   });
 
   it("invites a collaborator and shows a success toast", async () => {
@@ -231,17 +217,5 @@ describe("ListCollaboratorsSection", () => {
 
     expect(removeMutate).toHaveBeenCalledWith({ listId: "list-1", collaboratorId: "user-2" });
     expect(toast.success).toHaveBeenCalledWith("collaborators.removeSuccess");
-  });
-
-  it("leaves the list after confirmation, toasts, and calls onLeft", async () => {
-    const user = userEvent.setup();
-    const { onLeft } = renderSection("EDITOR");
-
-    await user.click(screen.getByRole("button", { name: "collaborators.leave" }));
-    await user.click(screen.getByRole("button", { name: "collaborators.leaveConfirm" }));
-
-    expect(leaveMutate).toHaveBeenCalledWith({ listId: "list-1" });
-    expect(toast.success).toHaveBeenCalledWith("collaborators.leaveSuccess");
-    expect(onLeft).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/features/lists/components/list-collaborators-section.tsx
+++ b/apps/web/src/features/lists/components/list-collaborators-section.tsx
@@ -10,7 +10,6 @@ import { z } from "zod";
 import { canManageCollaborators, type ListRole } from "../constants/lists.constants";
 import { COLLABORATORS_PAGE_SIZE, useCollaborators } from "../hooks/use-collaborators";
 import { useInviteCollaborator } from "../hooks/use-invite-collaborator";
-import { useLeaveList } from "../hooks/use-leave-list";
 import { useRemoveCollaborator } from "../hooks/use-remove-collaborator";
 import { useUpdateCollaboratorRole } from "../hooks/use-update-collaborator-role";
 
@@ -51,7 +50,7 @@ export type ListCollaboratorsSectionProps = {
   listId: string;
   role?: ListRole;
   createdBy: string;
-  onLeft: () => void;
+  embedded?: boolean;
 };
 
 type InviteFormValues = {
@@ -68,12 +67,15 @@ function initials(user: { name?: string | null; email: string }) {
   return source.slice(0, 1).toUpperCase();
 }
 
-export function ListCollaboratorsSection({ listId, role, onLeft }: ListCollaboratorsSectionProps) {
+export function ListCollaboratorsSection({
+  listId,
+  role,
+  embedded = false,
+}: ListCollaboratorsSectionProps) {
   const tLists = useTranslations("lists");
   const getErrorMessage = useErrorMessage();
   const { user } = useAuth();
   const canManage = canManageCollaborators(role);
-  const canLeave = role !== undefined && role !== "OWNER";
 
   const { data, isPending, isError, error, refetch } = useCollaborators(listId, {
     limit: COLLABORATORS_PAGE_SIZE,
@@ -83,11 +85,18 @@ export function ListCollaboratorsSection({ listId, role, onLeft }: ListCollabora
   const showOwnerRow = role === "OWNER" && user;
 
   return (
-    <section className="border-t border-border pt-6" data-testid="list-collaborators-section">
-      <header className="mb-4">
-        <h2 className="font-display text-base font-semibold tracking-tight">
-          {tLists("collaborators.section.title")}
-        </h2>
+    <section
+      className={embedded ? "grid gap-3" : "border-t border-border pt-6"}
+      data-testid="list-collaborators-section"
+    >
+      <header className={embedded ? undefined : "mb-4"}>
+        {embedded ? (
+          <h3 className="text-sm font-medium">{tLists("collaborators.section.title")}</h3>
+        ) : (
+          <h2 className="font-display text-base font-semibold tracking-tight">
+            {tLists("collaborators.section.title")}
+          </h2>
+        )}
       </header>
 
       {canManage ? <InviteCollaboratorForm listId={listId} /> : null}
@@ -143,8 +152,6 @@ export function ListCollaboratorsSection({ listId, role, onLeft }: ListCollabora
           ) : null}
         </ul>
       ) : null}
-
-      {canLeave ? <LeaveListControl listId={listId} onLeft={onLeft} /> : null}
     </section>
   );
 }
@@ -431,75 +438,5 @@ function RemoveCollaboratorDialog({
         </DialogFooter>
       </DialogContent>
     </Dialog>
-  );
-}
-
-function LeaveListControl({ listId, onLeft }: { listId: string; onLeft: () => void }) {
-  const tLists = useTranslations("lists");
-  const tCommon = useTranslations("common");
-  const getErrorMessage = useErrorMessage();
-  const { mutateAsync: leaveList, isPending } = useLeaveList();
-  const [open, setOpen] = useState(false);
-
-  async function handleLeave() {
-    if (isPending) return;
-
-    try {
-      await leaveList({ listId });
-      toast.success(tLists("collaborators.leaveSuccess"));
-      setOpen(false);
-      onLeft();
-    } catch (error) {
-      if (getErrorCode(error) === "LIST_OWNER_CANNOT_LEAVE") {
-        toast.error(tLists("collaborators.leaveError"), {
-          description: getErrorMessage(error),
-        });
-        return;
-      }
-      toast.error(tLists("collaborators.leaveError"), {
-        description: getErrorMessage(error),
-      });
-    }
-  }
-
-  return (
-    <>
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        className="mt-4 w-fit"
-        onClick={() => setOpen(true)}
-      >
-        {tLists("collaborators.leave")}
-      </Button>
-      <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>{tLists("collaborators.leaveTitle")}</DialogTitle>
-            <DialogDescription>{tLists("collaborators.leaveDescription")}</DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => setOpen(false)}
-              disabled={isPending}
-            >
-              {tCommon("buttons.cancel")}
-            </Button>
-            <Button
-              type="button"
-              variant="destructive"
-              loading={isPending}
-              disabled={isPending}
-              onClick={handleLeave}
-            >
-              {tLists("collaborators.leaveConfirm")}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </>
   );
 }

--- a/apps/web/src/features/lists/components/share-list-dialog.test.tsx
+++ b/apps/web/src/features/lists/components/share-list-dialog.test.tsx
@@ -10,6 +10,28 @@ import { useUnshareList } from "../hooks/use-unshare-list";
 
 import { ShareListDialog } from "./share-list-dialog";
 
+vi.mock("./list-collaborators-section", () => ({
+  ListCollaboratorsSection: ({
+    listId,
+    role,
+    createdBy,
+    embedded,
+  }: {
+    listId: string;
+    role?: string;
+    createdBy: string;
+    embedded?: boolean;
+  }) => (
+    <div
+      data-testid="list-collaborators-section"
+      data-list-id={listId}
+      data-role={role ?? ""}
+      data-created-by={createdBy}
+      data-embedded={embedded ? "1" : "0"}
+    />
+  ),
+}));
+
 vi.mock("../hooks/use-share-list", () => ({
   useShareList: vi.fn(),
 }));
@@ -49,6 +71,25 @@ describe("ShareListDialog", () => {
   const revokeEditLink = vi.fn();
   const writeText = vi.fn();
 
+  function renderDialog(
+    overrides: Partial<{
+      shareToken: string | null;
+      editToken: string | null;
+    }> = {}
+  ) {
+    return render(
+      <ShareListDialog
+        listId="list-1"
+        shareToken={overrides.shareToken ?? null}
+        editToken={overrides.editToken ?? null}
+        role="OWNER"
+        createdBy="user-1"
+        open
+        onOpenChange={onOpenChange}
+      />
+    );
+  }
+
   beforeEach(() => {
     vi.clearAllMocks();
     shareList.mockResolvedValue({ shareLink: "https://example.com/shared/new-token" });
@@ -77,18 +118,20 @@ describe("ShareListDialog", () => {
     );
   });
 
+  it("renders collaborators next to the share links", () => {
+    renderDialog();
+
+    const collaborators = screen.getByTestId("list-collaborators-section");
+    expect(collaborators).toHaveAttribute("data-list-id", "list-1");
+    expect(collaborators).toHaveAttribute("data-role", "OWNER");
+    expect(collaborators).toHaveAttribute("data-created-by", "user-1");
+    expect(collaborators).toHaveAttribute("data-embedded", "1");
+    expect(screen.getByRole("button", { name: "share.editLink.generate" })).toBeInTheDocument();
+  });
+
   it("generates a read link when none exists", async () => {
     const user = userEvent.setup();
-
-    render(
-      <ShareListDialog
-        listId="list-1"
-        shareToken={null}
-        editToken={null}
-        open
-        onOpenChange={onOpenChange}
-      />
-    );
+    renderDialog();
 
     await user.click(screen.getByRole("button", { name: "share.readLink.generate" }));
 
@@ -98,16 +141,7 @@ describe("ShareListDialog", () => {
 
   it("generates an edit link when none exists", async () => {
     const user = userEvent.setup();
-
-    render(
-      <ShareListDialog
-        listId="list-1"
-        shareToken={null}
-        editToken={null}
-        open
-        onOpenChange={onOpenChange}
-      />
-    );
+    renderDialog();
 
     await user.click(screen.getByRole("button", { name: "share.editLink.generate" }));
 
@@ -126,15 +160,7 @@ describe("ShareListDialog", () => {
     });
     const expectedUrl = `${window.location.origin}/shared/abc123`;
 
-    render(
-      <ShareListDialog
-        listId="list-1"
-        shareToken="abc123"
-        editToken={null}
-        open
-        onOpenChange={onOpenChange}
-      />
-    );
+    renderDialog({ shareToken: "abc123" });
 
     await user.click(screen.getByRole("button", { name: "share.readLink.copy" }));
 
@@ -144,16 +170,7 @@ describe("ShareListDialog", () => {
 
   it("revokes a read link after inline confirmation", async () => {
     const user = userEvent.setup();
-
-    render(
-      <ShareListDialog
-        listId="list-1"
-        shareToken="abc123"
-        editToken={null}
-        open
-        onOpenChange={onOpenChange}
-      />
-    );
+    renderDialog({ shareToken: "abc123" });
 
     await user.click(screen.getByRole("button", { name: "share.readLink.revoke" }));
     expect(unshareList).not.toHaveBeenCalled();
@@ -167,16 +184,7 @@ describe("ShareListDialog", () => {
 
   it("revokes an edit link after inline confirmation", async () => {
     const user = userEvent.setup();
-
-    render(
-      <ShareListDialog
-        listId="list-1"
-        shareToken={null}
-        editToken="edit-1"
-        open
-        onOpenChange={onOpenChange}
-      />
-    );
+    renderDialog({ editToken: "edit-1" });
 
     await user.click(screen.getByRole("button", { name: "share.editLink.revoke" }));
     await user.click(screen.getByRole("button", { name: "share.editLink.revokeConfirm" }));

--- a/apps/web/src/features/lists/components/share-list-dialog.tsx
+++ b/apps/web/src/features/lists/components/share-list-dialog.tsx
@@ -4,11 +4,14 @@ import { useTranslations } from "next-intl";
 import { useState } from "react";
 import { toast } from "sonner";
 
+import type { ListRole } from "../constants/lists.constants";
 import { useGenerateEditLink } from "../hooks/use-generate-edit-link";
 import { useRevokeEditLink } from "../hooks/use-revoke-edit-link";
 import { useShareList } from "../hooks/use-share-list";
 import { useUnshareList } from "../hooks/use-unshare-list";
 import { buildEditLinkUrl, buildShareUrl } from "../utils/share-links.utils";
+
+import { ListCollaboratorsSection } from "./list-collaborators-section";
 
 import {
   Button,
@@ -31,6 +34,8 @@ export type ShareListDialogProps = {
   listId: string;
   shareToken: string | null;
   editToken: string | null;
+  role?: ListRole;
+  createdBy: string;
   open: boolean;
   onOpenChange: (open: boolean) => void;
 };
@@ -146,6 +151,9 @@ function useShareListDialog({ listId, shareToken, editToken, onOpenChange }: Sha
 type ShareDialogState = ReturnType<typeof useShareListDialog>;
 
 function ShareListBody({
+  listId,
+  role,
+  createdBy,
   tLists,
   tCommon,
   shareUrl,
@@ -159,9 +167,9 @@ function ShareListBody({
   handleGenerate,
   handleCopy,
   handleRevoke,
-}: ShareDialogState) {
+}: ShareDialogState & Pick<ShareListDialogProps, "listId" | "role" | "createdBy">) {
   return (
-    <div className="grid gap-6">
+    <div className="grid max-h-[min(70vh,32rem)] gap-6 overflow-y-auto">
       <ShareLinkSection
         title={tLists("share.readLink.title")}
         description={tLists("share.readLink.description")}
@@ -200,6 +208,7 @@ function ShareListBody({
         onCancelRevoke={() => setConfirming(null)}
         onConfirmRevoke={() => handleRevoke("edit")}
       />
+      <ListCollaboratorsSection listId={listId} role={role} createdBy={createdBy} embedded />
     </div>
   );
 }
@@ -314,7 +323,12 @@ function ShareListDesktopDialog(props: ShareListDialogProps) {
           <DialogTitle>{tLists("share.title")}</DialogTitle>
           <DialogDescription>{tLists("share.description")}</DialogDescription>
         </DialogHeader>
-        <ShareListBody {...state} />
+        <ShareListBody
+          {...state}
+          listId={props.listId}
+          role={props.role}
+          createdBy={props.createdBy}
+        />
       </DialogContent>
     </Dialog>
   );
@@ -332,7 +346,12 @@ function ShareListDrawer(props: ShareListDialogProps) {
           <DrawerDescription>{tLists("share.description")}</DrawerDescription>
         </DrawerHeader>
         <div className="px-4 pb-4">
-          <ShareListBody {...state} />
+          <ShareListBody
+            {...state}
+            listId={props.listId}
+            role={props.role}
+            createdBy={props.createdBy}
+          />
         </div>
       </DrawerContent>
     </Drawer>

--- a/apps/web/src/features/lists/views/lists-detail-view.test.tsx
+++ b/apps/web/src/features/lists/views/lists-detail-view.test.tsx
@@ -70,22 +70,11 @@ vi.mock("../components/list-pois-section", () => ({
   ),
 }));
 
-vi.mock("../components/list-collaborators-section", () => ({
-  ListCollaboratorsSection: ({
-    listId,
-    role,
-    createdBy,
-  }: {
-    listId: string;
-    role?: string;
-    createdBy: string;
-  }) => (
-    <div
-      data-testid="list-collaborators-section"
-      data-list-id={listId}
-      data-role={role ?? ""}
-      data-created-by={createdBy}
-    />
+vi.mock("../components/leave-list-control", () => ({
+  LeaveListControl: ({ listId }: { listId: string }) => (
+    <button type="button" data-testid="leave-list-control" data-list-id={listId}>
+      collaborators.leave
+    </button>
   ),
 }));
 
@@ -203,11 +192,8 @@ describe("ListsDetailView", () => {
     expect(poisSection).toHaveAttribute("data-list-id", "list-1");
     expect(poisSection).toHaveAttribute("data-role", "OWNER");
 
-    const collaboratorsSection = screen.getByTestId("list-collaborators-section");
-    expect(collaboratorsSection).toBeInTheDocument();
-    expect(collaboratorsSection).toHaveAttribute("data-list-id", "list-1");
-    expect(collaboratorsSection).toHaveAttribute("data-role", "OWNER");
-    expect(collaboratorsSection).toHaveAttribute("data-created-by", "user-1");
+    expect(screen.queryByTestId("list-collaborators-section")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("leave-list-control")).not.toBeInTheDocument();
   });
 
   it("shows edit button for OWNER and calls onEdit", async () => {
@@ -233,7 +219,7 @@ describe("ListsDetailView", () => {
 
     expect(screen.queryByRole("button", { name: "edit.action" })).not.toBeInTheDocument();
     expect(screen.queryByText("edit.readOnly")).not.toBeInTheDocument();
-    expect(screen.getByTestId("list-collaborators-section")).toHaveAttribute("data-role", "VIEWER");
+    expect(screen.getByTestId("leave-list-control")).toHaveAttribute("data-list-id", "list-1");
   });
 
   it("hides delete button for VIEWER", () => {
@@ -282,7 +268,7 @@ describe("ListsDetailView", () => {
     expect(screen.getByRole("button", { name: "share.action" })).toBeInTheDocument();
   });
 
-  it("hides share button for VIEWER", () => {
+  it("hides share button for VIEWER and shows Leave", () => {
     mockListQuery({
       data: { list: { ...mockList, role: "VIEWER" } },
     });
@@ -290,9 +276,10 @@ describe("ListsDetailView", () => {
     render(<ListsDetailView listId="list-1" onBack={onBack} onEdit={onEdit} onDelete={onDelete} />);
 
     expect(screen.queryByRole("button", { name: "share.action" })).not.toBeInTheDocument();
+    expect(screen.getByTestId("leave-list-control")).toBeInTheDocument();
   });
 
-  it("hides share button for EDITOR", () => {
+  it("hides share button for EDITOR and shows Leave", () => {
     mockListQuery({
       data: { list: { ...mockList, role: "EDITOR" } },
     });
@@ -301,6 +288,7 @@ describe("ListsDetailView", () => {
 
     expect(screen.getByRole("button", { name: "edit.action" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "share.action" })).not.toBeInTheDocument();
+    expect(screen.getByTestId("leave-list-control")).toBeInTheDocument();
   });
 
   it("shows delete button for OWNER", () => {

--- a/apps/web/src/features/lists/views/lists-detail-view.tsx
+++ b/apps/web/src/features/lists/views/lists-detail-view.tsx
@@ -5,7 +5,7 @@ import { useTranslations } from "next-intl";
 import { useState } from "react";
 
 import { DeleteListDialog } from "../components/delete-list-dialog";
-import { ListCollaboratorsSection } from "../components/list-collaborators-section";
+import { LeaveListControl } from "../components/leave-list-control";
 import { ListPoisSection } from "../components/list-pois-section";
 import { ListsDetailMetadata } from "../components/lists-detail-metadata";
 import { ListsListQueryBoundary } from "../components/lists-list-query-boundary";
@@ -52,72 +52,73 @@ export function ListsDetailView({ listId, onBack, onEdit, onDelete }: ListsDetai
         onDeselect={clearSelection}
       />
       <ListsListQueryBoundary listId={listId}>
-        {(loadedList) => (
-          <div className="grid gap-6">
-            <ListsDetailMetadata list={loadedList} />
-            {(canEditList(loadedList.role) || canDeleteList(loadedList.role)) && (
-              <div className="flex flex-wrap gap-2">
-                {canManageShareAndEditLinks(loadedList.role) && (
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    onClick={() => setShareDialogOpen(true)}
-                  >
-                    <Share2Icon className="size-4" />
-                    {tLists("share.action")}
-                  </Button>
-                )}
-                {canEditList(loadedList.role) && (
-                  <Button type="button" variant="outline" size="sm" onClick={onEdit}>
-                    <PencilIcon className="size-4" />
-                    {tLists("edit.action")}
-                  </Button>
-                )}
-                {canDeleteList(loadedList.role) && (
-                  <Button
-                    type="button"
-                    variant="destructive"
-                    size="sm"
-                    onClick={() => setDeleteDialogOpen(true)}
-                  >
-                    <Trash2Icon className="size-4" />
-                    {tLists("delete.submit")}
-                  </Button>
-                )}
-              </div>
-            )}
-            {canManageShareAndEditLinks(loadedList.role) && (
-              <ShareListDialog
+        {(loadedList) => {
+          const canLeave = loadedList.role !== undefined && loadedList.role !== "OWNER";
+
+          return (
+            <div className="grid gap-6">
+              <ListsDetailMetadata list={loadedList} />
+              {(canEditList(loadedList.role) || canDeleteList(loadedList.role) || canLeave) && (
+                <div className="flex flex-wrap gap-2">
+                  {canManageShareAndEditLinks(loadedList.role) && (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setShareDialogOpen(true)}
+                    >
+                      <Share2Icon className="size-4" />
+                      {tLists("share.action")}
+                    </Button>
+                  )}
+                  {canEditList(loadedList.role) && (
+                    <Button type="button" variant="outline" size="sm" onClick={onEdit}>
+                      <PencilIcon className="size-4" />
+                      {tLists("edit.action")}
+                    </Button>
+                  )}
+                  {canDeleteList(loadedList.role) && (
+                    <Button
+                      type="button"
+                      variant="destructive"
+                      size="sm"
+                      onClick={() => setDeleteDialogOpen(true)}
+                    >
+                      <Trash2Icon className="size-4" />
+                      {tLists("delete.submit")}
+                    </Button>
+                  )}
+                  {canLeave ? <LeaveListControl listId={listId} onLeft={onBack} /> : null}
+                </div>
+              )}
+              {canManageShareAndEditLinks(loadedList.role) && (
+                <ShareListDialog
+                  listId={listId}
+                  shareToken={loadedList.shareToken}
+                  editToken={loadedList.editToken}
+                  role={loadedList.role}
+                  createdBy={loadedList.createdBy}
+                  open={shareDialogOpen}
+                  onOpenChange={setShareDialogOpen}
+                />
+              )}
+              {canDeleteList(loadedList.role) && (
+                <DeleteListDialog
+                  listId={listId}
+                  open={deleteDialogOpen}
+                  onOpenChange={setDeleteDialogOpen}
+                  onDeleted={onDelete}
+                />
+              )}
+              <ListPoisSection
                 listId={listId}
-                shareToken={loadedList.shareToken}
-                editToken={loadedList.editToken}
-                open={shareDialogOpen}
-                onOpenChange={setShareDialogOpen}
+                role={loadedList.role}
+                selectedPoiId={selectedPoiId}
+                onSelectPoi={selectPoi}
               />
-            )}
-            {canDeleteList(loadedList.role) && (
-              <DeleteListDialog
-                listId={listId}
-                open={deleteDialogOpen}
-                onOpenChange={setDeleteDialogOpen}
-                onDeleted={onDelete}
-              />
-            )}
-            <ListCollaboratorsSection
-              listId={listId}
-              role={loadedList.role}
-              createdBy={loadedList.createdBy}
-              onLeft={onBack}
-            />
-            <ListPoisSection
-              listId={listId}
-              role={loadedList.role}
-              selectedPoiId={selectedPoiId}
-              onSelectPoi={selectPoi}
-            />
-          </div>
-        )}
+            </div>
+          );
+        }}
       </ListsListQueryBoundary>
     </ListsSectionLayout>
   );

--- a/apps/web/src/lib/i18n/locales-parity.test.tsx
+++ b/apps/web/src/lib/i18n/locales-parity.test.tsx
@@ -46,6 +46,7 @@ const NEW_LISTS_KEYS = [
   "share.readLink.generate",
   "share.editLink.revokeConfirm",
   "share.copySuccess",
+  "share.description",
   "collaborators.section.title",
   "collaborators.invite.submit",
   "collaborators.leaveConfirm",

--- a/apps/web/src/lib/i18n/locales/en/lists.json
+++ b/apps/web/src/lib/i18n/locales/en/lists.json
@@ -114,7 +114,7 @@
   "share": {
     "action": "Share",
     "title": "Share list",
-    "description": "Create a read-only link or an edit invite link for this list.",
+    "description": "Create a read-only or edit invite link, and manage people on this list.",
     "readLink": {
       "title": "Read-only link",
       "description": "Anyone with this link can view the list.",

--- a/apps/web/src/lib/i18n/locales/fr/lists.json
+++ b/apps/web/src/lib/i18n/locales/fr/lists.json
@@ -114,7 +114,7 @@
   "share": {
     "action": "Partager",
     "title": "Partager la liste",
-    "description": "Crée un lien de lecture ou un lien d'invitation à éditer pour cette liste.",
+    "description": "Crée un lien de lecture ou d'invitation à éditer, et gère les personnes de cette liste.",
     "readLink": {
       "title": "Lien en lecture seule",
       "description": "Toute personne avec ce lien peut consulter la liste.",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Description

Moves collaborator management into the Share dialog (next to read-only and edit-invite links) and keeps Leave on the list detail for non-owners. The list detail now goes metadata → actions → POIs.

Closes #173 (NIR-84).

## 🎯 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🎨 Style/UI update (no functional changes)
- [x] ✅ Test update

## 🔗 Related Issues

Closes #173
Related to NIR-68, NIR-75, NIR-76

## 🚀 Changes Made

- Extracted `LeaveListControl` and placed it on the list detail for non-OWNER roles
- Embedded `ListCollaboratorsSection` in the Share dialog/drawer (edit-link generate/copy/revoke unchanged)
- Removed the collaborators block from the list detail
- Updated `share.description` (en/fr)

## 🧪 Testing

- [ ] Tested locally with `pnpm dev`
- [x] All quality checks pass (`pnpm lint`)
- [x] Unit tests pass (`pnpm test`)
- [ ] Database migrations applied if needed

`pnpm --filter @nirby/web test` — 317 passed  
`pnpm --filter @nirby/web lint` — pass  
`pnpm -C apps/web exec tsc --noEmit` — pass

## 📸 Screenshots/Videos

N/A

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated if needed
- [x] No console errors or warnings
- [x] Removed any debug code

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffb89-2207-7758-8794-ec303f733868?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffb89-2207-7758-8794-ec303f733868&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

