### PR TITLE
fix(api): wrap multi-step writes in Prisma transactions

### DIFF
--- a/apps/api/__test__/auth/routes.test.ts
+++ b/apps/api/__test__/auth/routes.test.ts
@@ -27,6 +27,34 @@ import { deleteFile } from "../../src/upload/service";
 
 const app = createServer();
 
+function spyTransactionMethodFailure(
+  model: "user" | "session",
+  method: "delete" | "deleteMany" | "update"
+) {
+  const originalTransaction = prisma.$transaction.bind(prisma);
+  return vi.spyOn(prisma, "$transaction").mockImplementationOnce((async (fn: unknown) => {
+    return originalTransaction(async (tx) => {
+      const callback = fn as (client: typeof tx) => Promise<unknown>;
+      const failingTx = new Proxy(tx, {
+        get(target, prop, receiver) {
+          if (prop === model) {
+            return new Proxy(Reflect.get(target, prop, receiver) as object, {
+              get(modelTarget, modelProp, modelReceiver) {
+                if (modelProp === method) {
+                  return () => Promise.reject(new Error("simulated db failure"));
+                }
+                return Reflect.get(modelTarget, modelProp, modelReceiver);
+              },
+            });
+          }
+          return Reflect.get(target, prop, receiver);
+        },
+      });
+      return callback(failingTx);
+    });
+  }) as typeof prisma.$transaction);
+}
+
 describe("Auth routes", () => {
   beforeAll(async () => {
     await prisma.session.deleteMany();
@@ -924,6 +952,41 @@ describe("Auth routes", () => {
       const sessions = await prisma.session.findMany({ where: { userId: user.id } });
       expect(sessions).toHaveLength(0);
     });
+
+    it("should roll back if session invalidation fails during password reset", async () => {
+      const passwordHash = await hashPassword("oldpassword123");
+      const user = await prisma.user.create({
+        data: {
+          email: "reset-rollback@example.com",
+          passwordHash,
+          emailVerified: true,
+          passwordResetToken: "rollback-reset-token",
+          passwordResetExpiresAt: new Date(Date.now() + 60 * 60 * 1000),
+        },
+      });
+
+      await prisma.session.create({
+        data: {
+          userId: user.id,
+          refreshToken: "reset-rollback-refresh",
+          expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+        },
+      });
+
+      const spy = spyTransactionMethodFailure("session", "deleteMany");
+      const res = await request(app)
+        .post("/auth/reset-password")
+        .send({ token: "rollback-reset-token", password: "newpassword123" });
+      spy.mockRestore();
+
+      expect(res.status).toBe(500);
+      expect(res.body.error.code).toBe(ErrorCodes.INTERNAL_ERROR);
+
+      const remaining = await prisma.user.findUnique({ where: { id: user.id } });
+      expect(remaining?.passwordHash).toBe(passwordHash);
+      expect(remaining?.passwordResetToken).toBe("rollback-reset-token");
+      expect(await prisma.session.findMany({ where: { userId: user.id } })).toHaveLength(1);
+    });
   });
 });
 
@@ -1037,6 +1100,34 @@ describe("POST /auth/change-password", () => {
 
     const sessions = await prisma.session.findMany({ where: { userId } });
     expect(sessions).toHaveLength(0);
+  });
+
+  it("should roll back if session invalidation fails during password change", async () => {
+    await prisma.session.create({
+      data: {
+        userId,
+        refreshToken: "change-rollback-refresh",
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      },
+    });
+
+    const before = await prisma.user.findUnique({ where: { id: userId } });
+    const spy = spyTransactionMethodFailure("session", "deleteMany");
+    const res = await request(app)
+      .post("/auth/change-password")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .send({
+        oldPassword: "oldpassword123",
+        newPassword: "newpassword123",
+      });
+    spy.mockRestore();
+
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe(ErrorCodes.INTERNAL_ERROR);
+
+    const remaining = await prisma.user.findUnique({ where: { id: userId } });
+    expect(remaining?.passwordHash).toBe(before?.passwordHash);
+    expect(await prisma.session.findMany({ where: { userId } })).toHaveLength(1);
   });
 });
 

