### PR TITLE
feat(pois): add custom POI to a list

### DIFF
--- a/apps/web/src/features/lists/components/list-pois-section.test.tsx
+++ b/apps/web/src/features/lists/components/list-pois-section.test.tsx
@@ -28,8 +28,8 @@ vi.mock("../hooks/use-remove-poi-from-list", () => ({
 }));
 
 vi.mock("@/features/pois/components/create-poi-dialog", () => ({
-  CreatePoiDialog: ({ open }: { open: boolean }) =>
-    open ? <div data-testid="create-poi-dialog" /> : null,
+  CreatePoiDialog: ({ open, listId }: { open: boolean; listId?: string }) =>
+    open ? <div data-testid="create-poi-dialog" data-list-id={listId} /> : null,
 }));
 
 const customSavedPoi: SavedPoiListItem = {
@@ -122,12 +122,18 @@ describe("ListPoisSection", () => {
     expect(screen.queryByRole("button", { name: "create.title" })).not.toBeInTheDocument();
   });
 
-  it("shows empty-state create CTA for EDITOR", () => {
+  it("shows empty-state create CTA for EDITOR", async () => {
+    const user = userEvent.setup();
     mockListPoisInfiniteQuery();
 
     render(<ListPoisSection listId="list-1" role="EDITOR" />);
 
-    expect(screen.getByRole("button", { name: "create.title" })).toBeInTheDocument();
+    const createButton = screen.getByRole("button", { name: "create.title" });
+    expect(createButton).toBeInTheDocument();
+
+    await user.click(createButton);
+
+    expect(screen.getByTestId("create-poi-dialog")).toHaveAttribute("data-list-id", "list-1");
   });
 
   it("hides create CTA for VIEWER", () => {

--- a/apps/web/src/features/lists/components/list-pois-section.tsx
+++ b/apps/web/src/features/lists/components/list-pois-section.tsx
@@ -156,7 +156,9 @@ export function ListPoisSection({
         </>
       )}
 
-      {canEdit ? <CreatePoiDialog open={createOpen} onOpenChange={setCreateOpen} /> : null}
+      {canEdit ? (
+        <CreatePoiDialog listId={listId} open={createOpen} onOpenChange={setCreateOpen} />
+      ) : null}
     </section>
   );
 }

--- a/apps/web/src/features/lists/hooks/use-add-poi-to-list.test.tsx
+++ b/apps/web/src/features/lists/hooks/use-add-poi-to-list.test.tsx
@@ -56,6 +56,30 @@ describe("useAddPoiToList", () => {
     expect(resolved).toEqual(data);
   });
 
+  it("calls addPoiToList with poiId and returns data on success", async () => {
+    const input = {
+      listId: "list-1",
+      body: { poiId: "poi-1" },
+    };
+    const data = { savedPoi: { id: "saved-1", poiId: "poi-1" } };
+    vi.mocked(addPoiToList).mockResolvedValue(apiResponse({ data }));
+
+    const { result } = renderHook(() => useAddPoiToList(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    let resolved: unknown;
+    await act(async () => {
+      resolved = await result.current.mutateAsync(input);
+    });
+
+    expect(addPoiToList).toHaveBeenCalledWith({
+      path: { listId: "list-1" },
+      body: { poiId: "poi-1" },
+    });
+    expect(resolved).toEqual(data);
+  });
+
   it("invalidates POI, detail, and lists cache on success", async () => {
     const listId = "list-1";
     vi.mocked(addPoiToList).mockResolvedValue(

--- a/apps/web/src/features/pois/components/create-poi-dialog.tsx
+++ b/apps/web/src/features/pois/components/create-poi-dialog.tsx
@@ -22,6 +22,7 @@ export type CreatePoiDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onCreated?: (poiId: string) => void;
+  listId?: string;
 };
 
 /** Create custom POI: Dialog on desktop, Drawer on mobile. */
@@ -31,7 +32,7 @@ export function CreatePoiDialog(props: CreatePoiDialogProps) {
   return isMobile ? <CreatePoiDrawer {...props} /> : <CreatePoiDesktopDialog {...props} />;
 }
 
-function CreatePoiDesktopDialog({ open, onOpenChange, onCreated }: CreatePoiDialogProps) {
+function CreatePoiDesktopDialog({ open, onOpenChange, onCreated, listId }: CreatePoiDialogProps) {
   const tPoi = useTranslations("poi");
 
   return (
@@ -41,13 +42,17 @@ function CreatePoiDesktopDialog({ open, onOpenChange, onCreated }: CreatePoiDial
           <DialogTitle>{tPoi("create.title")}</DialogTitle>
           <DialogDescription className="sr-only">{tPoi("create.title")}</DialogDescription>
         </DialogHeader>
-        <CreatePoiForm closeDialog={() => onOpenChange(false)} onCreated={onCreated} />
+        <CreatePoiForm
+          listId={listId}
+          closeDialog={() => onOpenChange(false)}
+          onCreated={onCreated}
+        />
       </DialogContent>
     </Dialog>
   );
 }
 
-function CreatePoiDrawer({ open, onOpenChange, onCreated }: CreatePoiDialogProps) {
+function CreatePoiDrawer({ open, onOpenChange, onCreated, listId }: CreatePoiDialogProps) {
   const tPoi = useTranslations("poi");
 
   return (
@@ -58,7 +63,11 @@ function CreatePoiDrawer({ open, onOpenChange, onCreated }: CreatePoiDialogProps
           <DrawerDescription className="sr-only">{tPoi("create.title")}</DrawerDescription>
         </DrawerHeader>
         <div className="overflow-y-auto px-4 pb-4">
-          <CreatePoiForm closeDialog={() => onOpenChange(false)} onCreated={onCreated} />
+          <CreatePoiForm
+            listId={listId}
+            closeDialog={() => onOpenChange(false)}
+            onCreated={onCreated}
+          />
         </div>
       </DrawerContent>
     </Drawer>

--- a/apps/web/src/features/pois/forms/create-poi-form.test.tsx
+++ b/apps/web/src/features/pois/forms/create-poi-form.test.tsx
@@ -8,12 +8,18 @@ import { useUploadPoiPhoto } from "../hooks/use-upload-poi-photo";
 
 import { CreatePoiForm } from "./create-poi-form";
 
+import { useAddPoiToList } from "@/features/lists/hooks/use-add-poi-to-list";
+
 vi.mock("../hooks/use-create-poi", () => ({
   useCreatePoi: vi.fn(),
 }));
 
 vi.mock("../hooks/use-upload-poi-photo", () => ({
   useUploadPoiPhoto: vi.fn(),
+}));
+
+vi.mock("@/features/lists/hooks/use-add-poi-to-list", () => ({
+  useAddPoiToList: vi.fn(),
 }));
 
 vi.mock("@/hooks/use-error-message", () => ({
@@ -31,11 +37,13 @@ describe("CreatePoiForm", () => {
   const closeDialog = vi.fn();
   const createPoi = vi.fn();
   const uploadPoiPhoto = vi.fn();
+  const addPoiToList = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
     createPoi.mockResolvedValue({ poi: { id: "poi-1", name: "Secret spot" } });
     uploadPoiPhoto.mockResolvedValue({ url: "https://cdn.example.com/spot.webp" });
+    addPoiToList.mockResolvedValue({ savedPoi: { id: "saved-1", poiId: "poi-1" } });
     vi.mocked(useCreatePoi).mockReturnValue({
       mutateAsync: createPoi,
       isPending: false,
@@ -44,6 +52,10 @@ describe("CreatePoiForm", () => {
       mutateAsync: uploadPoiPhoto,
       isPending: false,
     } as unknown as ReturnType<typeof useUploadPoiPhoto>);
+    vi.mocked(useAddPoiToList).mockReturnValue({
+      mutateAsync: addPoiToList,
+      isPending: false,
+    } as unknown as ReturnType<typeof useAddPoiToList>);
   });
 
   it("shows validation messages for required fields", async () => {
@@ -82,6 +94,7 @@ describe("CreatePoiForm", () => {
     });
 
     expect(uploadPoiPhoto).not.toHaveBeenCalled();
+    expect(addPoiToList).not.toHaveBeenCalled();
     expect(toast.success).toHaveBeenCalledWith("createPoi.success");
     expect(closeDialog).toHaveBeenCalledTimes(1);
   });
@@ -139,5 +152,52 @@ describe("CreatePoiForm", () => {
     });
 
     expect(closeDialog).not.toHaveBeenCalled();
+  });
+
+  it("adds the created POI to the list when listId is provided", async () => {
+    const user = userEvent.setup();
+
+    render(<CreatePoiForm listId="list-1" closeDialog={closeDialog} />);
+
+    await user.type(screen.getByLabelText("fields.name"), "Secret spot");
+    await user.type(screen.getByLabelText("fields.latitude"), "48.8566");
+    await user.type(screen.getByLabelText("fields.longitude"), "2.3522");
+    await user.click(screen.getByRole("button", { name: "create.submit" }));
+
+    await waitFor(() => {
+      expect(createPoi).toHaveBeenCalled();
+      expect(addPoiToList).toHaveBeenCalledWith({
+        listId: "list-1",
+        body: { poiId: "poi-1" },
+      });
+    });
+
+    expect(createPoi.mock.invocationCallOrder[0]).toBeLessThan(
+      addPoiToList.mock.invocationCallOrder[0]
+    );
+    expect(toast.success).toHaveBeenCalledWith("addPoi.success");
+    expect(closeDialog).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows an error toast when addPoiToList fails after create", async () => {
+    const user = userEvent.setup();
+    addPoiToList.mockRejectedValue({ message: "Forbidden" });
+
+    render(<CreatePoiForm listId="list-1" closeDialog={closeDialog} />);
+
+    await user.type(screen.getByLabelText("fields.name"), "Secret spot");
+    await user.type(screen.getByLabelText("fields.latitude"), "48.8566");
+    await user.type(screen.getByLabelText("fields.longitude"), "2.3522");
+    await user.click(screen.getByRole("button", { name: "create.submit" }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("addPoi.error", {
+        description: "API error message",
+      });
+    });
+
+    expect(createPoi).toHaveBeenCalled();
+    expect(closeDialog).not.toHaveBeenCalled();
+    expect(toast.success).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/features/pois/forms/create-poi-form.tsx
+++ b/apps/web/src/features/pois/forms/create-poi-form.tsx
@@ -16,6 +16,7 @@ import { poiFormValuesToBody } from "../utils/poi-form.utils";
 import { PoiFormFields } from "./poi-form-fields";
 
 import { Button, Form } from "@/components/ui";
+import { useAddPoiToList } from "@/features/lists/hooks/use-add-poi-to-list";
 import { poiPhotoFileSchema } from "@/features/upload";
 import { useErrorMessage } from "@/hooks/use-error-message";
 import { cn } from "@/lib/utils";
@@ -23,14 +24,18 @@ import { cn } from "@/lib/utils";
 export type CreatePoiFormProps = {
   closeDialog?: () => void;
   onCreated?: (poiId: string) => void;
+  /** When set, the created POI is added to this list after create. */
+  listId?: string;
 };
 
-export function CreatePoiForm({ closeDialog, onCreated }: CreatePoiFormProps) {
+export function CreatePoiForm({ closeDialog, onCreated, listId }: CreatePoiFormProps) {
   const tPoi = useTranslations("poi");
+  const tLists = useTranslations("lists");
   const t = useTranslations();
   const getErrorMessage = useErrorMessage();
   const { mutateAsync: createPoi, isPending: isCreating } = useCreatePoi();
   const { mutateAsync: uploadPoiPhoto, isPending: isUploading } = useUploadPoiPhoto();
+  const { mutateAsync: addPoiToList, isPending: isAdding } = useAddPoiToList();
   const poiFormSchema = usePoiFormSchema();
   const [photoFile, setPhotoFile] = useState<File | null>(null);
 
@@ -47,7 +52,7 @@ export function CreatePoiForm({ closeDialog, onCreated }: CreatePoiFormProps) {
     },
   });
 
-  const isPending = isCreating || isUploading;
+  const isPending = isCreating || isUploading || isAdding;
 
   async function onSubmit(values: CreatePoiFormData) {
     try {
@@ -78,7 +83,21 @@ export function CreatePoiForm({ closeDialog, onCreated }: CreatePoiFormProps) {
         ...(photoUrls ? { photoUrls } : {}),
       });
 
-      toast.success(tPoi("createPoi.success"));
+      if (listId && poi.id) {
+        try {
+          await addPoiToList({ listId, body: { poiId: poi.id } });
+        } catch (error) {
+          toast.error(tLists("addPoi.error"), {
+            description: getErrorMessage(error),
+          });
+          return;
+        }
+
+        toast.success(tLists("addPoi.success"));
+      } else {
+        toast.success(tPoi("createPoi.success"));
+      }
+
       form.reset();
       setPhotoFile(null);
       closeDialog?.();

--- a/apps/web/src/lib/i18n/locales-parity.test.tsx
+++ b/apps/web/src/lib/i18n/locales-parity.test.tsx
@@ -45,6 +45,8 @@ const NEW_LISTS_KEYS = [
   "pois.error.retry",
   "poi.source.custom",
   "removePoi.success",
+  "addPoi.success",
+  "addPoi.error",
   "share.action",
   "share.readLink.generate",
   "share.editLink.revokeConfirm",

--- a/apps/web/src/lib/i18n/locales/en/lists.json
+++ b/apps/web/src/lib/i18n/locales/en/lists.json
@@ -111,6 +111,10 @@
     "success": "Place removed from list",
     "error": "Could not remove the place"
   },
+  "addPoi": {
+    "success": "Place added to the list",
+    "error": "Could not add the place"
+  },
   "share": {
     "action": "Share",
     "title": "Share list",

--- a/apps/web/src/lib/i18n/locales/fr/lists.json
+++ b/apps/web/src/lib/i18n/locales/fr/lists.json
@@ -111,6 +111,10 @@
     "success": "Lieu retiré de la liste",
     "error": "Impossible de retirer le lieu"
   },
+  "addPoi": {
+    "success": "Lieu ajouté à la liste",
+    "error": "Impossible d’ajouter le lieu"
+  },
   "share": {
     "action": "Partager",
     "title": "Partager la liste",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Description

Last child of NIR-69: add a newly created custom POI to the current list ([NIR-82](https://linear.app/nirbyfr/issue/NIR-82/add-custom-poi-to-a-list)).

From list detail, after `createPoi` succeeds, the form calls `useAddPoiToList({ listId, body: { poiId } })`. There is no list picker — the only entry is list detail. The user stays on the list; cache invalidation is already handled by the hook.

If add-to-list fails after create, the dialog stays open and we show `lists.addPoi.error` (the POI still exists).

## 🎯 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] ✅ Test update

## 🔗 Related Issues

Related to #159
Related to #146

## 🚀 Changes Made

- Thread `listId` from `ListPoisSection` → `CreatePoiDialog` → `CreatePoiForm`
- After create, add the POI to the list when `listId` is set
- Success toast `lists.addPoi.success`; add failure keeps the dialog open
- `useAddPoiToList` imported from the hook file to avoid a circular import via the lists barrel
- en/fr `lists.addPoi` keys + locale parity
- Tests: hook `poiId` payload, create-then-add flow, add failure, `listId` on the empty-state dialog

## 🧪 Testing

- [ ] Tested locally with `pnpm dev`
- [x] All quality checks pass (`pnpm lint`)
- [x] Unit tests pass (`pnpm test`) — 65 files / 360 tests
- [ ] Database migrations applied if needed

## 📸 Screenshots/Videos

N/A

## ✅ Checklist

- [x] Code follows project style guidelines
- [ ] Documentation updated if needed
- [x] No console errors or warnings
- [x] Removed any debug code

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffc2a-88d8-7f1a-9121-dcc6b7d75821?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffc2a-88d8-7f1a-9121-dcc6b7d75821&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

