### PR TITLE
feat(pois): add custom POI React Query hooks

### DIFF
--- a/apps/web/src/features/pois/constants/pois.constants.ts
+++ b/apps/web/src/features/pois/constants/pois.constants.ts
@@ -1,0 +1,47 @@
+/** Field limits for POI create — mirrors POST /poi validation. */
+export const poiConstraints = {
+  name: { min: 1, max: 255 },
+  description: { max: 1000 },
+  address: { max: 500 },
+  latitude: { min: -90, max: 90 },
+  longitude: { min: -180, max: 180 },
+} as const;
+
+export const POI_VISIBILITY_VALUES = ["PRIVATE", "SHARED", "PUBLIC"] as const;
+
+export type PoiVisibility = (typeof POI_VISIBILITY_VALUES)[number];
+
+export const DEFAULT_POI_VISIBILITY: PoiVisibility = "PRIVATE";
+
+/** Mirrors API `POI_CATEGORIES` in `apps/api/src/types.ts`. */
+export const POI_CATEGORY_VALUES = [
+  "restaurant",
+  "cafe",
+  "bar",
+  "bakery",
+  "grocery_store",
+  "supermarket",
+  "hotel",
+  "museum",
+  "park",
+  "gym",
+  "pharmacy",
+  "hospital",
+  "bank",
+  "gas_station",
+  "parking",
+  "shopping_mall",
+  "movie_theater",
+  "library",
+  "church",
+  "mosque",
+  "school",
+  "university",
+  "train_station",
+  "bus_station",
+  "airport",
+  "tourist_attraction",
+  "other",
+] as const;
+
+export type PoiCategory = (typeof POI_CATEGORY_VALUES)[number];

--- a/apps/web/src/features/pois/hooks/use-create-poi.test.tsx
+++ b/apps/web/src/features/pois/hooks/use-create-poi.test.tsx
@@ -1,0 +1,95 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useCreatePoi } from "./use-create-poi";
+
+import { createPoi } from "@/lib/api";
+import { queryKeys } from "@/lib/api/query-keys";
+
+vi.mock("@/lib/api", () => ({
+  createPoi: vi.fn(),
+}));
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+/** The hook only forwards the payload, so a partial response is enough here. */
+function apiResponse(value: { data?: unknown; error?: unknown }) {
+  return value as Awaited<ReturnType<typeof createPoi>>;
+}
+
+describe("useCreatePoi", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+  });
+
+  it("calls createPoi and returns data on success", async () => {
+    const input = { name: "Secret spot", latitude: 48.8566, longitude: 2.3522 };
+    const data = { poi: { id: "poi-1", name: "Secret spot" } };
+    vi.mocked(createPoi).mockResolvedValue(apiResponse({ data }));
+
+    const { result } = renderHook(() => useCreatePoi(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    let resolved: unknown;
+    await act(async () => {
+      resolved = await result.current.mutateAsync(input);
+    });
+
+    expect(createPoi).toHaveBeenCalledWith({ body: input });
+    expect(resolved).toEqual(data);
+  });
+
+  it("invalidates pois cache on success", async () => {
+    vi.mocked(createPoi).mockResolvedValue(
+      apiResponse({ data: { poi: { id: "poi-1", name: "Secret spot" } } })
+    );
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useCreatePoi(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        name: "Secret spot",
+        latitude: 48.8566,
+        longitude: 2.3522,
+      });
+    });
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.pois.all });
+    });
+  });
+
+  it("throws API error when response has no data", async () => {
+    const apiError = { message: "Forbidden" };
+    vi.mocked(createPoi).mockResolvedValue(apiResponse({ error: apiError }));
+
+    const { result } = renderHook(() => useCreatePoi(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await expect(
+      act(async () => {
+        await result.current.mutateAsync({
+          name: "Secret spot",
+          latitude: 48.8566,
+          longitude: 2.3522,
+        });
+      })
+    ).rejects.toEqual(apiError);
+  });
+});

--- a/apps/web/src/features/pois/hooks/use-create-poi.ts
+++ b/apps/web/src/features/pois/hooks/use-create-poi.ts
@@ -1,0 +1,35 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { createPoi } from "@/lib/api";
+import type { CreatePoiData } from "@/lib/api";
+import { queryKeys } from "@/lib/api/query-keys";
+
+/** Body payload for `POST /poi`. */
+export type CreatePoiInput = CreatePoiData["body"];
+
+/**
+ * Creates a custom POI for the authenticated user.
+ *
+ * On success, invalidates all POI queries so a future `GET /poi` list refetches.
+ * API errors are thrown so they can be handled with {@link useErrorMessage}.
+ */
+export function useCreatePoi() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (input: CreatePoiInput) => {
+      const response = await createPoi({ body: input });
+
+      if (response.data) {
+        return response.data;
+      }
+
+      throw response.error;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.pois.all });
+    },
+  });
+}

