### PR TITLE
feat(pois): add custom POI i18n keys

### DIFF
--- a/apps/web/src/features/pois/hooks/use-poi-form-schema.ts
+++ b/apps/web/src/features/pois/hooks/use-poi-form-schema.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useMemo } from "react";
+
+import { createPoiFormSchema } from "../schemas/pois.schema";
+
+/** Zod schema for custom POI create/edit forms with localized validation messages. */
+export function usePoiFormSchema() {
+  const tPoi = useTranslations("poi");
+
+  return useMemo(
+    () =>
+      createPoiFormSchema({
+        requiredName: tPoi("validation.requiredName"),
+        nameTooLong: tPoi("validation.nameTooLong"),
+        descriptionTooLong: tPoi("validation.descriptionTooLong"),
+        addressTooLong: tPoi("validation.addressTooLong"),
+        latitudeInvalid: tPoi("validation.latitudeInvalid"),
+        longitudeInvalid: tPoi("validation.longitudeInvalid"),
+      }),
+    [tPoi]
+  );
+}

--- a/apps/web/src/features/pois/index.ts
+++ b/apps/web/src/features/pois/index.ts
@@ -4,6 +4,7 @@ export { PoiOpeningHours } from "./components/poi-opening-hours";
 
 export { useCreatePoi } from "./hooks/use-create-poi";
 export { useUploadPoiPhoto } from "./hooks/use-upload-poi-photo";
