### PR TITLE
ci(api): enforce coverage thresholds in ci-api (#189)

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -142,8 +142,8 @@ jobs:
       - name: Type Check API
         run: pnpm -C apps/api exec tsc --noEmit
 
-      - name: Test API
-        run: pnpm -C apps/api test -- --reporter=verbose
+      - name: Test API with Coverage
+        run: pnpm -C apps/api test:coverage -- --reporter=verbose
         env:
           DATABASE_URL: postgresql://nirby:nirby@localhost:5432/nirby_test
           REDIS_URL: redis://localhost:6379
@@ -152,6 +152,13 @@ jobs:
           ACCESS_TOKEN_TTL: 900
           REFRESH_TOKEN_TTL: 604800
           NODE_ENV: test
+
+      - name: Upload API coverage report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: api-coverage-report
+          path: apps/api/coverage
 
   ci-web:
     runs-on: ubuntu-latest
@@ -192,6 +199,13 @@ jobs:
 
       - name: Test Web with Coverage
         run: pnpm -C apps/web test:coverage
+
+      - name: Upload Web coverage report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: web-coverage-report
+          path: apps/web/coverage
 
       - name: Build Web
         run: pnpm -C apps/web build

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -10,7 +10,7 @@ Complète les slides Figma et sert de base si le jury demande les plans de tests
 - **Limiter les régressions** sur les zones à fort impact métier : authentification, permissions, CRUD listes/POI.
 - **Automatiser** l’exécution à chaque PR et push sur `main` / `staging` via GitHub Actions.
 - **Documenter** les scénarios dans le code (`describe` / `it`) et consolider les scénarios représentatifs dans ce fichier.
-- **Mesurer** la couverture front (seuils Vitest) et disposer de rapports CI consultables.
+- **Mesurer** la couverture API et web (seuils Vitest bloquants en CI) et disposer de rapports HTML/JSON en artifacts.
 
 ---
 
@@ -29,7 +29,7 @@ Complète les slides Figma et sert de base si le jury demande les plans de tests
 
 **Rapports de tests :**
 
-- **CI GitHub Actions** : [workflow `ci-cd.yaml`](../.github/workflows/ci-cd.yaml) — logs `--reporter=verbose` (API), rapport de couverture (web).
+- **CI GitHub Actions** : [workflow `ci-cd.yaml`](../.github/workflows/ci-cd.yaml) — couverture bloquante API et web (`test:coverage`), artifacts HTML/JSON.
 - **Badge CI** : visible dans le [README](../README.md).
 - **Couverture locale** : `pnpm -C apps/web test:coverage` et `pnpm -C apps/api test:coverage`.
 
@@ -46,8 +46,8 @@ Complète les slides Figma et sert de base si le jury demande les plans de tests
 ### CI (GitHub Actions)
 
 - Déclenchement : **pull request** et **push** sur `main` / `staging`.
-- Job `ci-api` : PostGIS 16, base `nirby_test`, migrations Prisma, Redis, secrets factices (`JWT_SECRET`, `GOOGLE_PLACES_API_KEY`, …).
-- Job `ci-web` : tests + couverture + build de vérification.
+- Job `ci-api` : PostGIS 16, base `nirby_test`, migrations Prisma, Redis, secrets factices (`JWT_SECRET`, `GOOGLE_PLACES_API_KEY`, …), tests + couverture (seuils 70 %) + artifact `api-coverage-report`.
+- Job `ci-web` : tests + couverture (seuils 36 / 30 / 26) + artifact `web-coverage-report` + build de vérification.
 - Job `api-docker` : image API, health check, scan OWASP ZAP Baseline (rapport artifact).
 - Job `security-audit` : `pnpm audit --audit-level=high` (rapport artifact, non bloquant).
 - Job `web-docker` : image web, health check HTTP.
@@ -197,17 +197,19 @@ Les scénarios ci-dessous couvrent les risques les plus pertinents pour Nirby (A
 
 ### Volume
 
-- **35 fichiers de test** (`apps/api` + `apps/web`), dont `security/owasp.test.ts`.
+- **91 fichiers de test** (`apps/api` 18 + `apps/web` 73), dont `security/owasp.test.ts`.
 - **CI verte** requise pour merge (lint + tests + smoke Docker sur les chemins modifiés).
 
 ### Couverture (seuils Vitest)
 
-| App | Seuils configurés                           | Commande                                                                            |
-| --- | ------------------------------------------- | ----------------------------------------------------------------------------------- |
-| Web | ~36 % lignes, 30 % fonctions, 26 % branches | `pnpm -C apps/web test:coverage` (exécuté en CI)                                    |
-| API | 70 % (config locale)                        | `pnpm -C apps/api test:coverage` (local ; CI exécute les tests sans seuil coverage) |
+| App | Seuils configurés                            | Commande                                                        |
+| --- | -------------------------------------------- | --------------------------------------------------------------- |
+| Web | ~36 % lignes, 30 % fonctions, 26 % branches  | `pnpm -C apps/web test:coverage` (exécuté en CI, artifact HTML) |
+| API | 70 % lignes, fonctions, branches, statements | `pnpm -C apps/api test:coverage` (exécuté en CI, artifact HTML) |
 
 Les seuils web sont volontairement modestes : exclusion des composants UI génériques et du code généré (OpenAPI). L’effort porte sur les **features métier** (listes, auth).
+
+Constat local (août 2026) : API ~80 % statements / ~71 % branches. Le seuil CI à 70 % est un **plancher** : une régression en dessous fait échouer `ci-api`.
 
 ### Exemple de bug détecté et corrigé
 
@@ -235,7 +237,6 @@ _(Adapter la formulation à l’oral si le bug a été trouvé manuellement avan
 | Upload : validation MIME seulement            | Un binaire malveillant avec `Content-Type: image/jpeg` passerait | Ajouter une détection par magic bytes (ex. `file-type`)        |
 | Rate limiting non exercé en tests intégration | `NODE_ENV=test` désactive le blocage réel                        | Tests dédiés avec `NODE_ENV=production` ou tests de charge     |
 | CSRF / SSRF non couverts explicitement        | API stateless JWT ; proxy Google Places côté serveur             | Tests ciblés refresh cookie + validation stricte des URLs      |
-| Couverture API non bloquante en CI            | Seuils 70 % seulement en local                                   | Activer `test:coverage` dans `ci-api`                          |
 | Monitoring prod                               | Health check CI uniquement                                       | Prometheus / alertes HTTP 5xx                                  |
 | Mapbox / carte                                | Non couvert par tests automatisés                                | Tests manuels ou E2E visuels                                   |
 | Pentest manuel absent                         | Pas d’audit humain ni de fuzzing avancé                          | Audit externe avant mise en prod réelle                        |
@@ -248,8 +249,8 @@ _(Adapter la formulation à l’oral si le bug a été trouvé manuellement avan
 # Tous les tests
 pnpm test
 
-# API seule (verbose, comme en CI)
-pnpm -C apps/api test -- --reporter=verbose
+# API seule avec couverture (comme en CI)
+pnpm -C apps/api test:coverage -- --reporter=verbose
 
 # Tests sécurité OWASP uniquement
 pnpm -C apps/api test -- security/owasp
@@ -263,12 +264,13 @@ pnpm -C apps/web test:coverage
 
 **Rapports CI :** GitHub → onglet _Actions_ → workflow _CI/CD_ :
 
-- job `ci-api` / `ci-web` → logs de la step _Test_ ;
+- job `ci-api` → logs + artifact `api-coverage-report` (`apps/api/coverage`) ;
+- job `ci-web` → logs + artifact `web-coverage-report` (`apps/web/coverage`) ;
 - job `security-audit` → artifact `pnpm-audit-report` ;
 - job `api-docker` → artifact `zap-baseline-report` ;
 - onglet _Security_ → alertes **Dependabot**.
 
-**Couverture HTML (local) :** générée dans `apps/web/coverage/` après `test:coverage`.
+**Couverture HTML :** `apps/api/coverage/` et `apps/web/coverage/` après `test:coverage` (local ou artifact CI).
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Description

Makes API coverage thresholds actually block CI: `ci-api` now runs `test:coverage` (70% lines/functions/branches/statements). Coverage HTML/JSON reports for API and web are uploaded as artifacts for the RNCP dossier.

## 🎯 Type of Change

- [x] 📝 Documentation update
- [x] ⚡ Performance improvement
- [x] ✅ Test update

The change is CI/docs: coverage was already configured locally but never enforced on the API job.

## 🔗 Related Issues

Closes #189
Linear: NIR-88

## 🚀 Changes Made

- `ci-api`: `pnpm -C apps/api test:coverage -- --reporter=verbose` + artifact `api-coverage-report`
- `ci-web`: artifact `web-coverage-report` (coverage step already existed)
- Thresholds left at 70% — local run: statements 80.11%, branches 70.76%, functions 87.5%, lines 80.27%
- `docs/test-strategy.md`: 91 test files, CI coverage for both apps, removed the “API coverage not blocking” limit

## 🧪 Testing

- [x] Unit tests pass (`pnpm test`)
- [ ] Tested locally with `pnpm dev`
- [ ] All quality checks pass (`pnpm lint`)
- [ ] Database migrations applied if needed

`pnpm -C apps/api test:coverage` — 18 files, 378 tests, coverage above 70% on all four metrics.

## 📸 Screenshots/Videos

N/A

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated if needed
- [x] No console errors or warnings
- [x] Removed any debug code

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0003a-7bc3-70b8-9e48-3c625d43dc67?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0003a-7bc3-70b8-9e48-3c625d43dc67&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