--- a/apps/web/src/features/pois/hooks/use-upload-poi-photo.test.tsx
+++ b/apps/web/src/features/pois/hooks/use-upload-poi-photo.test.tsx
@@ -1,0 +1,107 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useUploadPoiPhoto } from "./use-upload-poi-photo";
+
+import { uploadPoiPhoto } from "@/lib/api";
+import { queryKeys } from "@/lib/api/query-keys";
+
+vi.mock("@/lib/api", () => ({
+  uploadPoiPhoto: vi.fn(),
+}));
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+function apiResponse(value: { data?: unknown; error?: unknown }) {
+  return value as Awaited<ReturnType<typeof uploadPoiPhoto>>;
+}
+
+describe("useUploadPoiPhoto", () => {
+  let queryClient: QueryClient;
+  const file = new File(["photo"], "spot.webp", { type: "image/webp" });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+  });
+
+  it("calls uploadPoiPhoto and returns data on success", async () => {
+    const input = { file, poiId: "poi-1" };
+    const data = { url: "https://cdn.example.com/poi-1.webp" };
+    vi.mocked(uploadPoiPhoto).mockResolvedValue(apiResponse({ data }));
+
+    const { result } = renderHook(() => useUploadPoiPhoto(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    let resolved: unknown;
+    await act(async () => {
+      resolved = await result.current.mutateAsync(input);
+    });
+
+    expect(uploadPoiPhoto).toHaveBeenCalledWith({ body: input });
+    expect(resolved).toEqual(data);
+  });
+
+  it("invalidates poi detail and all pois when poiId is provided", async () => {
+    vi.mocked(uploadPoiPhoto).mockResolvedValue(
+      apiResponse({ data: { url: "https://cdn.example.com/poi-1.webp" } })
+    );
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useUploadPoiPhoto(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ file, poiId: "poi-1" });
+    });
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: queryKeys.pois.detail("poi-1"),
+      });
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.pois.all });
+    });
+  });
+
+  it("does not invalidate cache when poiId is omitted", async () => {
+    vi.mocked(uploadPoiPhoto).mockResolvedValue(
+      apiResponse({ data: { url: "https://cdn.example.com/pending.webp" } })
+    );
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useUploadPoiPhoto(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ file });
+    });
+
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  it("throws API error when response has no data", async () => {
+    const apiError = { message: "File too large" };
+    vi.mocked(uploadPoiPhoto).mockResolvedValue(apiResponse({ error: apiError }));
+
+    const { result } = renderHook(() => useUploadPoiPhoto(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await expect(
+      act(async () => {
+        await result.current.mutateAsync({ file });
+      })
+    ).rejects.toEqual(apiError);
+  });
+});

--- a/apps/web/src/features/pois/hooks/use-upload-poi-photo.ts
+++ b/apps/web/src/features/pois/hooks/use-upload-poi-photo.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { uploadPoiPhoto } from "@/lib/api";
+import type { UploadPoiPhotoData } from "@/lib/api";
+import { queryKeys } from "@/lib/api/query-keys";
+
+/** Body payload for `POST /upload/poi-photo`. */
+export type UploadPoiPhotoInput = UploadPoiPhotoData["body"];
+
+/**
+ * Uploads a photo for a custom POI.
+ *
+ * When `poiId` is provided, invalidates that POI detail and all POI queries.
+ * API errors are thrown so they can be handled with {@link useErrorMessage}.
+ */
+export function useUploadPoiPhoto() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (input: UploadPoiPhotoInput) => {
+      const response = await uploadPoiPhoto({ body: input });
+
+      if (response.data) {
+        return response.data;
+      }
+
+      throw response.error;
+    },
+    onSuccess: (_data, { poiId }) => {
+      if (!poiId) {
+        return;
+      }
+
+      queryClient.invalidateQueries({ queryKey: queryKeys.pois.detail(poiId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.pois.all });
+    },
+  });
+}