+export { usePoiFormSchema } from "./hooks/use-poi-form-schema";
 
 export { createPoiFormSchema } from "./schemas/pois.schema";
 export {

--- a/apps/web/src/lib/i18n/locales-parity.test.tsx
+++ b/apps/web/src/lib/i18n/locales-parity.test.tsx
@@ -3,8 +3,10 @@ import { describe, expect, it } from "vitest";
 
 import enExplore from "./locales/en/explore.json";
 import enLists from "./locales/en/lists.json";
+import enPoi from "./locales/en/poi.json";
 import frExplore from "./locales/fr/explore.json";
 import frLists from "./locales/fr/lists.json";
+import frPoi from "./locales/fr/poi.json";
 
 type JsonObject = Record<string, unknown>;
 
@@ -39,6 +41,7 @@ function expectLocaleParity(en: JsonObject, fr: JsonObject, namespace: string) {
 const NEW_LISTS_KEYS = [
   "pois.section.title",
   "pois.empty.title",
+  "pois.empty.description",
   "pois.error.retry",
   "poi.source.custom",
   "removePoi.success",
@@ -71,6 +74,27 @@ const NEW_EXPLORE_KEYS = [
   "addToList.picker.alreadyInList",
 ] as const;
 
+const NEW_POI_KEYS = [
+  "create.title",
+  "create.submit",
+  "edit.submit",
+  "fields.name",
+  "fields.visibility",
+  "fields.category",
+  "placeholders.name",
+  "validation.requiredName",
+  "validation.latitudeInvalid",
+  "visibility.PRIVATE.label",
+  "categories.restaurant.label",
+  "categories.other.label",
+  "photo.uploadSuccess",
+  "photo.uploadError",
+  "createPoi.success",
+  "createPoi.error",
+  "updatePoi.success",
+  "updatePoi.error",
+] as const;
+
 function expectNonEmptyStrings(obj: JsonObject, keys: readonly string[], locale: string) {
   for (const key of keys) {
     const value = getValue(obj, key);
@@ -88,6 +112,10 @@ describe("locales parity", () => {
     expectLocaleParity(enExplore, frExplore, "explore");
   });
 
+  it("poi.json has the same keys in en and fr", () => {
+    expectLocaleParity(enPoi, frPoi, "poi");
+  });
+
   it("new lists keys are non-empty strings in both locales", () => {
     expectNonEmptyStrings(enLists, NEW_LISTS_KEYS, "en");
     expectNonEmptyStrings(frLists, NEW_LISTS_KEYS, "fr");
@@ -96,6 +124,11 @@ describe("locales parity", () => {
   it("new explore keys are non-empty strings in both locales", () => {
     expectNonEmptyStrings(enExplore, NEW_EXPLORE_KEYS, "en");
     expectNonEmptyStrings(frExplore, NEW_EXPLORE_KEYS, "fr");
+  });
+
+  it("new poi keys are non-empty strings in both locales", () => {
+    expectNonEmptyStrings(enPoi, NEW_POI_KEYS, "en");
+    expectNonEmptyStrings(frPoi, NEW_POI_KEYS, "fr");
   });
 
   it("does not keep the removed detail.poisComingSoon key", () => {
@@ -116,5 +149,12 @@ describe("message resolution", () => {
     expect(tExplore("addToList.picker.description", { placeName: "Tour Eiffel" })).toBe(
       'Choose a list for "Tour Eiffel"'
     );
+  });
+
+  it("resolves poi namespace", () => {
+    const tPoi = createTranslator({ locale: "en", messages: { poi: enPoi }, namespace: "poi" });
+
+    expect(tPoi("select", { name: "Secret garden" })).toBe("Select Secret garden");
+    expect(tPoi("create.title")).toBe("New place");
   });
 });

--- a/apps/web/src/lib/i18n/locales/en/lists.json
+++ b/apps/web/src/lib/i18n/locales/en/lists.json
@@ -86,7 +86,7 @@
     },
     "empty": {
       "title": "No places yet",
-      "description": "Search for places in Explore to add them here."
+      "description": "Search in Explore or create a custom place to add it here."
     },
     "loading": "Loading places…",
     "loadingMore": "Loading more…",

--- a/apps/web/src/lib/i18n/locales/en/poi.json
+++ b/apps/web/src/lib/i18n/locales/en/poi.json
@@ -11,5 +11,85 @@
     "opensAt": "Opens at {time}",
     "opensTomorrowAt": "Opens tomorrow at {time}",
     "opensDayAt": "Opens {day} at {time}"
+  },
+  "create": {
+    "title": "New place",
+    "submit": "Create"
+  },
+  "edit": {
+    "title": "Edit place",
+    "action": "Edit",
+    "submit": "Save"
+  },
+  "fields": {
+    "name": "Name",
+    "description": "Description",
+    "address": "Address",
+    "latitude": "Latitude",
+    "longitude": "Longitude",
+    "visibility": "Visibility",
+    "category": "Category"
+  },
+  "placeholders": {
+    "name": "e.g. Secret garden",
+    "description": "Optional notes about this place",
+    "address": "Street, city"
+  },
+  "visibility": {
+    "PRIVATE": { "label": "Private" },
+    "SHARED": { "label": "Shared" },
+    "PUBLIC": { "label": "Public" }
+  },
+  "categories": {
+    "restaurant": { "label": "Restaurant" },
+    "cafe": { "label": "Café" },
+    "bar": { "label": "Bar" },
+    "bakery": { "label": "Bakery" },
+    "grocery_store": { "label": "Grocery store" },
+    "supermarket": { "label": "Supermarket" },
+    "hotel": { "label": "Hotel" },
+    "museum": { "label": "Museum" },
+    "park": { "label": "Park" },
+    "gym": { "label": "Gym" },
+    "pharmacy": { "label": "Pharmacy" },
+    "hospital": { "label": "Hospital" },
+    "bank": { "label": "Bank" },
+    "gas_station": { "label": "Gas station" },
+    "parking": { "label": "Parking" },
+    "shopping_mall": { "label": "Shopping mall" },
+    "movie_theater": { "label": "Movie theater" },
+    "library": { "label": "Library" },
+    "church": { "label": "Church" },
+    "mosque": { "label": "Mosque" },
+    "school": { "label": "School" },
+    "university": { "label": "University" },
+    "train_station": { "label": "Train station" },
+    "bus_station": { "label": "Bus station" },
+    "airport": { "label": "Airport" },
+    "tourist_attraction": { "label": "Tourist attraction" },
+    "other": { "label": "Other" }
+  },
+  "photo": {
+    "title": "Photo",
+    "hint": "Tap to add a photo",
+    "formats": "JPEG, PNG or WebP · max. 5 MB",
+    "uploadSuccess": "Photo uploaded successfully",
+    "uploadError": "Could not upload the photo"
+  },
+  "createPoi": {
+    "success": "Place created successfully",
+    "error": "Could not create the place"
+  },
+  "updatePoi": {
+    "success": "Place updated successfully",
+    "error": "Could not update the place"
+  },
+  "validation": {
+    "requiredName": "Place name is required",
+    "nameTooLong": "Place name cannot be longer than 255 characters",
+    "descriptionTooLong": "Description cannot be longer than 1000 characters",
+    "addressTooLong": "Address cannot be longer than 500 characters",
+    "latitudeInvalid": "Latitude must be between -90 and 90",
+    "longitudeInvalid": "Longitude must be between -180 and 180"
   }
 }

--- a/apps/web/src/lib/i18n/locales/fr/lists.json
+++ b/apps/web/src/lib/i18n/locales/fr/lists.json
@@ -86,7 +86,7 @@
     },
     "empty": {
       "title": "Aucun lieu pour l'instant",
-      "description": "Recherche des lieux dans Explorer pour les ajouter ici."
+      "description": "Recherche dans Explorer ou crée un lieu personnalisé pour l’ajouter ici."
     },
     "loading": "Chargement des lieux…",
     "loadingMore": "Chargement…",

--- a/apps/web/src/lib/i18n/locales/fr/poi.json
+++ b/apps/web/src/lib/i18n/locales/fr/poi.json
@@ -11,5 +11,85 @@
     "opensAt": "Ouvre à {time}",
     "opensTomorrowAt": "Ouvre demain à {time}",
     "opensDayAt": "Ouvre {day} à {time}"
+  },
+  "create": {
+    "title": "Nouveau lieu",
+    "submit": "Créer"
+  },
+  "edit": {
+    "title": "Modifier le lieu",
+    "action": "Modifier",
+    "submit": "Enregistrer"
+  },
+  "fields": {
+    "name": "Nom",
+    "description": "Description",
+    "address": "Adresse",
+    "latitude": "Latitude",
+    "longitude": "Longitude",
+    "visibility": "Visibilité",
+    "category": "Catégorie"
+  },
+  "placeholders": {
+    "name": "ex. Jardin secret",
+    "description": "Notes optionnelles sur ce lieu",
+    "address": "Rue, ville"
+  },
+  "visibility": {
+    "PRIVATE": { "label": "Privé" },
+    "SHARED": { "label": "Partagé" },
+    "PUBLIC": { "label": "Public" }
+  },
+  "categories": {
+    "restaurant": { "label": "Restaurant" },
+    "cafe": { "label": "Café" },
+    "bar": { "label": "Bar" },
+    "bakery": { "label": "Boulangerie" },
+    "grocery_store": { "label": "Épicerie" },
+    "supermarket": { "label": "Supermarché" },
+    "hotel": { "label": "Hôtel" },
+    "museum": { "label": "Musée" },
+    "park": { "label": "Parc" },
+    "gym": { "label": "Salle de sport" },
+    "pharmacy": { "label": "Pharmacie" },
+    "hospital": { "label": "Hôpital" },
+    "bank": { "label": "Banque" },
+    "gas_station": { "label": "Station-service" },
+    "parking": { "label": "Parking" },
+    "shopping_mall": { "label": "Centre commercial" },
+    "movie_theater": { "label": "Cinéma" },
+    "library": { "label": "Bibliothèque" },
+    "church": { "label": "Église" },
+    "mosque": { "label": "Mosquée" },
+    "school": { "label": "École" },
+    "university": { "label": "Université" },
+    "train_station": { "label": "Gare" },
+    "bus_station": { "label": "Gare routière" },
+    "airport": { "label": "Aéroport" },
+    "tourist_attraction": { "label": "Attraction touristique" },
+    "other": { "label": "Autre" }
+  },
+  "photo": {
+    "title": "Photo",
+    "hint": "Appuyer pour ajouter une photo",
+    "formats": "JPEG, PNG ou WebP · 5 Mo max.",
+    "uploadSuccess": "Photo envoyée avec succès",
+    "uploadError": "Impossible d’envoyer la photo"
+  },
+  "createPoi": {
+    "success": "Lieu créé avec succès",
+    "error": "Impossible de créer le lieu"
+  },
+  "updatePoi": {
+    "success": "Lieu mis à jour avec succès",
+    "error": "Impossible de mettre à jour le lieu"
+  },
+  "validation": {
+    "requiredName": "Le nom du lieu est requis",
+    "nameTooLong": "Le nom du lieu ne peut pas dépasser 255 caractères",
+    "descriptionTooLong": "La description ne peut pas dépasser 1000 caractères",
+    "addressTooLong": "L’adresse ne peut pas dépasser 500 caractères",
+    "latitudeInvalid": "La latitude doit être comprise entre -90 et 90",
+    "longitudeInvalid": "La longitude doit être comprise entre -180 et 180"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Description

Second child of NIR-69: i18n keys for custom POI creation ([NIR-80](https://linear.app/nirbyfr/issue/NIR-80/add-custom-poi-i18n-keys)).

`poi.json` only had display strings (source, opening hours). This PR adds form labels, placeholders, validation, visibility, 27 category labels, photo copy, and success/error toasts in en/fr, plus `usePoiFormSchema` so NIR-81 can wire the Zod schema without inventing keys.

No UI. The create form is NIR-81.

## 🎯 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] ✅ Test update

## 🔗 Related Issues

Related to #157
Related to #146

## 🚀 Changes Made

- Add create/edit/fields/placeholders/visibility/categories/photo/toast/validation keys to `en/fr/poi.json`
- Update list empty-state copy to mention custom place creation
- Add `usePoiFormSchema` (localized Zod messages) and export it from `features/pois`
- Extend `locales-parity.test.tsx` for the `poi` namespace

## 🧪 Testing

- [ ] Tested locally with `pnpm dev`
- [x] All quality checks pass (`pnpm lint`)
- [x] Unit tests pass (`pnpm test`) — 63 files / 347 tests
- [ ] Database migrations applied if needed

## 📸 Screenshots/Videos

N/A

## ✅ Checklist

- [x] Code follows project style guidelines
- [ ] Documentation updated if needed
- [x] No console errors or warnings
- [x] Removed any debug code

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffc2a-88d8-7f1a-9121-dcc6b7d75821?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffc2a-88d8-7f1a-9121-dcc6b7d75821&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

