### PR TITLE
fix(auth): apply email verification guard on write routes

### DIFF
--- a/apps/api/__test__/list/routes.test.ts
+++ b/apps/api/__test__/list/routes.test.ts
@@ -71,6 +71,26 @@ describe("List Routes", () => {
       expect(res.status).toBe(401);
     });
 
+    it("should reject unverified email", async () => {
+      const unverified = await prisma.user.create({
+        data: {
+          email: "unverified-list@example.com",
+          passwordHash: await hashPassword("password123"),
+          emailVerified: false,
+        },
+      });
+      const token = signAccessToken({ userId: unverified.id, email: unverified.email });
+
+      const res = await request(app)
+        .post("/list")
+        .set("Authorization", `Bearer ${token}`)
+        .send({ name: "Unverified List" });
+
+      expect(res.status).toBe(403);
+      expect(res.body.error.code).toBe(ErrorCodes.EMAIL_NOT_VERIFIED);
+      expect(await prisma.poiList.count({ where: { createdBy: unverified.id } })).toBe(0);
+    });
+
     it("should fail with missing name", async () => {
       const res = await request(app)
         .post("/list")
@@ -1618,6 +1638,32 @@ describe("List Routes", () => {
         });
 
       expect(res.status).toBe(400);
+    });
+
+    it("should reject unverified email", async () => {
+      const unverified = await prisma.user.create({
+        data: {
+          email: "unverified-invite@example.com",
+          passwordHash: await hashPassword("password123"),
+          emailVerified: false,
+        },
+      });
+      const list = await prisma.poiList.create({
+        data: { name: "Owned List", createdBy: unverified.id },
+      });
+      const token = signAccessToken({ userId: unverified.id, email: unverified.email });
+
+      const res = await request(app)
+        .post(`/list/${list.id}/collaborators/invite`)
+        .set("Authorization", `Bearer ${token}`)
+        .send({
+          email: "invited@example.com",
+          role: "EDITOR",
+          sendEmail: false,
+        });
+
+      expect(res.status).toBe(403);
+      expect(res.body.error.code).toBe(ErrorCodes.EMAIL_NOT_VERIFIED);
     });
   });
 

--- a/apps/api/__test__/poi/routes.test.ts
+++ b/apps/api/__test__/poi/routes.test.ts
@@ -79,6 +79,27 @@ describe("POI Routes", () => {
       expect(res.status).toBe(401);
     });
 