--- a/apps/web/src/features/pois/index.ts
+++ b/apps/web/src/features/pois/index.ts
@@ -2,6 +2,17 @@ export { PoiCard } from "./components/poi-card";
 export { PoiPhoto } from "./components/poi-photo";
 export { PoiOpeningHours } from "./components/poi-opening-hours";
 
+export { useCreatePoi } from "./hooks/use-create-poi";
+export { useUploadPoiPhoto } from "./hooks/use-upload-poi-photo";
+
+export { createPoiFormSchema } from "./schemas/pois.schema";
+export {
+  poiConstraints,
+  POI_VISIBILITY_VALUES,
+  DEFAULT_POI_VISIBILITY,
+  POI_CATEGORY_VALUES,
+} from "./constants/pois.constants";
+
 export {
   getPoiDisplayDataFromSavedPoi,
   getPoiDisplayDataFromPoi,
@@ -14,6 +25,11 @@ export {
   getCoordinatesFromSavedPoi,
   getSavedPoiMapId,
 } from "./utils/get-poi-coordinates";
+
+export type { CreatePoiInput } from "./hooks/use-create-poi";
+export type { UploadPoiPhotoInput } from "./hooks/use-upload-poi-photo";
+export type { CreatePoiFormData, CreatePoiFormMessages } from "./schemas/pois.schema";
+export type { PoiVisibility, PoiCategory } from "./constants/pois.constants";
 
 export type {
   PoiDisplayData,

--- a/apps/web/src/features/pois/schemas/pois.schema.test.ts
+++ b/apps/web/src/features/pois/schemas/pois.schema.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+
+import { poiConstraints } from "../constants/pois.constants";
+
+import { createPoiFormSchema } from "./pois.schema";
+
+const messages = {
+  requiredName: "required",
+  nameTooLong: "name too long",
+  descriptionTooLong: "desc too long",
+  addressTooLong: "address too long",
+  latitudeInvalid: "lat invalid",
+  longitudeInvalid: "lng invalid",
+};
+
+function schema() {
+  return createPoiFormSchema(messages);
+}
+
+const validInput = {
+  name: "Secret spot",
+  latitude: 48.8566,
+  longitude: 2.3522,
+};
+
+describe("createPoiFormSchema", () => {
+  it("accepts valid required fields", () => {
+    const result = schema().safeParse(validInput);
+    expect(result.success).toBe(true);
+  });
+
+  it("trims whitespace from name", () => {
+    const result = schema().safeParse({
+      ...validInput,
+      name: "  Secret spot  ",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.name).toBe("Secret spot");
+    }
+  });
+
+  it("accepts optional MVP fields", () => {
+    const result = schema().safeParse({
+      ...validInput,
+      description: "A quiet corner",
+      address: "1 rue de Rivoli",
+      visibility: "PRIVATE",
+      category: "park",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects empty name with required message", () => {
+    const result = schema().safeParse({
+      ...validInput,
+      name: "",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe(messages.requiredName);
+    }
+  });
+
+  it("rejects name longer than max", () => {
+    const result = schema().safeParse({
+      ...validInput,
+      name: "a".repeat(poiConstraints.name.max + 1),
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe(messages.nameTooLong);
+    }
+  });
+
+  it("rejects latitude below min", () => {
+    const result = schema().safeParse({
+      ...validInput,
+      latitude: poiConstraints.latitude.min - 0.1,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe(messages.latitudeInvalid);
+    }
+  });
+
+  it("rejects latitude above max", () => {
+    const result = schema().safeParse({
+      ...validInput,
+      latitude: poiConstraints.latitude.max + 0.1,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe(messages.latitudeInvalid);
+    }
+  });
+
+  it("rejects longitude below min", () => {
+    const result = schema().safeParse({
+      ...validInput,
+      longitude: poiConstraints.longitude.min - 0.1,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe(messages.longitudeInvalid);
+    }
+  });
+
+  it("rejects longitude above max", () => {
+    const result = schema().safeParse({
+      ...validInput,
+      longitude: poiConstraints.longitude.max + 0.1,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe(messages.longitudeInvalid);
+    }
+  });
+
+  it("rejects description longer than max", () => {
+    const result = schema().safeParse({
+      ...validInput,
+      description: "a".repeat(poiConstraints.description.max + 1),
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe(messages.descriptionTooLong);
+    }
+  });
+
+  it("rejects address longer than max", () => {
+    const result = schema().safeParse({
+      ...validInput,
+      address: "a".repeat(poiConstraints.address.max + 1),
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe(messages.addressTooLong);
+    }
+  });
+
+  it("rejects invalid visibility", () => {
+    const result = schema().safeParse({
+      ...validInput,
+      visibility: "SECRET",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid category", () => {
+    const result = schema().safeParse({
+      ...validInput,
+      category: "not-a-category",
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/web/src/features/pois/schemas/pois.schema.ts
+++ b/apps/web/src/features/pois/schemas/pois.schema.ts
@@ -1,0 +1,48 @@
+import * as z from "zod";
+
+import {
+  POI_CATEGORY_VALUES,
+  POI_VISIBILITY_VALUES,
+  poiConstraints,
+} from "../constants/pois.constants";
+
+const poiVisibility = z.enum(POI_VISIBILITY_VALUES);
+const poiCategory = z.enum(POI_CATEGORY_VALUES);
+
+export interface CreatePoiFormMessages {
+  requiredName: string;
+  nameTooLong: string;
+  descriptionTooLong: string;
+  addressTooLong: string;
+  latitudeInvalid: string;
+  longitudeInvalid: string;
+}
+
+export function createPoiFormSchema(messages: CreatePoiFormMessages) {
+  const { name, description, address, latitude, longitude } = poiConstraints;
+
+  return z.object({
+    name: z
+      .string()
+      .trim()
+      .min(name.min, { message: messages.requiredName })
+      .max(name.max, { message: messages.nameTooLong }),
+    latitude: z
+      .number()
+      .min(latitude.min, { message: messages.latitudeInvalid })
+      .max(latitude.max, { message: messages.latitudeInvalid }),
+    longitude: z
+      .number()
+      .min(longitude.min, { message: messages.longitudeInvalid })
+      .max(longitude.max, { message: messages.longitudeInvalid }),
+    description: z
+      .string()
+      .max(description.max, { message: messages.descriptionTooLong })
+      .optional(),
+    address: z.string().max(address.max, { message: messages.addressTooLong }).optional(),
+    visibility: poiVisibility.optional(),
+    category: poiCategory.optional(),
+  });
+}
+
+export type CreatePoiFormData = z.infer<ReturnType<typeof createPoiFormSchema>>;

--- a/apps/web/src/features/upload/upload.schema.test.ts
+++ b/apps/web/src/features/upload/upload.schema.test.ts
@@ -1,57 +1,34 @@
 import { describe, it, expect } from "vitest";
 
-import { avatarFileSchema } from "@/features/upload";
+import { avatarFileSchema, poiPhotoFileSchema } from "@/features/upload";
+
+function imageFile(type: string, size: number, name = "test.jpg") {
+  const file = new File(["test content"], name, { type });
+  Object.defineProperty(file, "size", {
+    value: size,
+    writable: false,
+  });
+  return file;
+}
 
 describe("avatarFileSchema", () => {
   it("should validate a valid JPEG file under 2MB", () => {
-    const file = new File(["test content"], "test.jpg", {
-      type: "image/jpeg",
-    });
-
-    Object.defineProperty(file, "size", {
-      value: 1024 * 1024,
-      writable: false,
-    });
-    const result = avatarFileSchema.safeParse(file);
+    const result = avatarFileSchema.safeParse(imageFile("image/jpeg", 1024 * 1024));
     expect(result.success).toBe(true);
   });
 
   it("should validate a valid PNG file under 2MB", () => {
-    const file = new File(["test content"], "test.png", {
-      type: "image/png",
-    });
-
-    Object.defineProperty(file, "size", {
-      value: 1024 * 1024,
-      writable: false,
-    });
-    const result = avatarFileSchema.safeParse(file);
+    const result = avatarFileSchema.safeParse(imageFile("image/png", 1024 * 1024, "test.png"));
     expect(result.success).toBe(true);
   });
 
   it("should validate a valid WebP file under 2MB", () => {
-    const file = new File(["test content"], "test.webp", {
-      type: "image/webp",
-    });
-
-    Object.defineProperty(file, "size", {
-      value: 1024 * 1024,
-      writable: false,
-    });
-    const result = avatarFileSchema.safeParse(file);
+    const result = avatarFileSchema.safeParse(imageFile("image/webp", 1024 * 1024, "test.webp"));
     expect(result.success).toBe(true);
   });
 
   it("should reject a file larger than 2MB", () => {
-    const file = new File(["test content"], "test.jpg", {
-      type: "image/jpeg",
-    });
-
-    Object.defineProperty(file, "size", {
-      value: 2 * 1024 * 1024 + 1,
-      writable: false,
-    });
-    const result = avatarFileSchema.safeParse(file);
+    const result = avatarFileSchema.safeParse(imageFile("image/jpeg", 2 * 1024 * 1024 + 1));
     expect(result.success).toBe(false);
     if (!result.success) {
       expect(result.error.issues[0].message).toBe("upload.fileTooLarge");
@@ -59,15 +36,7 @@ describe("avatarFileSchema", () => {
   });
 
   it("should reject an empty file (size = 0)", () => {
-    const file = new File([], "test.jpg", {
-      type: "image/jpeg",
-    });
-
-    Object.defineProperty(file, "size", {
-      value: 0,
-      writable: false,
-    });
-    const result = avatarFileSchema.safeParse(file);
+    const result = avatarFileSchema.safeParse(imageFile("image/jpeg", 0));
     expect(result.success).toBe(false);
     if (!result.success) {
       expect(result.error.issues[0].message).toBe("upload.fileEmpty");
@@ -75,15 +44,9 @@ describe("avatarFileSchema", () => {
   });
 
   it("should reject an invalid MIME type (e.g., PDF)", () => {
-    const file = new File(["test content"], "test.pdf", {
-      type: "application/pdf",
-    });
-
-    Object.defineProperty(file, "size", {
-      value: 1024 * 1024,
-      writable: false,
-    });
-    const result = avatarFileSchema.safeParse(file);
+    const result = avatarFileSchema.safeParse(
+      imageFile("application/pdf", 1024 * 1024, "test.pdf")
+    );
     expect(result.success).toBe(false);
     if (!result.success) {
       expect(result.error.issues[0].message).toBe("upload.invalidMimeType");
@@ -101,6 +64,28 @@ describe("avatarFileSchema", () => {
     expect(result.success).toBe(false);
     if (!result.success) {
       expect(result.error.issues[0].message).toBe("upload.invalidMimeType");
+    }
+  });
+});
+
+describe("poiPhotoFileSchema", () => {
+  it("should accept a JPEG under 5MB", () => {
+    const result = poiPhotoFileSchema.safeParse(imageFile("image/jpeg", 3 * 1024 * 1024));
+    expect(result.success).toBe(true);
+  });
+
+  it("should accept a file at the 5MB limit", () => {
+    const result = poiPhotoFileSchema.safeParse(
+      imageFile("image/webp", 5 * 1024 * 1024, "spot.webp")
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("should reject a file larger than 5MB", () => {
+    const result = poiPhotoFileSchema.safeParse(imageFile("image/jpeg", 5 * 1024 * 1024 + 1));
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe("upload.fileTooLarge");
     }
   });
 });

--- a/apps/web/src/features/upload/upload.schema.ts
+++ b/apps/web/src/features/upload/upload.schema.ts
@@ -2,17 +2,24 @@ import * as z from "zod";
 
 const ALLOWED_MIME_TYPES = ["image/jpeg", "image/png", "image/webp"];
 const MAX_AVATAR_SIZE = 2 * 1024 * 1024; // 2MB
+const MAX_POI_PHOTO_SIZE = 5 * 1024 * 1024; // 5MB
 
-export const avatarFileSchema = z
-  .instanceof(File, {
-    message: "upload.invalidMimeType",
-  })
-  .refine((file) => file.size > 0, {
-    message: "upload.fileEmpty",
-  })
-  .refine((file) => file.size <= MAX_AVATAR_SIZE, {
-    message: "upload.fileTooLarge",
-  })
-  .refine((file) => ALLOWED_MIME_TYPES.includes(file.type), {
-    message: "upload.invalidMimeType",
-  });
+function imageFileSchema(maxSize: number) {
+  return z
+    .instanceof(File, {
+      message: "upload.invalidMimeType",
+    })
+    .refine((file) => file.size > 0, {
+      message: "upload.fileEmpty",
+    })
+    .refine((file) => file.size <= maxSize, {
+      message: "upload.fileTooLarge",
+    })
+    .refine((file) => ALLOWED_MIME_TYPES.includes(file.type), {
+      message: "upload.invalidMimeType",
+    });
+}
+
+export const avatarFileSchema = imageFileSchema(MAX_AVATAR_SIZE);
+
+export const poiPhotoFileSchema = imageFileSchema(MAX_POI_PHOTO_SIZE);

--- a/apps/web/src/lib/api/query-keys.test.ts
+++ b/apps/web/src/lib/api/query-keys.test.ts
@@ -102,3 +102,24 @@ describe("queryKeys.lists", () => {
     expect(queryKeys.lists.poiMembership.byPlaces(["a"])[0]).toBe(queryKeys.lists.all[0]);
   });
 });
+
+describe("queryKeys.pois", () => {
+  it("all is stable root", () => {
+    expect(queryKeys.pois.all).toEqual(["pois"]);
+  });
+
+  it("list includes filters", () => {
+    const filters = { page: 1, limit: 10 };
+    expect(queryKeys.pois.list(filters)).toEqual(["pois", "list", filters]);
+    expect(queryKeys.pois.list()).toEqual(["pois", "list", undefined]);
+  });
+
+  it("detail includes poiId", () => {
+    expect(queryKeys.pois.detail("poi-1")).toEqual(["pois", "detail", "poi-1"]);
+  });
+
+  it("keys are prefixed by all", () => {
+    expect(queryKeys.pois.list()[0]).toBe(queryKeys.pois.all[0]);
+    expect(queryKeys.pois.detail("id")[0]).toBe(queryKeys.pois.all[0]);
+  });
+});

--- a/apps/web/src/lib/api/query-keys.ts
+++ b/apps/web/src/lib/api/query-keys.ts
@@ -2,6 +2,7 @@ import {
   GetCollaboratorsData,
   GetListPoisData,
   GetListsData,
+  GetPoisData,
   GetSharedListPoisData,
 } from "./generated/types.gen";
 
@@ -12,6 +13,7 @@ import type { ListsInfiniteFilters } from "@/features/lists/hooks/use-lists-infi
 // initializer makes TypeScript infer `any`, which silently widens every `useQuery` result.
 const GOOGLE_PLACES_ROOT = ["google-places"] as const;
 const LISTS_ROOT = ["lists"] as const;
+const POIS_ROOT = ["pois"] as const;
 const SHARED_ROOT = ["shared"] as const;
 
 const listPoisRoot = (listId: string) => [...LISTS_ROOT, "pois", listId] as const;
@@ -46,6 +48,11 @@ export const queryKeys = {
       list: (listId: string, filters?: GetCollaboratorsData["query"]) =>
         [...listCollaboratorsRoot(listId), filters] as const,
     },
+  },
+  pois: {
+    all: POIS_ROOT,
+    list: (filters?: GetPoisData["query"]) => [...POIS_ROOT, "list", filters] as const,
+    detail: (poiId: string) => [...POIS_ROOT, "detail", poiId] as const,
   },
   shared: {
     all: SHARED_ROOT,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Description

First child of NIR-69: data layer for custom POI creation ([NIR-79](https://linear.app/nirbyfr/issue/NIR-79/add-custom-poi-react-query-hooks)).

`createPoi` and `uploadPoiPhoto` were already exported from the OpenAPI client but unused. This PR adds typed React Query mutations, query keys, and a Zod form schema aligned with `POST /poi`, following the lists pattern (`use-create-list` + `createListFormSchema`).

No UI. i18n wiring, the create form, and add-to-list flow are NIR-80 / NIR-81 / NIR-82.

## 🎯 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] ✅ Test update

## 🔗 Related Issues

Related to #156
Related to #146

## 🚀 Changes Made

- Add `queryKeys.pois.{all,list,detail}` (distinct from `queryKeys.lists.pois`)
- Add `useCreatePoi` — `POST /poi`, invalidates `pois.all`
- Add `useUploadPoiPhoto` — `POST /upload/poi-photo`, invalidates detail + all when `poiId` is set
- Add `createPoiFormSchema(messages)` (name, lat, lng required; description, address, visibility, category optional)
- Add `poiPhotoFileSchema` (JPEG/PNG/WebP, 5 MB)
- Export hooks, schema, and constants from `features/pois`

## 🧪 Testing

- [ ] Tested locally with `pnpm dev`
- [x] All quality checks pass (`pnpm lint`)
- [x] Unit tests pass (`pnpm test`) — 63 files / 344 tests
- [ ] Database migrations applied if needed

## 📸 Screenshots/Videos

N/A

## ✅ Checklist

- [x] Code follows project style guidelines
- [ ] Documentation updated if needed
- [x] No console errors or warnings
- [x] Removed any debug code

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffc2a-88d8-7f1a-9121-dcc6b7d75821?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffc2a-88d8-7f1a-9121-dcc6b7d75821&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

