### PR TITLE
feat(pois): edit custom POI from a list

### DIFF
--- a/apps/api/__test__/poi/routes.test.ts
+++ b/apps/api/__test__/poi/routes.test.ts
@@ -223,6 +223,50 @@ describe("POI Routes", () => {
       expect(res.body.poi.name).toBe("Updated POI");
     });
 
+    it("should keep existing photoUrls when they are omitted", async () => {
+      const poi = await prisma.poi.create({
+        data: {
+          name: "Test POI",
+          latitude: 40.7128,
+          longitude: -74.006,
+          createdBy: userId,
+          photoUrls: ["https://cdn.example.com/existing.jpg"],
+        },
+      });
+
+      const res = await request(app)
+        .put(`/poi/${poi.id}`)
+        .set("Authorization", `Bearer ${accessToken}`)
+        .send({
+          name: "Updated POI",
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.poi.photoUrls).toEqual(["https://cdn.example.com/existing.jpg"]);
+    });
+
+    it("should replace photoUrls when they are provided", async () => {
+      const poi = await prisma.poi.create({
+        data: {
+          name: "Test POI",
+          latitude: 40.7128,
+          longitude: -74.006,
+          createdBy: userId,
+          photoUrls: ["https://cdn.example.com/existing.jpg"],
+        },
+      });
+
+      const res = await request(app)
+        .put(`/poi/${poi.id}`)
+        .set("Authorization", `Bearer ${accessToken}`)
+        .send({
+          photoUrls: ["https://cdn.example.com/new.jpg"],
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.poi.photoUrls).toEqual(["https://cdn.example.com/new.jpg"]);
+    });
+
     it("should deny update to another user's POI", async () => {
       const otherUser = await prisma.user.create({
         data: {

--- a/apps/api/src/poi/routes.ts
+++ b/apps/api/src/poi/routes.ts
@@ -24,6 +24,15 @@ const openingHoursPeriodSchema = z.object({
   }),
 });
 
+/** Omitted `photoUrls` stays undefined so PUT does not wipe existing photos. */
+const photoUrlsSchema = z
+  .array(z.string())
+  .optional()
+  .transform((arr) => (arr === undefined ? undefined : arr.filter((url) => url !== "")))
+  .refine((arr) => arr === undefined || arr.every((url) => /^https?:\/\/.+/.test(url)), {
+    message: "Invalid url",
+  });
+
 const createPoiSchema = z.object({
   name: z
     .string({ required_error: ErrorCodes.POI_NAME_REQUIRED })
@@ -54,11 +63,7 @@ const createPoiSchema = z.object({
     .transform((val) => (val === "" ? undefined : val)),
   priceLevel: z.number().min(0).max(4).optional(),
   openingHours: z.array(openingHoursPeriodSchema).optional(),
-  photoUrls: z
-    .array(z.string())
-    .optional()
-    .transform((arr) => arr?.filter((url) => url !== "") ?? [])
-    .refine((arr) => arr.every((url) => /^https?:\/\/.+/.test(url)), { message: "Invalid url" }),
+  photoUrls: photoUrlsSchema,
 });
 
 const updatePoiSchema = z.object({
@@ -94,11 +99,7 @@ const updatePoiSchema = z.object({
     .transform((val) => (val === "" ? undefined : val)),
   priceLevel: z.number().min(0).max(4).optional(),
   openingHours: z.array(openingHoursPeriodSchema).optional(),
-  photoUrls: z
-    .array(z.string())
-    .optional()
-    .transform((arr) => arr?.filter((url) => url !== "") ?? [])
-    .refine((arr) => arr.every((url) => /^https?:\/\/.+/.test(url)), { message: "Invalid url" }),
+  photoUrls: photoUrlsSchema,
 });
 
 const nearbyPoiSchema = z.object({

--- a/apps/web/src/features/lists/components/list-poi-row.test.tsx
+++ b/apps/web/src/features/lists/components/list-poi-row.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ListPoiRow } from "./list-poi-row";
+
+import type { SavedPoiListItem } from "@/features/pois";
+
+const useAuth = vi.fn();
+
+vi.mock("@/features/auth/hooks", () => ({
+  useAuth: () => useAuth(),
+}));
+
+vi.mock("@/features/pois/components/edit-poi-dialog", () => ({
+  EditPoiDialog: ({ open, poi }: { open: boolean; poi: { id: string } }) =>
+    open ? <div data-testid="edit-poi-dialog" data-poi-id={poi.id} /> : null,
+}));
+
+vi.mock("./remove-poi-dialog", () => ({
+  RemovePoiDialog: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="remove-poi-dialog" /> : null,
+}));
+
+const customSavedPoi: SavedPoiListItem = {
+  id: "sp-1",
+  listId: "list-1",
+  poiId: "poi-1",
+  googlePlaceId: null,
+  createdAt: "2024-01-01T00:00:00.000Z",
+  poi: {
+    id: "poi-1",
+    name: "Fraktion",
+    address: "16 rue de la Grange Batelière, Paris",
+    category: "park",
+    latitude: 48.87324153744834,
+    longitude: 2.3412600502008014,
+    createdBy: "user-1",
+    photoUrls: [],
+  },
+};
+
+const googleSavedPoi: SavedPoiListItem = {
+  id: "sp-2",
+  listId: "list-1",
+  poiId: null,
+  googlePlaceId: "ChIJxYJUC2lv5kcRlhdpWba_aGU",
+  createdAt: "2024-01-02T00:00:00.000Z",
+  poi: undefined,
+  googlePlaceCache: {
+    placeId: "ChIJxYJUC2lv5kcRlhdpWba_aGU",
+    name: "Le Tout-Paris",
+    address: "8 Quai du Louvre, Paris",
+    categoryDisplayName: "French Restaurant",
+    latitude: 48.8587493,
+    longitude: 2.3422529,
+    photoReferences: [],
+  },
+};
+
+describe("ListPoiRow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAuth.mockReturnValue({ user: { id: "user-1" } });
+  });
+
+  it("shows the edit button for a custom POI created by the user", async () => {
+    const user = userEvent.setup();
+
+    render(<ListPoiRow savedPoi={customSavedPoi} listId="list-1" canRemove />);
+
+    const editButton = screen.getByRole("button", { name: "edit.action" });
+    expect(editButton).toBeInTheDocument();
+
+    await user.click(editButton);
+
+    expect(screen.getByTestId("edit-poi-dialog")).toHaveAttribute("data-poi-id", "poi-1");
+  });
+
+  it("hides the edit button when the user did not create the POI", () => {
+    useAuth.mockReturnValue({ user: { id: "user-2" } });
+
+    render(<ListPoiRow savedPoi={customSavedPoi} listId="list-1" canRemove />);
+
+    expect(screen.queryByRole("button", { name: "edit.action" })).not.toBeInTheDocument();
+  });
+
+  it("hides the edit button for a Google Place", () => {
+    render(<ListPoiRow savedPoi={googleSavedPoi} listId="list-1" canRemove />);
+
+    expect(screen.queryByRole("button", { name: "edit.action" })).not.toBeInTheDocument();
+  });
+
+  it("shows the remove button when canRemove is true", () => {
+    render(<ListPoiRow savedPoi={customSavedPoi} listId="list-1" canRemove />);
+
+    expect(screen.getByRole("button", { name: "removePoi.action" })).toBeInTheDocument();
+  });
+
+  it("hides the remove button when canRemove is false but still shows edit for the creator", () => {
+    render(<ListPoiRow savedPoi={customSavedPoi} listId="list-1" canRemove={false} />);
+
+    expect(screen.getByRole("button", { name: "edit.action" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "removePoi.action" })).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/lists/components/list-poi-row.tsx
+++ b/apps/web/src/features/lists/components/list-poi-row.tsx
@@ -1,18 +1,21 @@
 "use client";
 
-import { Trash2Icon } from "lucide-react";
+import { PencilIcon, Trash2Icon } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
 
 import { RemovePoiDialog } from "./remove-poi-dialog";
 
 import { Button } from "@/components/ui";
+import { useAuth } from "@/features/auth/hooks";
 import {
   PoiCard,
   getPoiDisplayDataFromSavedPoi,
   getSavedPoiMapId,
   type SavedPoiListItem,
 } from "@/features/pois";
+import { EditPoiDialog } from "@/features/pois/components/edit-poi-dialog";
+import { canEditSavedPoi } from "@/features/pois/utils/can-edit-saved-poi";
 
 type ListPoiRowProps = {
   savedPoi: SavedPoiListItem;
@@ -24,7 +27,10 @@ type ListPoiRowProps = {
 
 export function ListPoiRow({ savedPoi, listId, canRemove, isSelected, onSelect }: ListPoiRowProps) {
   const tLists = useTranslations("lists");
+  const tPoi = useTranslations("poi");
+  const { user } = useAuth();
   const [removeDialogOpen, setRemoveDialogOpen] = useState(false);
+  const [editDialogOpen, setEditDialogOpen] = useState(false);
   const display = getPoiDisplayDataFromSavedPoi(savedPoi);
 
   if (!display) {
@@ -32,7 +38,9 @@ export function ListPoiRow({ savedPoi, listId, canRemove, isSelected, onSelect }
   }
 
   const showRemoveAction = canRemove && Boolean(savedPoi.id);
+  const showEditAction = canEditSavedPoi(savedPoi, user?.id);
   const mapId = getSavedPoiMapId(savedPoi);
+  const editablePoi = savedPoi.poi?.id ? { ...savedPoi.poi, id: savedPoi.poi.id } : null;
 
   return (
     <>
@@ -41,20 +49,44 @@ export function ListPoiRow({ savedPoi, listId, canRemove, isSelected, onSelect }
         isSelected={isSelected}
         onSelect={mapId && onSelect ? () => onSelect(mapId) : undefined}
         actions={
-          showRemoveAction ? (
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-sm"
-              className="text-muted-foreground/70 hover:bg-destructive/10 hover:text-destructive"
-              aria-label={tLists("removePoi.action")}
-              onClick={() => setRemoveDialogOpen(true)}
-            >
-              <Trash2Icon className="size-3.5" />
-            </Button>
+          showEditAction || showRemoveAction ? (
+            <div className="flex items-center">
+              {showEditAction ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  className="text-muted-foreground/70"
+                  aria-label={tPoi("edit.action")}
+                  onClick={() => setEditDialogOpen(true)}
+                >
+                  <PencilIcon className="size-3.5" />
+                </Button>
+              ) : null}
+              {showRemoveAction ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  className="text-muted-foreground/70 hover:bg-destructive/10 hover:text-destructive"
+                  aria-label={tLists("removePoi.action")}
+                  onClick={() => setRemoveDialogOpen(true)}
+                >
+                  <Trash2Icon className="size-3.5" />
+                </Button>
+              ) : null}
+            </div>
           ) : undefined
         }
       />
+      {showEditAction && editablePoi ? (
+        <EditPoiDialog
+          poi={editablePoi}
+          listId={listId}
+          open={editDialogOpen}
+          onOpenChange={setEditDialogOpen}
+        />
+      ) : null}
       {showRemoveAction && savedPoi.id ? (
         <RemovePoiDialog
           listId={listId}

--- a/apps/web/src/features/lists/components/list-pois-section.test.tsx
+++ b/apps/web/src/features/lists/components/list-pois-section.test.tsx
@@ -27,6 +27,10 @@ vi.mock("../hooks/use-remove-poi-from-list", () => ({
   }),
 }));
 
+vi.mock("@/features/auth/hooks", () => ({
+  useAuth: () => ({ user: { id: "user-1" } }),
+}));
+
 const customSavedPoi: SavedPoiListItem = {
   id: "sp-1",
   listId: "list-1",

--- a/apps/web/src/features/pois/components/edit-poi-dialog.tsx
+++ b/apps/web/src/features/pois/components/edit-poi-dialog.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+
+import { EditPoiForm } from "../forms/edit-poi-form";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui";
+import { useMediaQuery } from "@/hooks/use-media-query";
+import type { Poi } from "@/lib/api";
+
+export type EditPoiDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  poi: Poi & { id: string };
+  listId?: string;
+};
+
+/** Edit custom POI: Dialog on desktop, Drawer on mobile. */
+export function EditPoiDialog(props: EditPoiDialogProps) {
+  const isMobile = useMediaQuery("(max-width: 768px)");
+
+  return isMobile ? <EditPoiDrawer {...props} /> : <EditPoiDesktopDialog {...props} />;
+}
+
+function EditPoiDesktopDialog({ open, onOpenChange, poi, listId }: EditPoiDialogProps) {
+  const tPoi = useTranslations("poi");
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[85vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{tPoi("edit.title")}</DialogTitle>
+          <DialogDescription className="sr-only">{tPoi("edit.title")}</DialogDescription>
+        </DialogHeader>
+        <EditPoiForm poi={poi} listId={listId} closeDialog={() => onOpenChange(false)} />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function EditPoiDrawer({ open, onOpenChange, poi, listId }: EditPoiDialogProps) {
+  const tPoi = useTranslations("poi");
+
+  return (
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <DrawerContent>
+        <DrawerHeader>
+          <DrawerTitle>{tPoi("edit.title")}</DrawerTitle>
+          <DrawerDescription className="sr-only">{tPoi("edit.title")}</DrawerDescription>
+        </DrawerHeader>
+        <div className="overflow-y-auto px-4 pb-4">
+          <EditPoiForm poi={poi} listId={listId} closeDialog={() => onOpenChange(false)} />
+        </div>
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/apps/web/src/features/pois/forms/edit-poi-form.test.tsx
+++ b/apps/web/src/features/pois/forms/edit-poi-form.test.tsx
@@ -1,0 +1,147 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { toast } from "sonner";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useUpdatePoi } from "../hooks/use-update-poi";
+import { useUploadPoiPhoto } from "../hooks/use-upload-poi-photo";
+
+import { EditPoiForm } from "./edit-poi-form";
+
+import type { Poi } from "@/lib/api";
+
+vi.mock("../hooks/use-update-poi", () => ({
+  useUpdatePoi: vi.fn(),
+}));
+
+vi.mock("../hooks/use-upload-poi-photo", () => ({
+  useUploadPoiPhoto: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-error-message", () => ({
+  useErrorMessage: () => () => "API error message",
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const poi: Poi & { id: string } = {
+  id: "poi-1",
+  name: "Secret spot",
+  description: "A quiet garden",
+  address: "12 rue Example",
+  latitude: 48.8566,
+  longitude: 2.3522,
+  visibility: "PRIVATE",
+  category: "park",
+  createdBy: "user-1",
+  photoUrls: [],
+};
+
+describe("EditPoiForm", () => {
+  const closeDialog = vi.fn();
+  const updatePoi = vi.fn();
+  const uploadPoiPhoto = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    updatePoi.mockResolvedValue({ poi: { ...poi, name: "Updated spot" } });
+    uploadPoiPhoto.mockResolvedValue({ url: "https://cdn.example.com/spot.webp" });
+    vi.mocked(useUpdatePoi).mockReturnValue({
+      mutateAsync: updatePoi,
+      isPending: false,
+    } as unknown as ReturnType<typeof useUpdatePoi>);
+    vi.mocked(useUploadPoiPhoto).mockReturnValue({
+      mutateAsync: uploadPoiPhoto,
+      isPending: false,
+    } as unknown as ReturnType<typeof useUploadPoiPhoto>);
+  });
+
+  it("prefills fields and hides lat/lng inputs", () => {
+    render(<EditPoiForm poi={poi} listId="list-1" closeDialog={closeDialog} />);
+
+    expect(screen.getByLabelText("fields.name")).toHaveValue("Secret spot");
+    expect(screen.getByLabelText("fields.description")).toHaveValue("A quiet garden");
+    expect(screen.getByLabelText("fields.address")).toHaveValue("12 rue Example");
+    expect(screen.queryByLabelText("fields.latitude")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("fields.longitude")).not.toBeInTheDocument();
+  });
+
+  it("submits updatePoi with existing coordinates and no photo", async () => {
+    const user = userEvent.setup();
+
+    render(<EditPoiForm poi={poi} listId="list-1" closeDialog={closeDialog} />);
+
+    await user.clear(screen.getByLabelText("fields.name"));
+    await user.type(screen.getByLabelText("fields.name"), "Updated spot");
+    await user.click(screen.getByRole("button", { name: "edit.submit" }));
+
+    await waitFor(() => {
+      expect(updatePoi).toHaveBeenCalledWith({
+        poiId: "poi-1",
+        listId: "list-1",
+        body: {
+          name: "Updated spot",
+          latitude: 48.8566,
+          longitude: 2.3522,
+          description: "A quiet garden",
+          address: "12 rue Example",
+          visibility: "PRIVATE",
+          category: "park",
+        },
+      });
+    });
+
+    expect(uploadPoiPhoto).not.toHaveBeenCalled();
+    expect(toast.success).toHaveBeenCalledWith("updatePoi.success");
+    expect(closeDialog).toHaveBeenCalledTimes(1);
+  });
+
+  it("uploads a photo then updates the POI with photoUrls", async () => {
+    const user = userEvent.setup();
+    const file = new File(["photo"], "spot.webp", { type: "image/webp" });
+
+    render(<EditPoiForm poi={poi} listId="list-1" closeDialog={closeDialog} />);
+
+    const photoInput = document.querySelector('input[type="file"]');
+    expect(photoInput).toBeInstanceOf(HTMLInputElement);
+    await user.upload(photoInput as HTMLInputElement, file);
+    await user.click(screen.getByRole("button", { name: "edit.submit" }));
+
+    await waitFor(() => {
+      expect(uploadPoiPhoto).toHaveBeenCalledWith({ file });
+      expect(updatePoi).toHaveBeenCalledWith({
+        poiId: "poi-1",
+        listId: "list-1",
+        body: expect.objectContaining({
+          photoUrls: ["https://cdn.example.com/spot.webp"],
+        }),
+      });
+    });
+
+    expect(uploadPoiPhoto.mock.invocationCallOrder[0]).toBeLessThan(
+      updatePoi.mock.invocationCallOrder[0]
+    );
+  });
+
+  it("shows an error toast when updatePoi fails", async () => {
+    const user = userEvent.setup();
+    updatePoi.mockRejectedValue({ message: "Forbidden" });
+
+    render(<EditPoiForm poi={poi} listId="list-1" closeDialog={closeDialog} />);
+
+    await user.click(screen.getByRole("button", { name: "edit.submit" }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("updatePoi.error", {
+        description: "API error message",
+      });
+    });
+
+    expect(closeDialog).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/features/pois/forms/edit-poi-form.test.tsx
+++ b/apps/web/src/features/pois/forms/edit-poi-form.test.tsx
@@ -18,6 +18,10 @@ vi.mock("../hooks/use-upload-poi-photo", () => ({
   useUploadPoiPhoto: vi.fn(),
 }));
 
+vi.mock("../components/poi-photo", () => ({
+  PoiPhoto: ({ alt }: { alt: string }) => <div data-testid="existing-poi-photo">{alt}</div>,
+}));
+
 vi.mock("@/hooks/use-error-message", () => ({
   useErrorMessage: () => () => "API error message",
 }));
@@ -69,6 +73,31 @@ describe("EditPoiForm", () => {
     expect(screen.getByLabelText("fields.address")).toHaveValue("12 rue Example");
     expect(screen.queryByLabelText("fields.latitude")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("fields.longitude")).not.toBeInTheDocument();
+  });
+
+  it("shows the existing photo and omits photoUrls when none is added", async () => {
+    const user = userEvent.setup();
+    const poiWithPhoto = {
+      ...poi,
+      photoUrls: ["https://cdn.example.com/existing.jpg"],
+    };
+
+    render(<EditPoiForm poi={poiWithPhoto} listId="list-1" closeDialog={closeDialog} />);
+
+    expect(screen.getByTestId("existing-poi-photo")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "photo.replaceHint" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "edit.submit" }));
+
+    await waitFor(() => {
+      expect(updatePoi).toHaveBeenCalledWith({
+        poiId: "poi-1",
+        listId: "list-1",
+        body: expect.not.objectContaining({ photoUrls: expect.anything() }),
+      });
+    });
+
+    expect(uploadPoiPhoto).not.toHaveBeenCalled();
   });
 
   it("submits updatePoi with existing coordinates and no photo", async () => {

--- a/apps/web/src/features/pois/forms/edit-poi-form.tsx
+++ b/apps/web/src/features/pois/forms/edit-poi-form.tsx
@@ -111,6 +111,7 @@ export function EditPoiForm({ poi, listId, closeDialog }: EditPoiFormProps) {
           disabled={isPending}
           photoFile={photoFile}
           onPhotoChange={setPhotoFile}
+          existingPhotoUrl={poi.photoUrls?.[0]}
         />
 
         <div className={cn("mt-2 flex flex-col gap-2 md:flex-row md:justify-end")}>

--- a/apps/web/src/features/pois/forms/edit-poi-form.tsx
+++ b/apps/web/src/features/pois/forms/edit-poi-form.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { standardSchemaResolver } from "@hookform/resolvers/standard-schema";
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+
+import {
+  DEFAULT_POI_VISIBILITY,
+  POI_CATEGORY_VALUES,
+  type PoiCategory,
+  type PoiVisibility,
+} from "../constants/pois.constants";
+import { usePoiFormSchema } from "../hooks/use-poi-form-schema";
+import { useUpdatePoi } from "../hooks/use-update-poi";
+import { useUploadPoiPhoto } from "../hooks/use-upload-poi-photo";
+import type { CreatePoiFormData } from "../schemas/pois.schema";
+import { poiFormValuesToBody } from "../utils/poi-form.utils";
+
+import { PoiFormFields } from "./poi-form-fields";
+
+import { Button, Form } from "@/components/ui";
+import { poiPhotoFileSchema } from "@/features/upload";
+import { useErrorMessage } from "@/hooks/use-error-message";
+import type { Poi } from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+export type EditPoiFormProps = {
+  poi: Poi & { id: string };
+  listId?: string;
+  closeDialog?: () => void;
+};
+
+function toPoiCategory(value: string | null | undefined): PoiCategory | undefined {
+  return POI_CATEGORY_VALUES.includes(value as PoiCategory) ? (value as PoiCategory) : undefined;
+}
+
+export function EditPoiForm({ poi, listId, closeDialog }: EditPoiFormProps) {
+  const tPoi = useTranslations("poi");
+  const t = useTranslations();
+  const getErrorMessage = useErrorMessage();
+  const { mutateAsync: updatePoi, isPending: isUpdating } = useUpdatePoi();
+  const { mutateAsync: uploadPoiPhoto, isPending: isUploading } = useUploadPoiPhoto();
+  const poiFormSchema = usePoiFormSchema();
+  const [photoFile, setPhotoFile] = useState<File | null>(null);
+
+  const form = useForm<CreatePoiFormData>({
+    resolver: standardSchemaResolver(poiFormSchema),
+    defaultValues: {
+      name: poi.name ?? "",
+      description: poi.description ?? "",
+      address: poi.address ?? "",
+      latitude: poi.latitude,
+      longitude: poi.longitude,
+      visibility: (poi.visibility as PoiVisibility | undefined) ?? DEFAULT_POI_VISIBILITY,
+      category: toPoiCategory(poi.category),
+    },
+  });
+
+  const isPending = isUpdating || isUploading;
+
+  async function onSubmit(values: CreatePoiFormData) {
+    try {
+      let photoUrls: string[] | undefined;
+
+      if (photoFile) {
+        const parsedPhoto = poiPhotoFileSchema.safeParse(photoFile);
+        if (!parsedPhoto.success) {
+          toast.error(tPoi("photo.uploadError"), {
+            description: t(parsedPhoto.error.issues[0]?.message ?? "errors.default"),
+          });
+          return;
+        }
+
+        try {
+          const uploaded = await uploadPoiPhoto({ file: photoFile });
+          photoUrls = [uploaded.url];
+        } catch (error) {
+          toast.error(tPoi("photo.uploadError"), {
+            description: getErrorMessage(error),
+          });
+          return;
+        }
+      }
+
+      await updatePoi({
+        poiId: poi.id,
+        listId,
+        body: {
+          ...poiFormValuesToBody(values),
+          ...(photoUrls ? { photoUrls } : {}),
+        },
+      });
+
+      toast.success(tPoi("updatePoi.success"));
+      setPhotoFile(null);
+      closeDialog?.();
+    } catch (error) {
+      toast.error(tPoi("updatePoi.error"), {
+        description: getErrorMessage(error),
+      });
+    }
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="grid gap-4">
+        <PoiFormFields
+          control={form.control}
+          disabled={isPending}
+          photoFile={photoFile}
+          onPhotoChange={setPhotoFile}
+        />
+
+        <div className={cn("mt-2 flex flex-col gap-2 md:flex-row md:justify-end")}>
+          {closeDialog ? (
+            <Button variant="outline" type="button" onClick={closeDialog} disabled={isPending}>
+              {t("common.buttons.cancel")}
+            </Button>
+          ) : null}
+          <Button type="submit" disabled={isPending} loading={isPending}>
+            {tPoi("edit.submit")}
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+}

--- a/apps/web/src/features/pois/forms/poi-form-fields.tsx
+++ b/apps/web/src/features/pois/forms/poi-form-fields.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from "next-intl";
 import { useRef } from "react";
 import type { Control } from "react-hook-form";
 
+import { PoiPhoto } from "../components/poi-photo";
 import {
   POI_CATEGORY_VALUES,
   POI_VISIBILITY_VALUES,
@@ -46,16 +47,19 @@ type PoiFormFieldsProps = {
   disabled?: boolean;
   photoFile: File | null;
   onPhotoChange: (file: File | null) => void;
+  /** Current POI photo shown while editing, until a new file is picked. */
+  existingPhotoUrl?: string;
   /** When set, the user picks a destination list (no list is currently open). */
   listSelect?: PoiFormListSelect;
 };
 
-/** Shared fields for custom POI create (and future edit) forms. Lat/lng are map-picked, not shown. */
+/** Shared fields for custom POI create and edit forms. Lat/lng are map-picked, not shown. */
 export function PoiFormFields({
   control,
   disabled = false,
   photoFile,
   onPhotoChange,
+  existingPhotoUrl,
   listSelect,
 }: PoiFormFieldsProps) {
   const tPoi = useTranslations("poi");
@@ -202,6 +206,14 @@ export function PoiFormFields({
             event.target.value = "";
           }}
         />
+        {existingPhotoUrl && !photoFile ? (
+          <div className="relative size-20 overflow-hidden rounded-md">
+            <PoiPhoto
+              photo={{ kind: "url", url: existingPhotoUrl }}
+              alt={tPoi("photo.title")}
+            />
+          </div>
+        ) : null}
         <div className="flex flex-wrap items-center gap-2">
           <Button
             type="button"
@@ -211,7 +223,7 @@ export function PoiFormFields({
             onClick={() => photoInputRef.current?.click()}
           >
             <ImagePlusIcon className="size-4" />
-            {tPoi("photo.hint")}
+            {existingPhotoUrl ? tPoi("photo.replaceHint") : tPoi("photo.hint")}
           </Button>
           {photoFile ? (
             <span className="text-sm text-muted-foreground">{photoFile.name}</span>

--- a/apps/web/src/features/pois/hooks/use-update-poi.test.tsx
+++ b/apps/web/src/features/pois/hooks/use-update-poi.test.tsx
@@ -1,0 +1,133 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useUpdatePoi } from "./use-update-poi";
+
+import { updatePoi } from "@/lib/api";
+import { queryKeys } from "@/lib/api/query-keys";
+
+vi.mock("@/lib/api", () => ({
+  updatePoi: vi.fn(),
+}));
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+function apiResponse(value: { data?: unknown; error?: unknown }) {
+  return value as Awaited<ReturnType<typeof updatePoi>>;
+}
+
+describe("useUpdatePoi", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+  });
+
+  it("calls updatePoi and returns data on success", async () => {
+    const input = {
+      poiId: "poi-1",
+      listId: "list-1",
+      body: { name: "Updated spot" },
+    };
+    const data = { poi: { id: "poi-1", name: "Updated spot" } };
+    vi.mocked(updatePoi).mockResolvedValue(apiResponse({ data }));
+
+    const { result } = renderHook(() => useUpdatePoi(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    let resolved: unknown;
+    await act(async () => {
+      resolved = await result.current.mutateAsync(input);
+    });
+
+    expect(updatePoi).toHaveBeenCalledWith({
+      path: { id: "poi-1" },
+      body: { name: "Updated spot" },
+    });
+    expect(resolved).toEqual(data);
+  });
+
+  it("invalidates POI and list caches on success when listId is set", async () => {
+    vi.mocked(updatePoi).mockResolvedValue(
+      apiResponse({ data: { poi: { id: "poi-1", name: "Updated spot" } } })
+    );
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useUpdatePoi(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        poiId: "poi-1",
+        listId: "list-1",
+        body: { name: "Updated spot" },
+      });
+    });
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.pois.all });
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.pois.detail("poi-1") });
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: queryKeys.lists.pois.all("list-1"),
+      });
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: queryKeys.lists.detail("list-1"),
+      });
+    });
+  });
+
+  it("does not invalidate list caches when listId is omitted", async () => {
+    vi.mocked(updatePoi).mockResolvedValue(
+      apiResponse({ data: { poi: { id: "poi-1", name: "Updated spot" } } })
+    );
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useUpdatePoi(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        poiId: "poi-1",
+        body: { name: "Updated spot" },
+      });
+    });
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.pois.all });
+    });
+
+    expect(invalidateSpy).not.toHaveBeenCalledWith({
+      queryKey: queryKeys.lists.pois.all("list-1"),
+    });
+  });
+
+  it("throws API error when response has no data", async () => {
+    const apiError = { message: "Forbidden" };
+    vi.mocked(updatePoi).mockResolvedValue(apiResponse({ error: apiError }));
+
+    const { result } = renderHook(() => useUpdatePoi(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await expect(
+      act(async () => {
+        await result.current.mutateAsync({
+          poiId: "poi-1",
+          body: { name: "Updated spot" },
+        });
+      })
+    ).rejects.toEqual(apiError);
+  });
+});

--- a/apps/web/src/features/pois/hooks/use-update-poi.ts
+++ b/apps/web/src/features/pois/hooks/use-update-poi.ts
@@ -1,0 +1,45 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { updatePoi } from "@/lib/api";
+import type { UpdatePoiData } from "@/lib/api";
+import { queryKeys } from "@/lib/api/query-keys";
+
+/** Payload for `PUT /poi/:id`. */
+export type UpdatePoiInput = {
+  poiId: string;
+  listId?: string;
+  body: UpdatePoiData["body"];
+};
+
+/**
+ * Updates a custom POI owned by the authenticated user.
+ *
+ * On success, invalidates POI queries and, when `listId` is set, that list's POI queries.
+ * API errors are thrown so they can be handled with {@link useErrorMessage}.
+ */
+export function useUpdatePoi() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ poiId, body }: UpdatePoiInput) => {
+      const response = await updatePoi({ path: { id: poiId }, body });
+
+      if (response.data) {
+        return response.data;
+      }
+
+      throw response.error;
+    },
+    onSuccess: (_data, { poiId, listId }) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.pois.all });
+      queryClient.invalidateQueries({ queryKey: queryKeys.pois.detail(poiId) });
+
+      if (listId) {
+        queryClient.invalidateQueries({ queryKey: queryKeys.lists.pois.all(listId) });
+        queryClient.invalidateQueries({ queryKey: queryKeys.lists.detail(listId) });
+      }
+    },
+  });
+}

--- a/apps/web/src/features/pois/index.ts
+++ b/apps/web/src/features/pois/index.ts
@@ -2,12 +2,15 @@ export { PoiCard } from "./components/poi-card";
 export { PoiPhoto } from "./components/poi-photo";
 export { PoiOpeningHours } from "./components/poi-opening-hours";
 export { CreatePoiDialog } from "./components/create-poi-dialog";
+export { EditPoiDialog } from "./components/edit-poi-dialog";
 
 export { useCreatePoi } from "./hooks/use-create-poi";
+export { useUpdatePoi } from "./hooks/use-update-poi";
 export { useUploadPoiPhoto } from "./hooks/use-upload-poi-photo";
 export { usePoiFormSchema } from "./hooks/use-poi-form-schema";
 
 export { CreatePoiForm } from "./forms/create-poi-form";
+export { EditPoiForm } from "./forms/edit-poi-form";
 export { createPoiFormSchema } from "./schemas/pois.schema";
 export {
   poiConstraints,
@@ -28,8 +31,10 @@ export {
   getCoordinatesFromSavedPoi,
   getSavedPoiMapId,
 } from "./utils/get-poi-coordinates";
+export { canEditSavedPoi } from "./utils/can-edit-saved-poi";
 
 export type { CreatePoiInput } from "./hooks/use-create-poi";
+export type { UpdatePoiInput } from "./hooks/use-update-poi";
 export type { UploadPoiPhotoInput } from "./hooks/use-upload-poi-photo";
 export type { CreatePoiFormData, CreatePoiFormMessages } from "./schemas/pois.schema";
 export type { PoiVisibility, PoiCategory } from "./constants/pois.constants";

--- a/apps/web/src/features/pois/utils/can-edit-saved-poi.test.ts
+++ b/apps/web/src/features/pois/utils/can-edit-saved-poi.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import type { SavedPoiListItem } from "../types/poi-display-types";
+
+import { canEditSavedPoi } from "./can-edit-saved-poi";
+
+const customPoi: SavedPoiListItem = {
+  id: "sp-1",
+  listId: "list-1",
+  poiId: "poi-1",
+  googlePlaceId: null,
+  poi: {
+    id: "poi-1",
+    name: "Secret spot",
+    createdBy: "user-1",
+    latitude: 48.8566,
+    longitude: 2.3522,
+  },
+};
+
+const googlePoi: SavedPoiListItem = {
+  id: "sp-2",
+  listId: "list-1",
+  poiId: null,
+  googlePlaceId: "ChIJ",
+  poi: undefined,
+  googlePlaceCache: {
+    placeId: "ChIJ",
+    name: "Le Tout-Paris",
+  },
+};
+
+describe("canEditSavedPoi", () => {
+  it("returns true for a custom POI created by the user", () => {
+    expect(canEditSavedPoi(customPoi, "user-1")).toBe(true);
+  });
+
+  it("returns false for a custom POI created by someone else", () => {
+    expect(canEditSavedPoi(customPoi, "user-2")).toBe(false);
+  });
+
+  it("returns false for a Google Place", () => {
+    expect(canEditSavedPoi(googlePoi, "user-1")).toBe(false);
+  });
+
+  it("returns false when the saved POI has no nested poi", () => {
+    expect(canEditSavedPoi({ ...customPoi, poi: undefined }, "user-1")).toBe(false);
+  });
+
+  it("returns false when there is no user", () => {
+    expect(canEditSavedPoi(customPoi, undefined)).toBe(false);
+  });
+});

--- a/apps/web/src/features/pois/utils/can-edit-saved-poi.ts
+++ b/apps/web/src/features/pois/utils/can-edit-saved-poi.ts
@@ -1,0 +1,6 @@
+import type { SavedPoiListItem } from "../types/poi-display-types";
+
+/** Whether the current user may edit this saved POI (custom place they created). */
+export function canEditSavedPoi(savedPoi: SavedPoiListItem, userId: string | undefined): boolean {
+  return Boolean(userId && savedPoi.poi?.id && savedPoi.poi.createdBy === userId);
+}

--- a/apps/web/src/lib/i18n/locales/en/poi.json
+++ b/apps/web/src/lib/i18n/locales/en/poi.json
@@ -77,6 +77,7 @@
   "photo": {
     "title": "Photo",
     "hint": "Tap to add a photo",
+    "replaceHint": "Tap to replace the photo",
     "formats": "JPEG, PNG or WebP · max. 5 MB",
     "uploadSuccess": "Photo uploaded successfully",
     "uploadError": "Could not upload the photo"

--- a/apps/web/src/lib/i18n/locales/fr/poi.json
+++ b/apps/web/src/lib/i18n/locales/fr/poi.json
@@ -77,6 +77,7 @@
   "photo": {
     "title": "Photo",
     "hint": "Appuyer pour ajouter une photo",
+    "replaceHint": "Appuyer pour remplacer la photo",
     "formats": "JPEG, PNG ou WebP · 5 Mo max.",
     "uploadSuccess": "Photo envoyée avec succès",
     "uploadError": "Impossible d’envoyer la photo"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Description

Follow-up of NIR-69: edit a custom POI from a list ([NIR-86](https://linear.app/nirbyfr/issue/NIR-86/edit-custom-poi-from-a-list)).

On a list row, a pencil button appears next to the trash **only** when the saved place is a custom POI created by the current user (`poi.createdBy === user.id`). Independent of list role: a VIEWER creator can edit; an EDITOR who did not create the place cannot. Google Places stay read-only. The trash still only removes the place from the list.

Clicking the pencil opens the desktop dialog / mobile sheet with fields prefilled. Latitude and longitude stay hidden (same as NIR-85). Submit calls `PUT /poi/:id` via `updatePoi`; a new photo is uploaded first, then sent as `photoUrls`. Existing photos are left unchanged.

Out of scope: `DELETE /poi`, moving the pin.

## 🎯 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] ✅ Test update

## 🔗 Related Issues

Related to #184
Related to #146

## 🚀 Changes Made

- `useUpdatePoi`: `PUT /poi/:id`, invalidates POI queries and the list POI/detail caches when `listId` is set
- `EditPoiForm` / `EditPoiDialog`: reuse `PoiFormFields`, prefill from the POI, toasts `updatePoi.success` / `error`
- `canEditSavedPoi`: custom POI + `createdBy === userId`
- Pencil button in `ListPoiRow` next to the trash; gated on the creator helper

## 🧪 Testing

- [ ] Tested locally with `pnpm dev`
- [x] All quality checks pass (`pnpm lint`)
- [x] Unit tests pass (`pnpm test`) — 71 files / 397 tests
- [ ] Database migrations applied if needed

## 📸 Screenshots/Videos

N/A

## ✅ Checklist

- [x] Code follows project style guidelines
- [ ] Documentation updated if needed
- [x] No console errors or warnings
- [x] Removed any debug code

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffc2a-88d8-7f1a-9121-dcc6b7d75821?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffc2a-88d8-7f1a-9121-dcc6b7d75821&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