+    it("should reject unverified email", async () => {
+      const unverified = await prisma.user.create({
+        data: {
+          email: "unverified-poi@example.com",
+          passwordHash: await hashPassword("password123"),
+          emailVerified: false,
+        },
+      });
+      const token = signAccessToken({ userId: unverified.id, email: unverified.email });
+
+      const res = await request(app).post("/poi").set("Authorization", `Bearer ${token}`).send({
+        name: "Unverified POI",
+        latitude: 40.7128,
+        longitude: -74.006,
+      });
+
+      expect(res.status).toBe(403);
+      expect(res.body.error.code).toBe("EMAIL_NOT_VERIFIED");
+      expect(await prisma.poi.count({ where: { createdBy: unverified.id } })).toBe(0);
+    });
+
     it("should fail with missing name", async () => {
       const res = await request(app)
         .post("/poi")

--- a/apps/api/src/list/collaborators.routes.ts
+++ b/apps/api/src/list/collaborators.routes.ts
@@ -3,7 +3,7 @@ import { Router } from "express";
 import jwt from "jsonwebtoken";
 import { z } from "zod";
 
-import { requireAuth } from "../auth/middleware";
+import { requireAuth, requireVerifiedEmail } from "../auth/middleware";
 import { prisma } from "../db";
 import { sendCollaboratorInviteEmail } from "../email/service";
 import { env } from "../env";
@@ -481,7 +481,7 @@ listCollaboratorsRouter.delete(
  *             schema:
  *               $ref: '#/components/schemas/Error'
  *       403:
- *         description: Access denied
+ *         description: Access denied or email not verified
  *         content:
  *           application/json:
  *             schema:
@@ -499,89 +499,99 @@ listCollaboratorsRouter.delete(
  *             schema:
  *               $ref: '#/components/schemas/Error'
  */
-listCollaboratorsRouter.post("/:listId/collaborators/invite", requireAuth, async (req, res) => {
-  try {
-    const { email, role, language, sendEmail } = inviteCollaboratorSchema.parse(req.body);
+listCollaboratorsRouter.post(
+  "/:listId/collaborators/invite",
+  requireAuth,
+  requireVerifiedEmail,
+  async (req, res) => {
+    try {
+      const { email, role, language, sendEmail } = inviteCollaboratorSchema.parse(req.body);
 
-    const list = await prisma.poiList.findUnique({ where: { id: req.params.listId } });
-    if (!list) {
-      return res.status(404).json(formatError(ErrorCodes.LIST_NOT_FOUND, "List not found"));
-    }
+      const list = await prisma.poiList.findUnique({ where: { id: req.params.listId } });
+      if (!list) {
+        return res.status(404).json(formatError(ErrorCodes.LIST_NOT_FOUND, "List not found"));
+      }
 
-    const ownerRole = await checkListAccess(list, req.user!.id);
-    if (!hasListAccess(ownerRole)) {
-      return res.status(404).json(formatError(ErrorCodes.LIST_NOT_FOUND, "List not found"));
-    }
+      const ownerRole = await checkListAccess(list, req.user!.id);
+      if (!hasListAccess(ownerRole)) {
+        return res.status(404).json(formatError(ErrorCodes.LIST_NOT_FOUND, "List not found"));
+      }
 
-    if (!canManageCollaborators(ownerRole)) {
-      return res.status(403).json(formatError(ErrorCodes.LIST_ACCESS_DENIED, "Access denied"));
-    }
+      if (!canManageCollaborators(ownerRole)) {
+        return res.status(403).json(formatError(ErrorCodes.LIST_ACCESS_DENIED, "Access denied"));
+      }
 
-    if (req.user!.email === email) {
-      return res
-        .status(400)
-        .json(
-          formatError(ErrorCodes.COLLABORATOR_CANNOT_INVITE_YOURSELF, "You cannot invite yourself")
-        );
-    }
-
-    const existingUser = await prisma.user.findUnique({ where: { email } });
-    if (existingUser) {
-      const collaborator = await prisma.listCollaborator.findUnique({
-        where: { listId_userId: { listId: list.id, userId: existingUser.id } },
-      });
-      if (collaborator) {
+      if (req.user!.email === email) {
         return res
           .status(400)
-          .json(formatError(ErrorCodes.COLLABORATOR_ALREADY_EXISTS, "Collaborator already exists"));
+          .json(
+            formatError(
+              ErrorCodes.COLLABORATOR_CANNOT_INVITE_YOURSELF,
+              "You cannot invite yourself"
+            )
+          );
       }
-    }
 
-    const invitationToken = jwt.sign(
-      { listId: list.id, email, role, invitedBy: req.user!.id, type: "collaborator_invite" },
-      env.JWT_SECRET,
-      { expiresIn: "7d" }
-    );
+      const existingUser = await prisma.user.findUnique({ where: { email } });
+      if (existingUser) {
+        const collaborator = await prisma.listCollaborator.findUnique({
+          where: { listId_userId: { listId: list.id, userId: existingUser.id } },
+        });
+        if (collaborator) {
+          return res
+            .status(400)
+            .json(
+              formatError(ErrorCodes.COLLABORATOR_ALREADY_EXISTS, "Collaborator already exists")
+            );
+        }
+      }
 
-    const inviteLink = `${env.FRONTEND_URL}/list/${list.id}/collaborators/accept?token=${invitationToken}`;
+      const invitationToken = jwt.sign(
+        { listId: list.id, email, role, invitedBy: req.user!.id, type: "collaborator_invite" },
+        env.JWT_SECRET,
+        { expiresIn: "7d" }
+      );
 
-    let emailSent = false;
-    if (sendEmail) {
-      const invitedByName = await prisma.user.findUnique({
-        where: { id: req.user!.id },
-        select: { name: true },
+      const inviteLink = `${env.FRONTEND_URL}/list/${list.id}/collaborators/accept?token=${invitationToken}`;
+
+      let emailSent = false;
+      if (sendEmail) {
+        const invitedByName = await prisma.user.findUnique({
+          where: { id: req.user!.id },
+          select: { name: true },
+        });
+
+        try {
+          await sendCollaboratorInviteEmail(
+            email,
+            list.name,
+            invitedByName?.name || req.user!.email,
+            inviteLink,
+            language
+          );
+
+          emailSent = true;
+        } catch (emailError) {
+          req.log?.error({ emailError }, "Failed to send collaborator invite email");
+        }
+      }
+
+      res.json({
+        inviteLink,
+        emailSent,
       });
-
-      try {
-        await sendCollaboratorInviteEmail(
-          email,
-          list.name,
-          invitedByName?.name || req.user!.email,
-          inviteLink,
-          language
-        );
-
-        emailSent = true;
-      } catch (emailError) {
-        req.log?.error({ emailError }, "Failed to send collaborator invite email");
+    } catch (err) {
+      if (err instanceof z.ZodError) {
+        const details = handleZodError(err);
+        return res
+          .status(400)
+          .json(formatError(ErrorCodes.VALIDATION_ERROR, "Invalid input", details));
       }
+      req.log?.error({ err }, "Failed to invite collaborator");
+      return res.status(500).json(formatError(ErrorCodes.INTERNAL_ERROR, "Internal server error"));
     }
-
-    res.json({
-      inviteLink,
-      emailSent,
-    });
-  } catch (err) {
-    if (err instanceof z.ZodError) {
-      const details = handleZodError(err);
-      return res
-        .status(400)
-        .json(formatError(ErrorCodes.VALIDATION_ERROR, "Invalid input", details));
-    }
-    req.log?.error({ err }, "Failed to invite collaborator");
-    return res.status(500).json(formatError(ErrorCodes.INTERNAL_ERROR, "Internal server error"));
   }
-});
+);
 
 /**
  * @openapi

--- a/apps/api/src/list/routes.ts
+++ b/apps/api/src/list/routes.ts
@@ -2,7 +2,7 @@ import { CollaboratorRole, PoiVisibility } from "@prisma/client";
 import { Router } from "express";
 import { z } from "zod";
 
-import { requireAuth } from "../auth/middleware";
+import { requireAuth, requireVerifiedEmail } from "../auth/middleware";
 import { prisma } from "../db";
 import { ErrorCodes } from "../utils/error-codes";
 import { formatError, handleZodError } from "../utils/errors";
@@ -125,6 +125,12 @@ const updateListSchema = z.object({
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/Error'
+ *       403:
+ *         description: Email not verified
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
  *       500:
  *         description: Internal server error
  *         content:
@@ -132,7 +138,7 @@ const updateListSchema = z.object({
  *             schema:
  *               $ref: '#/components/schemas/Error'
  */
-listRouter.post("/", requireAuth, async (req, res) => {
+listRouter.post("/", requireAuth, requireVerifiedEmail, async (req, res) => {
   try {
     const data = createListSchema.parse(req.body);
 

--- a/apps/api/src/poi/routes.ts
+++ b/apps/api/src/poi/routes.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import { z } from "zod";
 
-import { requireAuth } from "../auth/middleware";
+import { requireAuth, requireVerifiedEmail } from "../auth/middleware";
 import { prisma } from "../db";
 import { POI_CATEGORIES, SUPPORTED_LANGUAGES } from "../types";
 import { ErrorCodes } from "../utils/error-codes";
@@ -237,6 +237,12 @@ const nearbyPoiSchema = z.object({
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/Error'
+ *       403:
+ *         description: Email not verified
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
  *       500:
  *         description: Internal server error
  *         content:
@@ -244,7 +250,7 @@ const nearbyPoiSchema = z.object({
  *             schema:
  *               $ref: '#/components/schemas/Error'
  */
-poiRouter.post("/", requireAuth, async (req, res) => {
+poiRouter.post("/", requireAuth, requireVerifiedEmail, async (req, res) => {
   try {
     const data = createPoiSchema.parse(req.body);
 

--- a/apps/web/src/app/(auth)/login/page.test.tsx
+++ b/apps/web/src/app/(auth)/login/page.test.tsx
@@ -6,6 +6,7 @@ import LoginPage from "./page";
 
 const push = vi.fn();
 const login = vi.fn();
+const resendEmail = vi.fn();
 let searchParams = new URLSearchParams();
 
 vi.mock("next/navigation", () => ({
@@ -22,7 +23,7 @@ vi.mock("@/features/auth", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/features/auth")>();
   return {
     ...actual,
-    useAuth: () => ({ login }),
+    useAuth: () => ({ login, resendEmail }),
   };
 });
 
@@ -42,6 +43,8 @@ describe("LoginPage returnUrl", () => {
     push.mockClear();
     login.mockReset();
     login.mockResolvedValue(undefined);
+    resendEmail.mockReset();
+    resendEmail.mockResolvedValue(undefined);
     searchParams = new URLSearchParams();
   });
 
@@ -93,5 +96,42 @@ describe("LoginPage returnUrl", () => {
       "href",
       "/signup?returnUrl=%2Flist%2Flist-1%2Fjoin%3FeditToken%3Dedit-token"
     );
+  });
+});
+
+describe("LoginPage email verification", () => {
+  beforeEach(() => {
+    push.mockClear();
+    login.mockReset();
+    resendEmail.mockReset();
+    resendEmail.mockResolvedValue(undefined);
+    searchParams = new URLSearchParams();
+  });
+
+  it("shows resend email when login fails with EMAIL_NOT_VERIFIED", async () => {
+    login.mockRejectedValue({
+      success: false,
+      error: { code: "EMAIL_NOT_VERIFIED", message: "Please verify your email" },
+    });
+
+    render(<LoginPage />);
+
+    const user = userEvent.setup();
+    await user.type(screen.getByRole("textbox"), "user@example.com");
+    await user.type(screen.getByPlaceholderText("••••••••"), "password1");
+    await user.click(screen.getByRole("button", { name: "auth.login.login" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "auth.verifyEmail.resendEmail" })
+      ).toBeInTheDocument();
+    });
+    expect(push).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "auth.verifyEmail.resendEmail" }));
+
+    await waitFor(() => {
+      expect(resendEmail).toHaveBeenCalledWith("user@example.com");
+    });
   });
 });

--- a/apps/web/src/app/(auth)/login/page.tsx
+++ b/apps/web/src/app/(auth)/login/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { standardSchemaResolver } from "@hookform/resolvers/standard-schema";
-import { Eye, EyeOff } from "lucide-react";
+import { ArrowLeft, Eye, EyeOff, Mail } from "lucide-react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { useState, useMemo } from "react";
+import { useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 
@@ -21,6 +21,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { useAuth, type LoginSignupFormData, createLoginSignupSchema } from "@/features/auth";
 import { useErrorMessage } from "@/hooks/use-error-message";
+import { getErrorCode } from "@/lib/api/errors";
 import {
   RETURN_URL_PARAM,
   buildSignupHref,
@@ -29,7 +30,9 @@ import {
 
 export default function LoginPage() {
   const [showPassword, setShowPassword] = useState(false);
-  const { login } = useAuth();
+  const [needsVerification, setNeedsVerification] = useState(false);
+  const [isResending, setIsResending] = useState(false);
+  const { login, resendEmail } = useAuth();
   const router = useRouter();
   const searchParams = useSearchParams();
   const t = useTranslations();
@@ -59,107 +62,163 @@ export default function LoginPage() {
       await login(values.email, values.password);
       router.push(safeReturnPath ?? "/");
     } catch (error) {
+      if (getErrorCode(error) === "EMAIL_NOT_VERIFIED") {
+        setNeedsVerification(true);
+        return;
+      }
       toast.error(t("auth.login.loginError"), {
         description: getErrorMessage(error),
       });
     }
   }
 
+  async function handleResendEmail() {
+    setIsResending(true);
+    try {
+      await resendEmail(form.getValues("email"));
+      toast.success(t("auth.verifyEmail.emailResent"));
+    } catch (err) {
+      toast.error(t("auth.verifyEmail.emailResendError"), {
+        description: getErrorMessage(err),
+      });
+    } finally {
+      setIsResending(false);
+    }
+  }
+
   return (
-    <div className="flex flex-col items-center justify-center p-6 bg-background">
+    <div className="flex flex-col items-center justify-center p-6 bg-background relative">
+      {needsVerification && (
+        <Button
+          variant="ghost"
+          className="absolute top-11 left-4"
+          onClick={() => setNeedsVerification(false)}
+        >
+          <ArrowLeft className="w-4 h-4" />
+          {t("common.buttons.back")}
+        </Button>
+      )}
+
       <div className="w-full max-w-md lg:max-w-sm space-y-8 lg:space-y-6">
-        <div className="space-y-2 text-center">
-          <h1 className="text-2xl font-bold tracking-tight">{t("auth.login.title")}</h1>
-          <p className="text-muted-foreground text-md lg:text-sm">{t("auth.login.description")}</p>
-        </div>
-
-        <Form {...form}>
-          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6 lg:space-y-4">
-            <FormField
-              control={form.control}
-              name="email"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel className="text-md lg:text-sm">{t("common.labels.email")}</FormLabel>
-                  <FormControl>
-                    <Input
-                      placeholder={t("common.labels.emailPlaceholder")}
-                      {...field}
-                      className="px-4 lg:px-3"
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name="password"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel className="text-md lg:text-sm">
-                    {t("common.labels.password")}
-                  </FormLabel>
-                  <FormControl>
-                    <div className="relative">
-                      <Input
-                        type={showPassword ? "text" : "password"}
-                        placeholder="••••••••"
-                        {...field}
-                        className="px-4 lg:px-3 pr-12 lg:pr-10"
-                      />
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon"
-                        className="absolute right-0 lg:right-2 top-0 lg:top-1.5 h-full lg:h-6 w-12 lg:w-6 hover:bg-transparent"
-                        onClick={() => setShowPassword((prev) => !prev)}
-                      >
-                        {showPassword ? (
-                          <EyeOff className="size-5 lg:size-4 text-muted-foreground" />
-                        ) : (
-                          <Eye className="size-5 lg:size-4 text-muted-foreground" />
-                        )}
-                        <span className="sr-only">
-                          {showPassword
-                            ? t("auth.general.hidePassword")
-                            : t("auth.general.showPassword")}
-                        </span>
-                      </Button>
-                    </div>
-                  </FormControl>
-                  <FormMessage />
-                  <div className="flex justify-end pt-2 lg:pt-1">
-                    <Link
-                      href="/forgot-password"
-                      className="text-sm font-medium text-primary hover:underline"
-                    >
-                      {t("auth.login.forgotPassword")}
-                    </Link>
-                  </div>
-                </FormItem>
-              )}
-            />
+        {needsVerification ? (
+          <div className="space-y-2 text-center">
+            <Mail className="w-10 h-10 mx-auto text-primary" />
+            <h1 className="text-2xl font-bold tracking-tight">
+              {t("auth.login.emailNotVerifiedTitle")}
+            </h1>
+            <p className="text-muted-foreground text-md lg:text-sm">
+              {t("auth.login.emailNotVerifiedDescription")}
+            </p>
             <Button
-              type="submit"
+              variant="outline"
+              onClick={handleResendEmail}
               className="w-full mt-4"
-              disabled={form.formState.isSubmitting}
-              loading={form.formState.isSubmitting}
+              disabled={isResending}
+              loading={isResending}
             >
-              {t("auth.login.login")}
+              {t("auth.verifyEmail.resendEmail")}
             </Button>
-          </form>
-        </Form>
+          </div>
+        ) : (
+          <>
+            <div className="space-y-2 text-center">
+              <h1 className="text-2xl font-bold tracking-tight">{t("auth.login.title")}</h1>
+              <p className="text-muted-foreground text-md lg:text-sm">
+                {t("auth.login.description")}
+              </p>
+            </div>
 
-        <div className="text-center text-base lg:text-sm pt-4">
-          <span className="text-muted-foreground">{t("auth.login.noAccount")} </span>
-          <Link
-            href={safeReturnPath ? buildSignupHref(safeReturnPath) : "/signup"}
-            className="font-semibold text-primary hover:underline"
-          >
-            {t("auth.login.signup")}
-          </Link>
-        </div>
+            <Form {...form}>
+              <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6 lg:space-y-4">
+                <FormField
+                  control={form.control}
+                  name="email"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className="text-md lg:text-sm">
+                        {t("common.labels.email")}
+                      </FormLabel>
+                      <FormControl>
+                        <Input
+                          placeholder={t("common.labels.emailPlaceholder")}
+                          {...field}
+                          className="px-4 lg:px-3"
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="password"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className="text-md lg:text-sm">
+                        {t("common.labels.password")}
+                      </FormLabel>
+                      <FormControl>
+                        <div className="relative">
+                          <Input
+                            type={showPassword ? "text" : "password"}
+                            placeholder="••••••••"
+                            {...field}
+                            className="px-4 lg:px-3 pr-12 lg:pr-10"
+                          />
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            className="absolute right-0 lg:right-2 top-0 lg:top-1.5 h-full lg:h-6 w-12 lg:w-6 hover:bg-transparent"
+                            onClick={() => setShowPassword((prev) => !prev)}
+                          >
+                            {showPassword ? (
+                              <EyeOff className="size-5 lg:size-4 text-muted-foreground" />
+                            ) : (
+                              <Eye className="size-5 lg:size-4 text-muted-foreground" />
+                            )}
+                            <span className="sr-only">
+                              {showPassword
+                                ? t("auth.general.hidePassword")
+                                : t("auth.general.showPassword")}
+                            </span>
+                          </Button>
+                        </div>
+                      </FormControl>
+                      <FormMessage />
+                      <div className="flex justify-end pt-2 lg:pt-1">
+                        <Link
+                          href="/forgot-password"
+                          className="text-sm font-medium text-primary hover:underline"
+                        >
+                          {t("auth.login.forgotPassword")}
+                        </Link>
+                      </div>
+                    </FormItem>
+                  )}
+                />
+                <Button
+                  type="submit"
+                  className="w-full mt-4"
+                  disabled={form.formState.isSubmitting}
+                  loading={form.formState.isSubmitting}
+                >
+                  {t("auth.login.login")}
+                </Button>
+              </form>
+            </Form>
+
+            <div className="text-center text-base lg:text-sm pt-4">
+              <span className="text-muted-foreground">{t("auth.login.noAccount")} </span>
+              <Link
+                href={safeReturnPath ? buildSignupHref(safeReturnPath) : "/signup"}
+                className="font-semibold text-primary hover:underline"
+              >
+                {t("auth.login.signup")}
+              </Link>
+            </div>
+          </>
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/lib/i18n/locales/en/auth.json
+++ b/apps/web/src/lib/i18n/locales/en/auth.json
@@ -18,7 +18,9 @@
     "login": "Login",
     "loginError": "Login error",
     "noAccount": "No account yet ?",
-    "signup": "Sign up"
+    "signup": "Sign up",
+    "emailNotVerifiedTitle": "Email not verified",
+    "emailNotVerifiedDescription": "Please verify your email before logging in. Check your inbox or resend the verification email."
   },
   "signup": {
     "title": "Sign up",

--- a/apps/web/src/lib/i18n/locales/en/errors.json
+++ b/apps/web/src/lib/i18n/locales/en/errors.json
@@ -15,7 +15,7 @@
     "TOKEN_REQUIRED": "The verification link is required",
     "TOKEN_EXPIRED": "The verification link has expired, please generate a new one",
     "EMAIL_ALREADY_VERIFIED": "Your email is already verified",
-    "EMAIL_NOT_VERIFIED": "Your email is not verified",
+    "EMAIL_NOT_VERIFIED": "Please verify your email before continuing",
     "ACCOUNT_DELETION_FAILED": "Account deletion failed, please try again",
     "NAME_TOO_LONG": "Name cannot contain more than 255 characters",
     "BIO_TOO_LONG": "Bio cannot contain more than 255 characters",

--- a/apps/web/src/lib/i18n/locales/fr/auth.json
+++ b/apps/web/src/lib/i18n/locales/fr/auth.json
@@ -18,7 +18,9 @@
     "login": "Se connecter",
     "loginError": "Erreur de connexion",
     "noAccount": "Pas encore de compte ?",
-    "signup": "S'inscrire"
+    "signup": "S'inscrire",
+    "emailNotVerifiedTitle": "Email non vérifié",
+    "emailNotVerifiedDescription": "Veuillez vérifier votre email avant de vous connecter. Consultez votre boîte de réception ou renvoyez l'email de vérification."
   },
   "signup": {
     "title": "Inscription",

--- a/docs/email-verification.md
+++ b/docs/email-verification.md
@@ -1,0 +1,50 @@
+# Vérification d’email — routes sensibles
+
+Document d’argumentaire RNCP (Bloc 1 : « routes sensibles protégées »).  
+Complète le ticket [NIR-100](https://linear.app/nirbyfr/issue/NIR-100/apply-or-remove-unused-email-verification-guard) / GitHub [#201](https://github.com/brissboss/Nirby/issues/201).
+
+---
+
+## 1. Pourquoi appliquer plutôt que supprimer
+
+`requireVerifiedEmail` existait dans [`apps/api/src/auth/middleware.ts`](../apps/api/src/auth/middleware.ts) et était testé, mais n’était monté **nulle part**.
+
+Le login refuse déjà les comptes non vérifiés (`403 EMAIL_NOT_VERIFIED`) et le signup n’émet pas de JWT. Fonctionnellement, ce contrôle suffirait.
+
+On l’a **branché** quand même :
+
+1. Du code mort, testé et commenté, est plus difficile à défendre qu’une défense en profondeur.
+2. Un JWT peut exister sans passer par le login (tests, seed, token encore valide si le statut changeait).
+3. Restreindre aux **écritures / emails** : GET `/auth/me` et lectures de listes restent possibles, ce qui permet d’afficher un CTA de vérification.
+
+---
+
+## 2. Périmètre
+
+Après `requireAuth` :
+
+| Route                                     | Raison              |
+| ----------------------------------------- | ------------------- |
+| `POST /poi`                               | Création de contenu |
+| `POST /list`                              | Création de contenu |
+| `POST /list/:listId/collaborators/invite` | Déclenche un email  |
+
+Lectures, updates, uploads, join et Google Places : hors scope volontaire (moins de surface, fixtures existantes déjà `emailVerified: true` sur les writes).
+
+---
+
+## 3. Front
+
+Parcours réel : le login. Sur `EMAIL_NOT_VERIFIED`, la page affiche le panneau « email non vérifié » et un bouton de renvoi (`resendEmail`), comme après le signup. Pas de handler global sur les mutations : un utilisateur réel n’obtient pas de token.
+
+---
+
+## 4. Démo jury
+
+```bash
+pnpm -C apps/api test -- __test__/auth/middleware.test.ts __test__/poi/routes.test.ts __test__/list/routes.test.ts
+```
+
+1. Montrer `requireVerifiedEmail` monté sur `POST /poi` (et list / invite).
+2. Test : JWT d’un user `emailVerified: false` → `403 EMAIL_NOT_VERIFIED`, aucune ligne créée.
+3. Login : toast n’est plus le seul feedback — CTA « renvoyer l’email ».

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -22,3 +22,4 @@ Nirby est une webapp « spatial IA » centrée sur la cartographie personnal
 - Projet de validation RNCP : stabilité, traçabilité et couverture fonctionnelle démontrables.
 - Droit à l’effacement (RGPD art. 17) : voir [gdpr-account-deletion.md](./gdpr-account-deletion.md).
 - Transactions Prisma (écritures multi-étapes, rollback) : voir [prisma-transactions.md](./prisma-transactions.md).
+- Vérification d’email sur les routes d’écriture : voir [email-verification.md](./email-verification.md).

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -123,6 +123,9 @@ Ci-dessous : **extraits représentatifs** au format attendu par la checklist (en
 | Token JWT invalide                | `Authorization: Bearer invalid-token-123` | HTTP 401                      | ✅ Pass  | idem                                        |
 | Token valide, user existant       | Bearer token signé + user en BDD          | HTTP 200, `user` dans body    | ✅ Pass  | idem                                        |
 | Email non vérifié                 | user `emailVerified: false`               | HTTP 403 sur route protégée   | ✅ Pass  | idem                                        |
+| POST /poi sans email vérifié      | JWT user `emailVerified: false`           | HTTP 403, aucun POI créé      | ✅ Pass  | `apps/api/__test__/poi/routes.test.ts`      |
+| POST /list sans email vérifié     | idem                                      | HTTP 403, aucune liste créée  | ✅ Pass  | `apps/api/__test__/list/routes.test.ts`     |
+| Invite collab. sans email vérifié | idem                                      | HTTP 403                      | ✅ Pass  | idem                                        |
 | Login mot de passe incorrect      | email valide, mauvais password            | HTTP 401                      | ✅ Pass  | `apps/api/__test__/auth/routes.test.ts`     |
 | Refresh token invalide            | cookie `refreshToken=invalid-token`       | HTTP 401                      | ✅ Pass  | idem                                        |
 | Suppression compte + POI et liste | `DELETE /auth/account`, user owner        | HTTP 200, plus de données     | ✅ Pass  | idem                                        |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Wires the unused `requireVerifiedEmail` middleware onto write/email routes instead of deleting it. Login now shows a resend-email panel when the API returns `EMAIL_NOT_VERIFIED`.

Linear: [NIR-100](https://linear.app/nirbyfr/issue/NIR-100/apply-or-remove-unused-email-verification-guard)

## Type of Change

- [x] Bug fix
- [x] Documentation update
- [x] Test update

## Related Issues

Closes #201

## Changes Made

- `requireVerifiedEmail` after `requireAuth` on `POST /poi`, `POST /list`, `POST /list/:id/collaborators/invite` + OpenAPI 403
- Login: unverified account → panel + CTA `resendEmail` (same pattern as signup)
- RNCP write-up in `docs/email-verification.md` (apply vs delete)

## Testing

- [ ] Tested locally with `pnpm dev`
- [x] All quality checks pass (`pnpm -C apps/api lint`, `tsc --noEmit`)
- [x] Unit tests pass (`pnpm -C apps/api test` — 372 tests; `pnpm -C apps/web test` — 399 tests)
- [ ] Database migrations applied if needed (none)

New cases: unverified JWT → 403 and no row created (POI, list, invite); login `EMAIL_NOT_VERIFIED` → resend button, no redirect.

## Screenshots/Videos

N/A

## Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated
- [x] Removed any debug code

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0003a-7bc3-70b8-9e48-3c625d43dc67?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0003a-7bc3-70b8-9e48-3c625d43dc67&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

