### PR TITLE
chore(docker): run api and web as non-root with HEALTHCHECK (#200)

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -281,6 +281,8 @@ jobs:
             nirby-api:ci
           sleep 10
           curl -f http://localhost:4000/health || (docker logs nirby-api-test && exit 1)
+          test "$(docker exec nirby-api-test id -u)" != "0"
+          docker exec nirby-api-test id
 
       - name: OWASP ZAP Baseline Scan
         uses: zaproxy/action-baseline@v0.14.0
@@ -371,6 +373,8 @@ jobs:
             nirby-web:ci
           sleep 10
           curl -f http://localhost:3000 || (docker logs nirby-web-test && exit 1)
+          test "$(docker exec nirby-web-test id -u)" != "0"
+          docker exec nirby-web-test id
 
       - name: Cleanup
         if: always()

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -36,13 +36,18 @@ ENV PATH="$PNPM_HOME:$PATH"
 RUN corepack enable
 
 # Copie toute la structure pnpm
-COPY --from=prod-deps /repo/pnpm-workspace.yaml /repo/package.json /repo/pnpm-lock.yaml /repo/
-COPY --from=prod-deps /repo/node_modules /repo/node_modules
-COPY --from=prod-deps /repo/apps/api/package.json ./package.json
-COPY --from=prod-deps /repo/apps/api/node_modules ./node_modules
-COPY --from=build /repo/apps/api/dist ./dist
-COPY --from=build /repo/apps/api/prisma ./prisma
-COPY --from=prod-deps /repo/apps/api/prisma.config.ts ./prisma.config.ts
+COPY --from=prod-deps --chown=node:node /repo/pnpm-workspace.yaml /repo/package.json /repo/pnpm-lock.yaml /repo/
+COPY --from=prod-deps --chown=node:node /repo/node_modules /repo/node_modules
+COPY --from=prod-deps --chown=node:node /repo/apps/api/package.json ./package.json
+COPY --from=prod-deps --chown=node:node /repo/apps/api/node_modules ./node_modules
+COPY --from=build --chown=node:node /repo/apps/api/dist ./dist
+COPY --from=build --chown=node:node /repo/apps/api/prisma ./prisma
+COPY --from=prod-deps --chown=node:node /repo/apps/api/prisma.config.ts ./prisma.config.ts
 
+RUN chown -R node:node /repo
+
+USER node
 EXPOSE 4000
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:4000/health > /dev/null || exit 1
 CMD ["node", "dist/index.js"]

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -30,9 +30,14 @@ WORKDIR /app
 ENV NODE_ENV=production
 
 # Copy standalone output
-COPY --from=builder /app/apps/web/.next/standalone ./
-COPY --from=builder /app/apps/web/.next/static ./apps/web/.next/static
-COPY --from=builder /app/apps/web/public ./apps/web/public
+COPY --from=builder --chown=node:node /app/apps/web/.next/standalone ./
+COPY --from=builder --chown=node:node /app/apps/web/.next/static ./apps/web/.next/static
+COPY --from=builder --chown=node:node /app/apps/web/public ./apps/web/public
 
+RUN chown -R node:node /app
+
+USER node
 EXPOSE 3000
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:3000/ > /dev/null || exit 1
 CMD ["node", "apps/web/server.js"]

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -20,6 +20,7 @@ Nirby est une webapp « spatial IA » centrée sur la cartographie personnal
 - Interface front en React + Tailwind + shadcn/ui.
 - Backend actuel Express/Prisma/PostgreSQL (PostGIS) + Redis.
 - Projet de validation RNCP : stabilité, traçabilité et couverture fonctionnelle démontrables.
+- Conteneurs API et web en utilisateur non-root (`USER node`) avec `HEALTHCHECK` Docker, aligné sur le rôle DB `nirby_app` (moindre privilège ANSSI).
 - Droit à l’effacement (RGPD art. 17) : voir [gdpr-account-deletion.md](./gdpr-account-deletion.md).
 - Droit à la portabilité (RGPD art. 20) : voir [gdpr-data-export.md](./gdpr-data-export.md).
 - Transactions Prisma (écritures multi-étapes, rollback) : voir [prisma-transactions.md](./prisma-transactions.md).

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -16,16 +16,16 @@ Complète les slides Figma et sert de base si le jury demande les plans de tests
 
 ## 2. Pyramide et outils
 
-| Niveau                   | Outil                            | Périmètre                                                         | Statut                   |
-| ------------------------ | -------------------------------- | ----------------------------------------------------------------- | ------------------------ |
-| Unitaires                | Vitest                           | Règles métier (`list-policy`, `poi-policy`), schémas, utils front | ✅ Implémenté            |
-| Intégration API          | Vitest + Supertest               | Routes Express, middleware auth, base PostgreSQL de test          | ✅ Implémenté            |
-| Composants / pages front | Vitest + Testing Library + jsdom | Vues listes, hooks, formulaires                                   | ✅ Implémenté            |
-| Smoke / health check     | Docker + `curl` (CI)             | Conteneurs API et web démarrent, `/health` et `/` répondent       | ✅ Implémenté            |
-| Sécurité (OWASP)         | Vitest + Supertest               | Injection, IDOR, XSS stocké, upload malveillant                   | ✅ Implémenté            |
-| Audit dépendances (SCA)  | `pnpm audit` + Dependabot        | CVE dans `pnpm-lock.yaml`, PRs de mise à jour hebdomadaires       | ✅ Implémenté            |
-| DAST                     | OWASP ZAP Baseline (CI)          | Scan passif/actif sur l’API Docker en CI                          | ✅ Implémenté            |
-| E2E                      | Playwright                       | Parcours utilisateur complets                                     | ⏳ Prévu, non implémenté |
+| Niveau                   | Outil                                | Périmètre                                                         | Statut                   |
+| ------------------------ | ------------------------------------ | ----------------------------------------------------------------- | ------------------------ |
+| Unitaires                | Vitest                               | Règles métier (`list-policy`, `poi-policy`), schémas, utils front | ✅ Implémenté            |
+| Intégration API          | Vitest + Supertest                   | Routes Express, middleware auth, base PostgreSQL de test          | ✅ Implémenté            |
+| Composants / pages front | Vitest + Testing Library + jsdom     | Vues listes, hooks, formulaires                                   | ✅ Implémenté            |
+| Smoke / health check     | Docker + `curl` (CI) + `HEALTHCHECK` | Conteneurs API et web non-root, `/health` et `/` répondent        | ✅ Implémenté            |
+| Sécurité (OWASP)         | Vitest + Supertest                   | Injection, IDOR, XSS stocké, upload malveillant                   | ✅ Implémenté            |
+| Audit dépendances (SCA)  | `pnpm audit` + Dependabot            | CVE dans `pnpm-lock.yaml`, PRs de mise à jour hebdomadaires       | ✅ Implémenté            |
+| DAST                     | OWASP ZAP Baseline (CI)              | Scan passif/actif sur l’API Docker en CI                          | ✅ Implémenté            |
+| E2E                      | Playwright                           | Parcours utilisateur complets                                     | ⏳ Prévu, non implémenté |
 
 **Rapports de tests :**
 
@@ -48,9 +48,9 @@ Complète les slides Figma et sert de base si le jury demande les plans de tests
 - Déclenchement : **pull request** et **push** sur `main` / `staging`.
 - Job `ci-api` : PostGIS 16, base `nirby_test`, migrations Prisma, Redis, secrets factices (`JWT_SECRET`, `GOOGLE_PLACES_API_KEY`, …), tests + couverture (seuils 70 %) + artifact `api-coverage-report`.
 - Job `ci-web` : tests + couverture (seuils 36 / 30 / 26) + artifact `web-coverage-report` + build de vérification.
-- Job `api-docker` : image API, health check, scan OWASP ZAP Baseline (rapport artifact).
+- Job `api-docker` : image API (`USER node`), health check HTTP + assert uid ≠ 0, scan OWASP ZAP Baseline (rapport artifact).
 - Job `security-audit` : `pnpm audit --audit-level=high` (rapport artifact, non bloquant).
-- Job `web-docker` : image web, health check HTTP.
+- Job `web-docker` : image web (`USER node`), health check HTTP + assert uid ≠ 0.
 - **Dependabot** : PRs hebdomadaires npm, Docker et GitHub Actions (`.github/dependabot.yml`).
 
 Chaque run CI recrée un environnement isolé ; les tests API nettoient les données (`deleteMany` en `beforeEach` / `afterAll`).
@@ -237,7 +237,8 @@ _(Adapter la formulation à l’oral si le bug a été trouvé manuellement avan
 | Upload : validation MIME seulement            | Un binaire malveillant avec `Content-Type: image/jpeg` passerait | Ajouter une détection par magic bytes (ex. `file-type`)        |
 | Rate limiting non exercé en tests intégration | `NODE_ENV=test` désactive le blocage réel                        | Tests dédiés avec `NODE_ENV=production` ou tests de charge     |
 | CSRF / SSRF non couverts explicitement        | API stateless JWT ; proxy Google Places côté serveur             | Tests ciblés refresh cookie + validation stricte des URLs      |
-| Monitoring prod                               | Health check CI uniquement                                       | Prometheus / alertes HTTP 5xx                                  |
+| Conteneurs : pas de drop de capabilities      | `USER node` + HEALTHCHECK suffisent pour le MVP ANSSI            | `cap_drop: ALL` Compose / distroless plus tard                 |
+| Monitoring prod                               | Health check CI + HEALTHCHECK image ; pas d’alerting 5xx         | Prometheus / alertes HTTP 5xx                                  |
 | Mapbox / carte                                | Non couvert par tests automatisés                                | Tests manuels ou E2E visuels                                   |
 | Pentest manuel absent                         | Pas d’audit humain ni de fuzzing avancé                          | Audit externe avant mise en prod réelle                        |
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Description

Runs API and web containers as the unprivileged `node` user (ANSSI least privilege) and adds native Docker `HEALTHCHECK`s. Aligns with the existing `nirby_app` DB role split.

## 🎯 Type of Change

- [x] 📝 Documentation update
- [x] ♻️ Code refactor (no functional changes)

Hardening only: same images, non-root process + healthcheck.

## 🔗 Related Issues

Closes #200
Linear: NIR-99

## 🚀 Changes Made

- `apps/api/Dockerfile` runtime: `--chown=node:node`, `chown -R /repo`, `USER node`, `HEALTHCHECK` on `/health`
- `apps/web/Dockerfile` runner: same for standalone/static/public, `HEALTHCHECK` on `/`
- `api-docker` / `web-docker`: `test "$(docker exec … id -u)" != "0"` after the existing curl smoke checks
- Docs: `test-strategy.md` + `project-overview.md`

## 🧪 Testing

- [ ] Tested locally with `pnpm dev`
- [ ] All quality checks pass (`pnpm lint`)
- [ ] Unit tests pass (`pnpm test`)
- [ ] Database migrations applied if needed

Docker is not available in this agent environment. Validation is the `api-docker` and `web-docker` jobs on this PR (`/health`, port 3000, uid ≠ 0).

## 📸 Screenshots/Videos

N/A

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated if needed
- [x] No console errors or warnings
- [x] Removed any debug code

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0003a-7bc3-70b8-9e48-3c625d43dc67?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0003a-7bc3-70b8-9e48-3c625d43dc67&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