--- a/apps/api/__test__/upload/routes.test.ts
+++ b/apps/api/__test__/upload/routes.test.ts
@@ -154,6 +154,32 @@ describe("Upload Routes", () => {
       expect(deleteFile).toHaveBeenCalledWith("https://s3.example.com/old-avatar.jpg");
     });
 
+    it("should not persist avatar URL when database update fails", async () => {
+      await prisma.user.update({
+        where: { id: userId },
+        data: { avatarUrl: "https://s3.example.com/old-avatar.jpg" },
+      });
+
+      const updateSpy = vi
+        .spyOn(prisma.user, "update")
+        .mockRejectedValueOnce(new Error("simulated db failure"));
+
+      const res = await request(app)
+        .post("/upload/avatar")
+        .set("Authorization", `Bearer ${accessToken}`)
+        .attach("file", createValidJpegBuffer(), "avatar.jpg");
+
+      updateSpy.mockRestore();
+
+      expect(res.status).toBe(500);
+      expect(res.body.error.code).toBe("INTERNAL_ERROR");
+
+      const user = await prisma.user.findUnique({ where: { id: userId } });
+      expect(user?.avatarUrl).toBe("https://s3.example.com/old-avatar.jpg");
+      expect(deleteFile).toHaveBeenCalledWith("https://s3.example.com/test-file.jpg");
+      expect(deleteFile).not.toHaveBeenCalledWith("https://s3.example.com/old-avatar.jpg");
+    });
+
     it("should fail without authentication", async () => {
       const res = await request(app)
         .post("/upload/avatar")

--- a/apps/api/src/auth/routes.ts
+++ b/apps/api/src/auth/routes.ts
@@ -846,16 +846,17 @@ authRouter.post("/reset-password", authBrutForceRateLimiter, async (req, res) =>
 
     const passwordHash = await hashPassword(password);
 
-    await prisma.user.update({
-      where: { id: user.id },
-      data: {
-        passwordHash,
-        passwordResetToken: null,
-        passwordResetExpiresAt: null,
-      },
+    await prisma.$transaction(async (tx) => {
+      await tx.user.update({
+        where: { id: user.id },
+        data: {
+          passwordHash,
+          passwordResetToken: null,
+          passwordResetExpiresAt: null,
+        },
+      });
+      await tx.session.deleteMany({ where: { userId: user.id } });
     });
-
-    await prisma.session.deleteMany({ where: { userId: user.id } });
 
     res.json({ message: "Password reset successfully" });
   } catch (err) {
@@ -960,9 +961,14 @@ authRouter.post("/change-password", requireAuth, async (req, res) => {
     }
 
     const newPasswordHash = await hashPassword(newPassword);
-    await prisma.user.update({ where: { id: user.id }, data: { passwordHash: newPasswordHash } });
 
-    await prisma.session.deleteMany({ where: { userId: user.id } });
+    await prisma.$transaction(async (tx) => {
+      await tx.user.update({
+        where: { id: user.id },
+        data: { passwordHash: newPasswordHash },
+      });
+      await tx.session.deleteMany({ where: { userId: user.id } });
+    });
 
     res.json({ message: "Password changed successfully" });
   } catch (err) {

--- a/apps/api/src/list/share.routes.ts
+++ b/apps/api/src/list/share.routes.ts
@@ -1,5 +1,6 @@
 import crypto from "crypto";
 
+import { Prisma } from "@prisma/client";
 import { Router } from "express";
 
 import { requireAuth } from "../auth/middleware";
@@ -411,43 +412,74 @@ listShareRouter.post("/join", requireAuth, async (req, res) => {
       return res.status(400).json(formatError(ErrorCodes.TOKEN_REQUIRED, "Edit token is required"));
     }
 
-    const list = await prisma.poiList.findUnique({ where: { editToken } });
+    const userId = req.user!.id;
 
-    if (!list) {
+    const result = await prisma.$transaction(async (tx) => {
+      const list = await tx.poiList.findUnique({ where: { editToken } });
+
+      if (!list) {
+        return { kind: "not_found" as const };
+      }
+
+      if (list.editTokenExpiresAt && list.editTokenExpiresAt < new Date()) {
+        return { kind: "expired" as const };
+      }
+
+      if (isListOwner(list.createdBy, userId)) {
+        return { kind: "owner" as const, list };
+      }
+
+      const collaborator = await tx.listCollaborator.findUnique({
+        where: { listId_userId: { listId: list.id, userId } },
+      });
+      if (collaborator) {
+        return { kind: "already" as const, list };
+      }
+
+      await tx.listCollaborator.create({
+        data: { listId: list.id, userId, role: "EDITOR" },
+      });
+
+      return { kind: "joined" as const, list };
+    });
+
+    if (result.kind === "not_found") {
       return res.status(404).json(formatError(ErrorCodes.LIST_NOT_FOUND, "List not found"));
     }
 
-    if (list.editTokenExpiresAt && list.editTokenExpiresAt < new Date()) {
+    if (result.kind === "expired") {
       return res
         .status(400)
         .json(formatError(ErrorCodes.LIST_EDIT_TOKEN_EXPIRED, "Edit token expired"));
     }
 
-    if (isListOwner(list.createdBy, req.user!.id)) {
+    if (result.kind === "owner") {
       return res.json({
         message: "You are the owner of this list.",
-        list,
+        list: result.list,
       });
     }
 
-    const collaborator = await prisma.listCollaborator.findUnique({
-      where: { listId_userId: { listId: list.id, userId: req.user!.id } },
+    if (result.kind === "already") {
+      return res.json({
+        message: "You are already a collaborator of this list.",
+        list: result.list,
+      });
+    }
+
+    res.json({
+      list: result.list,
     });
-    if (collaborator) {
+  } catch (err) {
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002") {
+      const list = await prisma.poiList.findUnique({
+        where: { editToken: req.query.editToken as string },
+      });
       return res.json({
         message: "You are already a collaborator of this list.",
         list,
       });
     }
-
-    await prisma.listCollaborator.create({
-      data: { listId: list.id, userId: req.user!.id, role: "EDITOR" },
-    });
-
-    res.json({
-      list,
-    });
-  } catch (err) {
     req.log?.error({ err }, "Failed to join list");
     return res.status(500).json(formatError(ErrorCodes.INTERNAL_ERROR, "Internal server error"));
   }

--- a/apps/api/src/upload/routes.ts
+++ b/apps/api/src/upload/routes.ts
@@ -115,6 +115,20 @@ uploadRouter.post("/avatar", requireAuth, upload.single("file"), async (req, res
     const key = generateKey("avatars", req.user!.id, file.mimetype);
     const url = await uploadFile(file.buffer, key, file.mimetype);
 
+    try {
+      await prisma.user.update({
+        where: { id: req.user!.id },
+        data: { avatarUrl: url },
+      });
+    } catch (err) {
+      try {
+        await deleteFile(url);
+      } catch (cleanupErr) {
+        req.log?.warn({ err: cleanupErr, url }, "Failed to delete orphaned avatar after DB error");
+      }
+      throw err;
+    }
+
     if (user?.avatarUrl) {
       try {
         await deleteFile(user.avatarUrl);
@@ -122,11 +136,6 @@ uploadRouter.post("/avatar", requireAuth, upload.single("file"), async (req, res
         req.log?.warn({ err }, "Failed to delete old avatar");
       }
     }
-
-    await prisma.user.update({
-      where: { id: req.user!.id },
-      data: { avatarUrl: url },
-    });
 
     res.json({ url });
   } catch (err) {
@@ -252,10 +261,22 @@ uploadRouter.post("/poi-photo", requireAuth, upload.single("file"), async (req, 
     const url = await uploadFile(file.buffer, key, file.mimetype);
 
     if (poiId) {
-      await prisma.poi.update({
-        where: { id: poiId },
-        data: { photoUrls: { push: url } },
-      });
+      try {
+        await prisma.poi.update({
+          where: { id: poiId },
+          data: { photoUrls: { push: url } },
+        });
+      } catch (err) {
+        try {
+          await deleteFile(url);
+        } catch (cleanupErr) {
+          req.log?.warn(
+            { err: cleanupErr, url },
+            "Failed to delete orphaned POI photo after DB error"
+          );
+        }
+        throw err;
+      }
     }
 
     res.json({ url });

--- a/docs/gdpr-account-deletion.md
+++ b/docs/gdpr-account-deletion.md
@@ -67,6 +67,8 @@ Pourquoi S3 hors transaction : l’API objet n’est pas transactionnelle avec P
 
 En cas d’échec de la transaction : `500 ACCOUNT_DELETION_FAILED` (pas le `INTERNAL_ERROR` générique). Rollback Postgres : user et sessions intacts.
 
+Le style `$transaction` interactif et les autres écritures multi-étapes (reset / change password, upload, join) sont décrits dans [prisma-transactions.md](./prisma-transactions.md).
+
 ---
 
 ## 5. Démo jury

--- a/docs/prisma-transactions.md
+++ b/docs/prisma-transactions.md
@@ -1,0 +1,62 @@
+# Transactions Prisma — écritures multi-étapes
+
+Document d’argumentaire RNCP (Bloc 2, BC02 : « Gestion des requêtes et transactions », Démo 2).  
+Complète le ticket [NIR-90](https://linear.app/nirbyfr/issue/NIR-90/wrap-multi-step-writes-in-prisma-transactions) / GitHub [#191](https://github.com/brissboss/Nirby/issues/191).
+
+La suppression de compte (premier `$transaction` du projet) est détaillée dans [gdpr-account-deletion.md](./gdpr-account-deletion.md).
+
+---
+
+## 1. Interactive vs séquentielle
+
+Prisma propose deux formes :
+
+| Forme            | Syntaxe                                      | Usage                                                            |
+| ---------------- | -------------------------------------------- | ---------------------------------------------------------------- |
+| **Séquentielle** | `prisma.$transaction([op1, op2])`            | Liste de promises figée à l’avance.                              |
+| **Interactive**  | `prisma.$transaction(async (tx) => { ... })` | Lectures puis écritures dans le même callback, même client `tx`. |
+
+**Choix retenu : interactive**, pour trois raisons :
+
+1. Alignement avec `DELETE /auth/account` (NIR-89) — un seul style à montrer au jury.
+2. Le join par edit token doit **relire** la liste et l’éventuel collaborateur avant le `create`.
+3. L’ordre `user.update` puis `session.deleteMany` est explicite dans le callback ; un échec du second annule le premier (rollback Postgres).
+
+La forme séquentielle suffirait pour reset / change password seuls, mais elle ne couvre pas le join. Un seul pattern évite la confusion en soutenance.
+
+---
+
+## 2. Flux couverts
+
+| Flux                      | Fichier                | Atomique ?                                  | Comportement si échec                                                    |
+| ------------------------- | ---------------------- | ------------------------------------------- | ------------------------------------------------------------------------ |
+| Reset password            | `auth/routes.ts`       | TX : update hash + `session.deleteMany`     | Mot de passe et sessions inchangés                                       |
+| Change password           | `auth/routes.ts`       | idem                                        | idem                                                                     |
+| Delete account            | `auth/routes.ts`       | TX : sessions + `user.delete` (cascades FK) | Compte intact — voir doc RGPD                                            |
+| Upload avatar / photo POI | `upload/routes.ts`     | **Compensation S3**, pas de TX objet        | Nouveau fichier S3 supprimé ; URL non persistée ; ancien avatar conservé |
+| Join par edit token       | `list/share.routes.ts` | TX : relecture liste + create collaborateur | Unique `(listId, userId)` ; `P2002` → 200 idempotent                     |
+
+S3 n’est pas transactionnel avec Postgres. Ordre : **upload objet d’abord**, puis écriture SQL. Si le SQL échoue, `deleteFile()` du **nouveau** fichier. L’ancien avatar n’est retiré qu’**après** un update réussi — l’inverse (supprimer l’ancien avant le SQL) faisait disparaître les deux URLs en cas d’échec.
+
+---
+
+## 3. Concurrence du join
+
+Deux `POST /list/join` simultanés peuvent tous deux voir « pas encore collaborateur ». La contrainte `@@unique([listId, userId])` fait échouer le second `create` (`P2002`). Le handler attrape ce code et répond comme « déjà collaborateur » (200), pas 500.
+
+La transaction interactive réduit la fenêtre (relecture + create sur le même `tx`) ; l’unicité Postgres reste le garde-fou réel. Pas de test HTTP de course (flaky) : le scénario se démontre en citant le `catch P2002` et le unique du schéma.
+
+---
+
+## 4. Démo jury — rollback
+
+```bash
+pnpm -C apps/api test -- __test__/auth/routes.test.ts
+```
+
+Scénario oral (reset password) :
+
+1. Utilisateur avec un token de reset valide et une session.
+2. Test « `session.deleteMany` lève au milieu de la TX » → HTTP 500, `passwordHash` identique, session toujours en base.
+3. Montrer le callback `$transaction` dans `POST /auth/reset-password`.
+4. Même histoire pour change password et, pour S3, le test upload avatar dont l’update SQL échoue (`deleteFile` appelé avec l’URL **nouvelle** uniquement).

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -21,3 +21,4 @@ Nirby est une webapp « spatial IA » centrée sur la cartographie personnal
 - Backend actuel Express/Prisma/PostgreSQL (PostGIS) + Redis.
 - Projet de validation RNCP : stabilité, traçabilité et couverture fonctionnelle démontrables.
 - Droit à l’effacement (RGPD art. 17) : voir [gdpr-account-deletion.md](./gdpr-account-deletion.md).
+- Transactions Prisma (écritures multi-étapes, rollback) : voir [prisma-transactions.md](./prisma-transactions.md).

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -117,18 +117,21 @@ Ci-dessous : **extraits représentatifs** au format attendu par la checklist (en
 
 ### 6.3 Authentification JWT
 
-| Scénario                          | Entrée                                    | Sortie attendue              | Résultat | Fichier                                     |
-| --------------------------------- | ----------------------------------------- | ---------------------------- | -------- | ------------------------------------------- |
-| Requête sans header Authorization | `GET /protected` sans token               | HTTP 401, `UNAUTHORIZED`     | ✅ Pass  | `apps/api/__test__/auth/middleware.test.ts` |
-| Token JWT invalide                | `Authorization: Bearer invalid-token-123` | HTTP 401                     | ✅ Pass  | idem                                        |
-| Token valide, user existant       | Bearer token signé + user en BDD          | HTTP 200, `user` dans body   | ✅ Pass  | idem                                        |
-| Email non vérifié                 | user `emailVerified: false`               | HTTP 403 sur route protégée  | ✅ Pass  | idem                                        |
-| Login mot de passe incorrect      | email valide, mauvais password            | HTTP 401                     | ✅ Pass  | `apps/api/__test__/auth/routes.test.ts`     |
-| Refresh token invalide            | cookie `refreshToken=invalid-token`       | HTTP 401                     | ✅ Pass  | idem                                        |
-| Suppression compte + POI et liste | `DELETE /auth/account`, user owner        | HTTP 200, plus de données    | ✅ Pass  | idem                                        |
-| Collaborateur d’une liste tierce  | delete du non-owner                       | liste intacte, collab. parti | ✅ Pass  | idem                                        |
-| Mot de passe invalide (delete)    | mauvais password, session existante       | HTTP 401, sessions intactes  | ✅ Pass  | idem                                        |
-| Rollback transaction delete       | `user.delete` lève en cours de TX         | user + sessions intacts      | ✅ Pass  | idem                                        |
+| Scénario                          | Entrée                                    | Sortie attendue               | Résultat | Fichier                                     |
+| --------------------------------- | ----------------------------------------- | ----------------------------- | -------- | ------------------------------------------- |
+| Requête sans header Authorization | `GET /protected` sans token               | HTTP 401, `UNAUTHORIZED`      | ✅ Pass  | `apps/api/__test__/auth/middleware.test.ts` |
+| Token JWT invalide                | `Authorization: Bearer invalid-token-123` | HTTP 401                      | ✅ Pass  | idem                                        |
+| Token valide, user existant       | Bearer token signé + user en BDD          | HTTP 200, `user` dans body    | ✅ Pass  | idem                                        |
+| Email non vérifié                 | user `emailVerified: false`               | HTTP 403 sur route protégée   | ✅ Pass  | idem                                        |
+| Login mot de passe incorrect      | email valide, mauvais password            | HTTP 401                      | ✅ Pass  | `apps/api/__test__/auth/routes.test.ts`     |
+| Refresh token invalide            | cookie `refreshToken=invalid-token`       | HTTP 401                      | ✅ Pass  | idem                                        |
+| Suppression compte + POI et liste | `DELETE /auth/account`, user owner        | HTTP 200, plus de données     | ✅ Pass  | idem                                        |
+| Collaborateur d’une liste tierce  | delete du non-owner                       | liste intacte, collab. parti  | ✅ Pass  | idem                                        |
+| Mot de passe invalide (delete)    | mauvais password, session existante       | HTTP 401, sessions intactes   | ✅ Pass  | idem                                        |
+| Rollback transaction delete       | `user.delete` lève en cours de TX         | user + sessions intacts       | ✅ Pass  | idem                                        |
+| Rollback reset password           | `session.deleteMany` lève dans la TX      | hash inchangé, session là     | ✅ Pass  | idem                                        |
+| Rollback change password          | idem                                      | hash inchangé, sessions là    | ✅ Pass  | idem                                        |
+| Upload avatar, update SQL échoue  | `user.update` throw après S3              | URL non persistée, S3 nettoyé | ✅ Pass  | `apps/api/__test__/upload/routes.test.ts`   |
 
 ### 6.4 CRUD listes & POI (routes API)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Wraps remaining multi-step writes in Prisma interactive `$transaction` (same style as NIR-89 account deletion) so a mid-flight failure no longer leaves the database inconsistent. S3 uploads use compensation instead of a DB transaction.

Linear: [NIR-90](https://linear.app/nirbyfr/issue/NIR-90/wrap-multi-step-writes-in-prisma-transactions)

## Type of Change

- [x] Bug fix
- [x] Documentation update
- [x] Test update

## Related Issues

Closes #191
Related to #190 (account deletion already transactional)

## Changes Made

- `POST /auth/reset-password` and `POST /auth/change-password`: hash update + `session.deleteMany` in one transaction
- Avatar / POI photo: upload S3 first, then SQL; delete the **new** object if the update fails; delete the old avatar only after a successful update
- `POST /list/join`: re-read list + create collaborator in a transaction; unique violation `P2002` returns 200 (already collaborator)
- RNCP write-up in `docs/prisma-transactions.md` (interactive vs sequential, rollback demo)

## Testing

- [ ] Tested locally with `pnpm dev`
- [x] All quality checks pass (`pnpm -C apps/api lint`, `tsc --noEmit`)
- [x] Unit tests pass (`pnpm -C apps/api test` — 369 tests)
- [ ] Database migrations applied if needed (none)

New cases:

- Reset / change password: simulated `session.deleteMany` failure → 500, hash and sessions unchanged
- Upload avatar: simulated `user.update` failure → 500, old URL kept, `deleteFile` called with the new URL only

## Screenshots/Videos

N/A

## Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated
- [x] Removed any debug code

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0003a-7bc3-70b8-9e48-3c625d43dc67?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0003a-7bc3-70b8-9e48-3c625d43dc67&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

