### PR TITLE
feat(pois): add custom POI create form

### DIFF
--- a/apps/web/src/features/lists/components/list-pois-section.test.tsx
+++ b/apps/web/src/features/lists/components/list-pois-section.test.tsx
@@ -27,6 +27,11 @@ vi.mock("../hooks/use-remove-poi-from-list", () => ({
   }),
 }));
 
+vi.mock("@/features/pois/components/create-poi-dialog", () => ({
+  CreatePoiDialog: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="create-poi-dialog" /> : null,
+}));
+
 const customSavedPoi: SavedPoiListItem = {
   id: "sp-1",
   listId: "list-1",
@@ -114,6 +119,23 @@ describe("ListPoisSection", () => {
     expect(screen.getByText("pois.section.total")).toBeInTheDocument();
     expect(screen.getByText("pois.empty.title")).toBeInTheDocument();
     expect(screen.getByText("pois.empty.description")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "create.title" })).not.toBeInTheDocument();
+  });
+
+  it("shows empty-state create CTA for EDITOR", () => {
+    mockListPoisInfiniteQuery();
+
+    render(<ListPoisSection listId="list-1" role="EDITOR" />);
+
+    expect(screen.getByRole("button", { name: "create.title" })).toBeInTheDocument();
+  });
+
+  it("hides create CTA for VIEWER", () => {
+    mockListPoisInfiniteQuery();
+
+    render(<ListPoisSection listId="list-1" role="VIEWER" />);
+
+    expect(screen.queryByRole("button", { name: "create.title" })).not.toBeInTheDocument();
   });
 
   it("shows error state with retry", async () => {
@@ -194,5 +216,6 @@ describe("ListPoisSection", () => {
     render(<ListPoisSection listId="list-1" role="EDITOR" />);
 
     expect(screen.getAllByRole("button", { name: "removePoi.action" })).toHaveLength(2);
+    expect(screen.getByRole("button", { name: "create.title" })).toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/lists/components/list-pois-section.tsx
+++ b/apps/web/src/features/lists/components/list-pois-section.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { Loader2Icon, MapPinOffIcon, OctagonXIcon } from "lucide-react";
+import { Loader2Icon, MapPinOffIcon, OctagonXIcon, PlusIcon } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 
 import { canEditList, type ListRole } from "../constants/lists.constants";
 import { useInfiniteScroll } from "../hooks/use-infinite-scroll";
@@ -13,6 +13,7 @@ import { ListPoisSkeleton } from "./list-pois-skeleton";
 
 import { Button } from "@/components/ui";
 import { getSavedPoiMapId, type SavedPoiListItem } from "@/features/pois";
+import { CreatePoiDialog } from "@/features/pois/components/create-poi-dialog";
 import { useErrorMessage } from "@/hooks/use-error-message";
 
 type ListPoisSectionProps = {
@@ -28,9 +29,11 @@ export function ListPoisSection({
   selectedPoiId,
   onSelectPoi,
 }: ListPoisSectionProps) {
-  const canRemove = canEditList(role);
+  const canEdit = canEditList(role);
   const tLists = useTranslations("lists");
+  const tPoi = useTranslations("poi");
   const getErrorMessage = useErrorMessage();
+  const [createOpen, setCreateOpen] = useState(false);
 
   const {
     data,
@@ -60,12 +63,22 @@ export function ListPoisSection({
 
   return (
     <section className="border-t border-border pt-6">
-      <header className="mb-4 grid gap-1">
-        <h2 className="font-display text-base font-semibold tracking-tight">
-          {tLists("pois.section.title")}
-        </h2>
-        {!isInitialLoading && !isError && total !== undefined ? (
-          <p className="text-sm text-muted-foreground">{tLists("pois.section.total", { total })}</p>
+      <header className="mb-4 flex items-start justify-between gap-3">
+        <div className="grid gap-1">
+          <h2 className="font-display text-base font-semibold tracking-tight">
+            {tLists("pois.section.title")}
+          </h2>
+          {!isInitialLoading && !isError && total !== undefined ? (
+            <p className="text-sm text-muted-foreground">
+              {tLists("pois.section.total", { total })}
+            </p>
+          ) : null}
+        </div>
+        {canEdit && !isInitialLoading && !isError && items.length > 0 ? (
+          <Button type="button" variant="outline" size="sm" onClick={() => setCreateOpen(true)}>
+            <PlusIcon />
+            {tPoi("create.title")}
+          </Button>
         ) : null}
       </header>
 
@@ -99,6 +112,12 @@ export function ListPoisSection({
             </h3>
             <p className="text-sm text-muted-foreground">{tLists("pois.empty.description")}</p>
           </div>
+          {canEdit ? (
+            <Button type="button" size="sm" onClick={() => setCreateOpen(true)}>
+              <PlusIcon />
+              {tPoi("create.title")}
+            </Button>
+          ) : null}
         </div>
       )}
 
@@ -113,7 +132,7 @@ export function ListPoisSection({
                   <ListPoiRow
                     savedPoi={savedPoi}
                     listId={listId}
-                    canRemove={canRemove}
+                    canRemove={canEdit}
                     isSelected={mapId !== null && selectedPoiId === mapId}
                     onSelect={onSelectPoi}
                   />
@@ -136,6 +155,8 @@ export function ListPoisSection({
           )}
         </>
       )}
+
+      {canEdit ? <CreatePoiDialog open={createOpen} onOpenChange={setCreateOpen} /> : null}
     </section>
   );
 }

--- a/apps/web/src/features/pois/components/create-poi-dialog.tsx
+++ b/apps/web/src/features/pois/components/create-poi-dialog.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+
+import { CreatePoiForm } from "../forms/create-poi-form";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui";
+import { useMediaQuery } from "@/hooks/use-media-query";
+
+export type CreatePoiDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCreated?: (poiId: string) => void;
+};
+
+/** Create custom POI: Dialog on desktop, Drawer on mobile. */
+export function CreatePoiDialog(props: CreatePoiDialogProps) {
+  const isMobile = useMediaQuery("(max-width: 768px)");
+
+  return isMobile ? <CreatePoiDrawer {...props} /> : <CreatePoiDesktopDialog {...props} />;
+}
+
+function CreatePoiDesktopDialog({ open, onOpenChange, onCreated }: CreatePoiDialogProps) {
+  const tPoi = useTranslations("poi");
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[85vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{tPoi("create.title")}</DialogTitle>
+          <DialogDescription className="sr-only">{tPoi("create.title")}</DialogDescription>
+        </DialogHeader>
+        <CreatePoiForm closeDialog={() => onOpenChange(false)} onCreated={onCreated} />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function CreatePoiDrawer({ open, onOpenChange, onCreated }: CreatePoiDialogProps) {
+  const tPoi = useTranslations("poi");
+
+  return (
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <DrawerContent>
+        <DrawerHeader>
+          <DrawerTitle>{tPoi("create.title")}</DrawerTitle>
+          <DrawerDescription className="sr-only">{tPoi("create.title")}</DrawerDescription>
+        </DrawerHeader>
+        <div className="overflow-y-auto px-4 pb-4">
+          <CreatePoiForm closeDialog={() => onOpenChange(false)} onCreated={onCreated} />
+        </div>
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/apps/web/src/features/pois/forms/create-poi-form.test.tsx
+++ b/apps/web/src/features/pois/forms/create-poi-form.test.tsx
@@ -1,0 +1,143 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { toast } from "sonner";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useCreatePoi } from "../hooks/use-create-poi";
+import { useUploadPoiPhoto } from "../hooks/use-upload-poi-photo";
+
+import { CreatePoiForm } from "./create-poi-form";
+
+vi.mock("../hooks/use-create-poi", () => ({
+  useCreatePoi: vi.fn(),
+}));
+
+vi.mock("../hooks/use-upload-poi-photo", () => ({
+  useUploadPoiPhoto: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-error-message", () => ({
+  useErrorMessage: () => () => "API error message",
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("CreatePoiForm", () => {
+  const closeDialog = vi.fn();
+  const createPoi = vi.fn();
+  const uploadPoiPhoto = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createPoi.mockResolvedValue({ poi: { id: "poi-1", name: "Secret spot" } });
+    uploadPoiPhoto.mockResolvedValue({ url: "https://cdn.example.com/spot.webp" });
+    vi.mocked(useCreatePoi).mockReturnValue({
+      mutateAsync: createPoi,
+      isPending: false,
+    } as unknown as ReturnType<typeof useCreatePoi>);
+    vi.mocked(useUploadPoiPhoto).mockReturnValue({
+      mutateAsync: uploadPoiPhoto,
+      isPending: false,
+    } as unknown as ReturnType<typeof useUploadPoiPhoto>);
+  });
+
+  it("shows validation messages for required fields", async () => {
+    const user = userEvent.setup();
+
+    render(<CreatePoiForm closeDialog={closeDialog} />);
+
+    await user.click(screen.getByRole("button", { name: "create.submit" }));
+
+    expect(await screen.findByText("validation.requiredName")).toBeInTheDocument();
+    expect(screen.getByText("validation.latitudeInvalid")).toBeInTheDocument();
+    expect(createPoi).not.toHaveBeenCalled();
+    expect(uploadPoiPhoto).not.toHaveBeenCalled();
+  });
+
+  it("submits createPoi without uploading when no photo is selected", async () => {
+    const user = userEvent.setup();
+
+    render(<CreatePoiForm closeDialog={closeDialog} />);
+
+    await user.type(screen.getByLabelText("fields.name"), "Secret spot");
+    await user.type(screen.getByLabelText("fields.latitude"), "48.8566");
+    await user.type(screen.getByLabelText("fields.longitude"), "2.3522");
+    await user.click(screen.getByRole("button", { name: "create.submit" }));
+
+    await waitFor(() => {
+      expect(createPoi).toHaveBeenCalledWith({
+        name: "Secret spot",
+        latitude: 48.8566,
+        longitude: 2.3522,
+        description: undefined,
+        address: undefined,
+        visibility: "PRIVATE",
+        category: undefined,
+      });
+    });
+
+    expect(uploadPoiPhoto).not.toHaveBeenCalled();
+    expect(toast.success).toHaveBeenCalledWith("createPoi.success");
+    expect(closeDialog).toHaveBeenCalledTimes(1);
+  });
+
+  it("uploads the photo then creates the POI with photoUrls", async () => {
+    const user = userEvent.setup();
+    const file = new File(["photo"], "spot.webp", { type: "image/webp" });
+
+    render(<CreatePoiForm closeDialog={closeDialog} />);
+
+    await user.type(screen.getByLabelText("fields.name"), "Secret spot");
+    await user.type(screen.getByLabelText("fields.latitude"), "48.8566");
+    await user.type(screen.getByLabelText("fields.longitude"), "2.3522");
+
+    const photoInput = document.querySelector('input[type="file"]');
+    expect(photoInput).toBeInstanceOf(HTMLInputElement);
+    await user.upload(photoInput as HTMLInputElement, file);
+
+    await user.click(screen.getByRole("button", { name: "create.submit" }));
+
+    await waitFor(() => {
+      expect(uploadPoiPhoto).toHaveBeenCalledWith({ file });
+      expect(createPoi).toHaveBeenCalledWith({
+        name: "Secret spot",
+        latitude: 48.8566,
+        longitude: 2.3522,
+        description: undefined,
+        address: undefined,
+        visibility: "PRIVATE",
+        category: undefined,
+        photoUrls: ["https://cdn.example.com/spot.webp"],
+      });
+    });
+
+    expect(uploadPoiPhoto.mock.invocationCallOrder[0]).toBeLessThan(
+      createPoi.mock.invocationCallOrder[0]
+    );
+  });
+
+  it("shows an error toast when createPoi fails", async () => {
+    const user = userEvent.setup();
+    createPoi.mockRejectedValue({ message: "Forbidden" });
+
+    render(<CreatePoiForm closeDialog={closeDialog} />);
+
+    await user.type(screen.getByLabelText("fields.name"), "Secret spot");
+    await user.type(screen.getByLabelText("fields.latitude"), "48.8566");
+    await user.type(screen.getByLabelText("fields.longitude"), "2.3522");
+    await user.click(screen.getByRole("button", { name: "create.submit" }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("createPoi.error", {
+        description: "API error message",
+      });
+    });
+
+    expect(closeDialog).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/features/pois/forms/create-poi-form.tsx
+++ b/apps/web/src/features/pois/forms/create-poi-form.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { standardSchemaResolver } from "@hookform/resolvers/standard-schema";
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+
+import { DEFAULT_POI_VISIBILITY } from "../constants/pois.constants";
+import { useCreatePoi } from "../hooks/use-create-poi";
+import { usePoiFormSchema } from "../hooks/use-poi-form-schema";
+import { useUploadPoiPhoto } from "../hooks/use-upload-poi-photo";
+import type { CreatePoiFormData } from "../schemas/pois.schema";
+import { poiFormValuesToBody } from "../utils/poi-form.utils";
+
+import { PoiFormFields } from "./poi-form-fields";
+
+import { Button, Form } from "@/components/ui";
+import { poiPhotoFileSchema } from "@/features/upload";
+import { useErrorMessage } from "@/hooks/use-error-message";
+import { cn } from "@/lib/utils";
+
+export type CreatePoiFormProps = {
+  closeDialog?: () => void;
+  onCreated?: (poiId: string) => void;
+};
+
+export function CreatePoiForm({ closeDialog, onCreated }: CreatePoiFormProps) {
+  const tPoi = useTranslations("poi");
+  const t = useTranslations();
+  const getErrorMessage = useErrorMessage();
+  const { mutateAsync: createPoi, isPending: isCreating } = useCreatePoi();
+  const { mutateAsync: uploadPoiPhoto, isPending: isUploading } = useUploadPoiPhoto();
+  const poiFormSchema = usePoiFormSchema();
+  const [photoFile, setPhotoFile] = useState<File | null>(null);
+
+  const form = useForm<CreatePoiFormData>({
+    resolver: standardSchemaResolver(poiFormSchema),
+    defaultValues: {
+      name: "",
+      description: "",
+      address: "",
+      latitude: undefined,
+      longitude: undefined,
+      visibility: DEFAULT_POI_VISIBILITY,
+      category: undefined,
+    },
+  });
+
+  const isPending = isCreating || isUploading;
+
+  async function onSubmit(values: CreatePoiFormData) {
+    try {
+      let photoUrls: string[] | undefined;
+
+      if (photoFile) {
+        const parsedPhoto = poiPhotoFileSchema.safeParse(photoFile);
+        if (!parsedPhoto.success) {
+          toast.error(tPoi("photo.uploadError"), {
+            description: t(parsedPhoto.error.issues[0]?.message ?? "errors.default"),
+          });
+          return;
+        }
+
+        try {
+          const uploaded = await uploadPoiPhoto({ file: photoFile });
+          photoUrls = [uploaded.url];
+        } catch (error) {
+          toast.error(tPoi("photo.uploadError"), {
+            description: getErrorMessage(error),
+          });
+          return;
+        }
+      }
+
+      const { poi } = await createPoi({
+        ...poiFormValuesToBody(values),
+        ...(photoUrls ? { photoUrls } : {}),
+      });
+
+      toast.success(tPoi("createPoi.success"));
+      form.reset();
+      setPhotoFile(null);
+      closeDialog?.();
+      if (poi.id) {
+        onCreated?.(poi.id);
+      }
+    } catch (error) {
+      toast.error(tPoi("createPoi.error"), {
+        description: getErrorMessage(error),
+      });
+    }
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="grid gap-4">
+        <PoiFormFields
+          control={form.control}
+          disabled={isPending}
+          photoFile={photoFile}
+          onPhotoChange={setPhotoFile}
+        />
+
+        <div className={cn("mt-2 flex flex-col gap-2 md:flex-row md:justify-end")}>
+          {closeDialog ? (
+            <Button variant="outline" type="button" onClick={closeDialog} disabled={isPending}>
+              {t("common.buttons.cancel")}
+            </Button>
+          ) : null}
+          <Button type="submit" disabled={isPending} loading={isPending}>
+            {tPoi("create.submit")}
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+}

--- a/apps/web/src/features/pois/forms/poi-form-fields.tsx
+++ b/apps/web/src/features/pois/forms/poi-form-fields.tsx
@@ -1,0 +1,264 @@
+"use client";
+
+import { ImagePlusIcon } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useRef } from "react";
+import type { Control } from "react-hook-form";
+
+import {
+  POI_CATEGORY_VALUES,
+  POI_VISIBILITY_VALUES,
+  poiConstraints,
+  type PoiCategory,
+  type PoiVisibility,
+} from "../constants/pois.constants";
+import type { CreatePoiFormData } from "../schemas/pois.schema";
+
+import {
+  Button,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Textarea,
+} from "@/components/ui";
+
+type PoiFormFieldsProps = {
+  control: Control<CreatePoiFormData>;
+  disabled?: boolean;
+  photoFile: File | null;
+  onPhotoChange: (file: File | null) => void;
+};
+
+function parseOptionalNumber(value: string): number | undefined {
+  if (value === "") {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+/** Shared fields for custom POI create (and future edit) forms. */
+export function PoiFormFields({
+  control,
+  disabled = false,
+  photoFile,
+  onPhotoChange,
+}: PoiFormFieldsProps) {
+  const tPoi = useTranslations("poi");
+  const photoInputRef = useRef<HTMLInputElement>(null);
+
+  return (
+    <>
+      <FormField
+        control={control}
+        name="name"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel className="text-md lg:text-sm">{tPoi("fields.name")}</FormLabel>
+            <FormControl>
+              <Input
+                {...field}
+                disabled={disabled}
+                maxLength={poiConstraints.name.max}
+                autoComplete="off"
+                placeholder={tPoi("placeholders.name")}
+              />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <div className="grid grid-cols-2 gap-3">
+        <FormField
+          control={control}
+          name="latitude"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel className="text-md lg:text-sm">{tPoi("fields.latitude")}</FormLabel>
+              <FormControl>
+                <Input
+                  type="number"
+                  step="any"
+                  inputMode="decimal"
+                  disabled={disabled}
+                  value={field.value ?? ""}
+                  onChange={(event) => field.onChange(parseOptionalNumber(event.target.value))}
+                  onBlur={field.onBlur}
+                  name={field.name}
+                  ref={field.ref}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={control}
+          name="longitude"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel className="text-md lg:text-sm">{tPoi("fields.longitude")}</FormLabel>
+              <FormControl>
+                <Input
+                  type="number"
+                  step="any"
+                  inputMode="decimal"
+                  disabled={disabled}
+                  value={field.value ?? ""}
+                  onChange={(event) => field.onChange(parseOptionalNumber(event.target.value))}
+                  onBlur={field.onBlur}
+                  name={field.name}
+                  ref={field.ref}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      </div>
+
+      <FormField
+        control={control}
+        name="address"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel className="text-md lg:text-sm">{tPoi("fields.address")}</FormLabel>
+            <FormControl>
+              <Input
+                {...field}
+                value={field.value ?? ""}
+                disabled={disabled}
+                maxLength={poiConstraints.address.max}
+                autoComplete="street-address"
+                placeholder={tPoi("placeholders.address")}
+              />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={control}
+        name="category"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel className="text-md lg:text-sm">{tPoi("fields.category")}</FormLabel>
+            <Select
+              value={field.value}
+              onValueChange={(value) => field.onChange(value as PoiCategory)}
+              disabled={disabled}
+            >
+              <FormControl>
+                <SelectTrigger disabled={disabled}>
+                  <SelectValue placeholder={tPoi("fields.category")} />
+                </SelectTrigger>
+              </FormControl>
+              <SelectContent>
+                {POI_CATEGORY_VALUES.map((value) => (
+                  <SelectItem key={value} value={value}>
+                    {tPoi(`categories.${value}.label`)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={control}
+        name="description"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel className="text-md lg:text-sm">{tPoi("fields.description")}</FormLabel>
+            <FormControl>
+              <Textarea
+                {...field}
+                value={field.value ?? ""}
+                disabled={disabled}
+                rows={3}
+                maxLength={poiConstraints.description.max}
+                className="min-h-22 resize-y"
+                placeholder={tPoi("placeholders.description")}
+              />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={control}
+        name="visibility"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel className="text-md lg:text-sm">{tPoi("fields.visibility")}</FormLabel>
+            <Select
+              value={field.value}
+              onValueChange={(value) => field.onChange(value as PoiVisibility)}
+              disabled={disabled}
+            >
+              <FormControl>
+                <SelectTrigger disabled={disabled}>
+                  <SelectValue />
+                </SelectTrigger>
+              </FormControl>
+              <SelectContent>
+                {POI_VISIBILITY_VALUES.map((value) => (
+                  <SelectItem key={value} value={value}>
+                    {tPoi(`visibility.${value}.label`)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <div className="grid gap-2">
+        <p className="text-md font-medium lg:text-sm">{tPoi("photo.title")}</p>
+        <p className="text-sm text-muted-foreground">{tPoi("photo.formats")}</p>
+        <input
+          ref={photoInputRef}
+          type="file"
+          accept="image/jpeg, image/png, image/webp"
+          className="hidden"
+          disabled={disabled}
+          onChange={(event) => {
+            onPhotoChange(event.target.files?.[0] ?? null);
+            event.target.value = "";
+          }}
+        />
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={disabled}
+            onClick={() => photoInputRef.current?.click()}
+          >
+            <ImagePlusIcon className="size-4" />
+            {tPoi("photo.hint")}
+          </Button>
+          {photoFile ? (
+            <span className="text-sm text-muted-foreground">{photoFile.name}</span>
+          ) : null}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/features/pois/index.ts
+++ b/apps/web/src/features/pois/index.ts
@@ -1,11 +1,13 @@
 export { PoiCard } from "./components/poi-card";
 export { PoiPhoto } from "./components/poi-photo";
 export { PoiOpeningHours } from "./components/poi-opening-hours";
+export { CreatePoiDialog } from "./components/create-poi-dialog";
 
 export { useCreatePoi } from "./hooks/use-create-poi";
 export { useUploadPoiPhoto } from "./hooks/use-upload-poi-photo";
 export { usePoiFormSchema } from "./hooks/use-poi-form-schema";
 
+export { CreatePoiForm } from "./forms/create-poi-form";
 export { createPoiFormSchema } from "./schemas/pois.schema";
 export {
   poiConstraints,

--- a/apps/web/src/features/pois/schemas/pois.schema.test.ts
+++ b/apps/web/src/features/pois/schemas/pois.schema.test.ts
@@ -73,6 +73,28 @@ describe("createPoiFormSchema", () => {
     }
   });
 
+  it("rejects missing latitude with invalid message", () => {
+    const result = schema().safeParse({
+      name: validInput.name,
+      longitude: validInput.longitude,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe(messages.latitudeInvalid);
+    }
+  });
+
+  it("rejects missing longitude with invalid message", () => {
+    const result = schema().safeParse({
+      name: validInput.name,
+      latitude: validInput.latitude,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe(messages.longitudeInvalid);
+    }
+  });
+
   it("rejects latitude below min", () => {
     const result = schema().safeParse({
       ...validInput,

--- a/apps/web/src/features/pois/schemas/pois.schema.ts
+++ b/apps/web/src/features/pois/schemas/pois.schema.ts
@@ -28,11 +28,11 @@ export function createPoiFormSchema(messages: CreatePoiFormMessages) {
       .min(name.min, { message: messages.requiredName })
       .max(name.max, { message: messages.nameTooLong }),
     latitude: z
-      .number()
+      .number(messages.latitudeInvalid)
       .min(latitude.min, { message: messages.latitudeInvalid })
       .max(latitude.max, { message: messages.latitudeInvalid }),
     longitude: z
-      .number()
+      .number(messages.longitudeInvalid)
       .min(longitude.min, { message: messages.longitudeInvalid })
       .max(longitude.max, { message: messages.longitudeInvalid }),
     description: z

--- a/apps/web/src/features/pois/utils/poi-form.utils.test.ts
+++ b/apps/web/src/features/pois/utils/poi-form.utils.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { poiFormValuesToBody } from "./poi-form.utils";
+
+describe("poiFormValuesToBody", () => {
+  it("trims empty optional strings to undefined", () => {
+    expect(
+      poiFormValuesToBody({
+        name: "Secret spot",
+        latitude: 48.8566,
+        longitude: 2.3522,
+        description: "   ",
+        address: "",
+        visibility: "PRIVATE",
+      })
+    ).toEqual({
+      name: "Secret spot",
+      latitude: 48.8566,
+      longitude: 2.3522,
+      description: undefined,
+      address: undefined,
+      visibility: "PRIVATE",
+      category: undefined,
+    });
+  });
+
+  it("keeps optional fields when provided", () => {
+    expect(
+      poiFormValuesToBody({
+        name: "Secret spot",
+        latitude: 48.8566,
+        longitude: 2.3522,
+        description: "A quiet corner",
+        address: "1 rue de Rivoli",
+        visibility: "SHARED",
+        category: "park",
+      })
+    ).toEqual({
+      name: "Secret spot",
+      latitude: 48.8566,
+      longitude: 2.3522,
+      description: "A quiet corner",
+      address: "1 rue de Rivoli",
+      visibility: "SHARED",
+      category: "park",
+    });
+  });
+});

--- a/apps/web/src/features/pois/utils/poi-form.utils.ts
+++ b/apps/web/src/features/pois/utils/poi-form.utils.ts
@@ -1,0 +1,16 @@
+import type { CreatePoiFormData } from "../schemas/pois.schema";
+
+import type { CreatePoiData } from "@/lib/api";
+
+/** Request body for `POST /poi` from the create form values. */
+export function poiFormValuesToBody(values: CreatePoiFormData): CreatePoiData["body"] {
+  return {
+    name: values.name,
+    latitude: values.latitude,
+    longitude: values.longitude,
+    description: values.description?.trim() || undefined,
+    address: values.address?.trim() || undefined,
+    visibility: values.visibility,
+    category: values.category,
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Description

Third child of NIR-69: create form for custom POIs ([NIR-81](https://linear.app/nirbyfr/issue/NIR-81/add-custom-poi-create-form)).

Users with EDITOR+ on a list can open a responsive dialog/drawer and create a custom place (name, coordinates, address, category, description, visibility, optional photo). Photo is uploaded first, then its URL is passed to `createPoi`. The place is **not** added to the list yet (NIR-82).

## 🎯 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] ✅ Test update

## 🔗 Related Issues

Related to #158
Related to #146

## 🚀 Changes Made

- `CreatePoiForm` + `PoiFormFields` (MVP fields, numeric lat/lng, optional photo)
- `CreatePoiDialog`: Dialog desktop / Drawer mobile
- EDITOR+ entry point on list detail (empty-state CTA + header button when the list already has places)
- Upload photo then `createPoi({ photoUrls })`
- Tests: required fields, submit, photo flow, API error, CTA visibility

## 🧪 Testing

- [ ] Tested locally with `pnpm dev`
- [x] All quality checks pass (`pnpm lint`)
- [x] Unit tests pass (`pnpm test`) — 65 files / 357 tests
- [ ] Database migrations applied if needed

## 📸 Screenshots/Videos

N/A

## ✅ Checklist

- [x] Code follows project style guidelines
- [ ] Documentation updated if needed
- [x] No console errors or warnings
- [x] Removed any debug code

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffc2a-88d8-7f1a-9121-dcc6b7d75821?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffc2a-88d8-7f1a-9121-dcc6b7d75821&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

