### PR TITLE
fix(web): allow zoom and add main landmark with skip link

### DIFF
--- a/apps/web/src/app/(auth)/layout.tsx
+++ b/apps/web/src/app/(auth)/layout.tsx
@@ -5,6 +5,7 @@ import { LegalLinks } from "@/components/legal-links";
 import { Logo } from "@/components/logo";
 import { LanguageSelector } from "@/components/ui/language-selector";
 import { isAuthenticated } from "@/features/auth/server";
+import { MAIN_CONTENT_ID } from "@/lib/a11y/landmarks";
 
 export default async function AuthLayout({ children }: { children: React.ReactNode }) {
   const authenticated = await isAuthenticated();
@@ -33,7 +34,9 @@ export default async function AuthLayout({ children }: { children: React.ReactNo
         </div>
       </div>
       <div className="flex min-h-screen flex-col">
-        <div className="flex flex-1 flex-col">{children}</div>
+        <main id={MAIN_CONTENT_ID} tabIndex={-1} className="flex flex-1 flex-col">
+          {children}
+        </main>
         <footer className="px-6 py-4">
           <LegalLinks />
         </footer>

--- a/apps/web/src/app/global-error.test.tsx
+++ b/apps/web/src/app/global-error.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+}));
+
+import GlobalError from "./global-error";
+
+function renderGlobalError(localeCookie: string) {
+  document.cookie = `NEXT_LOCALE=${localeCookie}`;
+  const error = Object.assign(new Error("boom"), { digest: "abc" });
+  render(<GlobalError error={error} reset={vi.fn()} />);
+}
+
+describe("GlobalError", () => {
+  it("renders French copy and lang by default", () => {
+    renderGlobalError("fr");
+
+    expect(document.documentElement).toHaveAttribute("lang", "fr");
+    expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent("Une erreur est survenue");
+    expect(
+      screen.getByText("Une erreur inattendue s'est produite. Veuillez réessayer.")
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Réessayer" })).toBeInTheDocument();
+  });
+
+  it("renders English copy when NEXT_LOCALE is en", () => {
+    renderGlobalError("en");
+
+    expect(document.documentElement).toHaveAttribute("lang", "en");
+    expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent("Something went wrong");
+    expect(screen.getByText("An unexpected error occurred. Please try again.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Try again" })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -3,6 +3,15 @@
 import * as Sentry from "@sentry/nextjs";
 import { useEffect } from "react";
 
+import { getLocaleFromCookieString } from "@/lib/i18n/locale-from-cookie";
+import enCommon from "@/lib/i18n/locales/en/common.json";
+import frCommon from "@/lib/i18n/locales/fr/common.json";
+
+const messages = {
+  fr: frCommon,
+  en: enCommon,
+} as const;
+
 export default function GlobalError({
   error,
   reset,
@@ -14,19 +23,20 @@ export default function GlobalError({
     Sentry.captureException(error);
   }, [error]);
 
+  const locale = getLocaleFromCookieString(typeof document === "undefined" ? "" : document.cookie);
+  const t = messages[locale].globalError;
+
   return (
-    <html lang="en">
+    <html lang={locale}>
       <body className="flex min-h-screen flex-col items-center justify-center gap-4 p-6 font-sans">
-        <h2 className="text-lg font-semibold">Something went wrong</h2>
-        <p className="text-muted-foreground text-center text-sm">
-          An unexpected error occurred. Please try again.
-        </p>
+        <h2 className="text-lg font-semibold">{t.title}</h2>
+        <p className="text-muted-foreground text-center text-sm">{t.description}</p>
         <button
           type="button"
           className="rounded-md bg-black px-4 py-2 text-sm text-white dark:bg-white dark:text-black"
           onClick={() => reset()}
         >
-          Try again
+          {t.retry}
         </button>
       </body>
     </html>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,9 +1,10 @@
 import type { Metadata, Viewport } from "next";
 import { Poppins, Quicksand } from "next/font/google";
 import { NextIntlClientProvider } from "next-intl";
-import { getMessages, getLocale } from "next-intl/server";
+import { getMessages, getLocale, getTranslations } from "next-intl/server";
 import { ThemeProvider } from "next-themes";
 
+import { SkipLink } from "@/components/skip-link";
 import { ToasterWrapper } from "@/components/ui";
 import { AuthProvider } from "@/features/auth";
 import { QueryProvider } from "@/lib/query-client";
@@ -36,7 +37,6 @@ export const metadata: Metadata = {
 export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
-  maximumScale: 1,
   viewportFit: "cover",
 };
 
@@ -47,6 +47,7 @@ export default async function RootLayout({
 }>) {
   const locale = await getLocale();
   const messages = await getMessages();
+  const t = await getTranslations("common");
 
   return (
     <html lang={locale} suppressHydrationWarning>
@@ -54,6 +55,7 @@ export default async function RootLayout({
         className={`${poppins.variable} ${quicksand.variable} font-sans antialiased`}
         suppressHydrationWarning
       >
+        <SkipLink>{t("skipLink")}</SkipLink>
         <NextIntlClientProvider messages={messages}>
           <ThemeProvider
             attribute="class"

--- a/apps/web/src/app/list/layout.tsx
+++ b/apps/web/src/app/list/layout.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 
 import { Logo } from "@/components/logo";
 import { LanguageSelector } from "@/components/ui/language-selector";
+import { MAIN_CONTENT_ID } from "@/lib/a11y/landmarks";
 
 export default function ListJoinLayout({ children }: { children: React.ReactNode }) {
   return (
@@ -15,7 +16,9 @@ export default function ListJoinLayout({ children }: { children: React.ReactNode
           <LanguageSelector />
         </div>
       </header>
-      <main className="mx-auto max-w-2xl px-4 py-8">{children}</main>
+      <main id={MAIN_CONTENT_ID} tabIndex={-1} className="mx-auto max-w-2xl px-4 py-8">
+        {children}
+      </main>
     </div>
   );
 }

--- a/apps/web/src/app/mentions/page.tsx
+++ b/apps/web/src/app/mentions/page.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { getTranslations } from "next-intl/server";
 
+import { MAIN_CONTENT_ID } from "@/lib/a11y/landmarks";
+
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations("legal");
   return {
@@ -16,7 +18,7 @@ export default async function MentionsPage() {
 
   return (
     <div className="bg-background text-foreground min-h-screen">
-      <div className="mx-auto max-w-2xl px-4 py-10 sm:py-14">
+      <main id={MAIN_CONTENT_ID} tabIndex={-1} className="mx-auto max-w-2xl px-4 py-10 sm:py-14">
         <p className="text-muted-foreground mb-8 rounded-lg border border-border bg-muted/30 px-4 py-3 text-sm">
           <strong className="text-foreground">{t("disclaimer.title")}</strong> —{" "}
           {t("disclaimer.mentions")}
@@ -100,7 +102,7 @@ export default async function MentionsPage() {
             {tCommon("legal.privacy")}
           </Link>
         </footer>
-      </div>
+      </main>
     </div>
   );
 }

--- a/apps/web/src/app/privacy/page.tsx
+++ b/apps/web/src/app/privacy/page.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { getTranslations } from "next-intl/server";
 
+import { MAIN_CONTENT_ID } from "@/lib/a11y/landmarks";
+
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations("legal");
   return {
@@ -16,7 +18,7 @@ export default async function PrivacyPage() {
 
   return (
     <div className="bg-background text-foreground min-h-screen">
-      <div className="mx-auto max-w-2xl px-4 py-10 sm:py-14">
+      <main id={MAIN_CONTENT_ID} tabIndex={-1} className="mx-auto max-w-2xl px-4 py-10 sm:py-14">
         <p className="text-muted-foreground mb-8 rounded-lg border border-border bg-muted/30 px-4 py-3 text-sm">
           <strong className="text-foreground">{t("disclaimer.title")}</strong> —{" "}
           {t("disclaimer.privacy")}
@@ -102,7 +104,7 @@ export default async function PrivacyPage() {
             {tCommon("legal.mentions")}
           </Link>
         </footer>
-      </div>
+      </main>
     </div>
   );
 }

--- a/apps/web/src/app/shared/layout.tsx
+++ b/apps/web/src/app/shared/layout.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 
 import { Logo } from "@/components/logo";
 import { LanguageSelector } from "@/components/ui/language-selector";
+import { MAIN_CONTENT_ID } from "@/lib/a11y/landmarks";
 
 export default function SharedLayout({ children }: { children: React.ReactNode }) {
   return (
@@ -15,7 +16,9 @@ export default function SharedLayout({ children }: { children: React.ReactNode }
           <LanguageSelector />
         </div>
       </header>
-      <main className="mx-auto max-w-2xl px-4 py-8">{children}</main>
+      <main id={MAIN_CONTENT_ID} tabIndex={-1} className="mx-auto max-w-2xl px-4 py-8">
+        {children}
+      </main>
     </div>
   );
 }

--- a/apps/web/src/components/index.ts
+++ b/apps/web/src/components/index.ts
@@ -1,3 +1,4 @@
 export * from "./ui";
 export * from "./logo";
 export * from "./legal-links";
+export * from "./skip-link";

--- a/apps/web/src/components/skip-link.test.tsx
+++ b/apps/web/src/components/skip-link.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { SkipLink } from "./skip-link";
+
+import { MAIN_CONTENT_ID } from "@/lib/a11y/landmarks";
+
+describe("SkipLink", () => {
+  it("points at the main landmark id", () => {
+    render(<SkipLink>skipLink</SkipLink>);
+
+    expect(screen.getByRole("link", { name: "skipLink" })).toHaveAttribute(
+      "href",
+      `#${MAIN_CONTENT_ID}`
+    );
+  });
+});

--- a/apps/web/src/components/skip-link.tsx
+++ b/apps/web/src/components/skip-link.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from "react";
+
+import { MAIN_CONTENT_ID } from "@/lib/a11y/landmarks";
+
+type SkipLinkProps = {
+  children: ReactNode;
+};
+
+export function SkipLink({ children }: SkipLinkProps) {
+  return (
+    <a
+      href={`#${MAIN_CONTENT_ID}`}
+      className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-popover focus:rounded-md focus:bg-background focus:px-4 focus:py-3 focus:text-sm focus:font-semibold focus:text-foreground focus:shadow-lg focus:ring-2 focus:ring-ring focus:outline-none"
+    >
+      {children}
+    </a>
+  );
+}

--- a/apps/web/src/features/app-shell/components/app-shell.component.test.tsx
+++ b/apps/web/src/features/app-shell/components/app-shell.component.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const replace = vi.fn();
+const push = vi.fn();
+let searchParams = new URLSearchParams();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push, replace, prefetch: vi.fn(), back: vi.fn() }),
+  usePathname: () => "/",
+  useSearchParams: () => searchParams,
+}));
+
+vi.mock("@/features/auth", () => ({
+  AuthGate: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+import { AppShell } from "./app-shell.component";
+
+import { MAIN_CONTENT_ID } from "@/lib/a11y/landmarks";
+
+const stubViews = {
+  explore: () => <div>Explore</div>,
+  lists: () => <div>Lists</div>,
+  profile: () => <div>Profile</div>,
+};
+
+describe("AppShell landmarks", () => {
+  beforeEach(() => {
+    replace.mockClear();
+    push.mockClear();
+    searchParams = new URLSearchParams();
+  });
+
+  it("exposes a single main landmark with a skip-link target id", () => {
+    render(<AppShell viewComponents={stubViews} />);
+
+    const mains = screen.getAllByRole("main");
+    expect(mains).toHaveLength(1);
+    expect(mains[0]).toHaveAttribute("id", MAIN_CONTENT_ID);
+  });
+});

--- a/apps/web/src/features/app-shell/components/app-shell.component.tsx
+++ b/apps/web/src/features/app-shell/components/app-shell.component.tsx
@@ -9,6 +9,8 @@ import { DesktopShell } from "./desktop/desktop-shell.component";
 import { MobileShell } from "./mobile/mobile-shell.component";
 import { ShellOverlay } from "./shared/shell-overlay.component";
 
+import { MAIN_CONTENT_ID } from "@/lib/a11y/landmarks";
+
 type AppShellProps = {
   viewComponents: Record<ShellView, ComponentType>;
 };
@@ -18,8 +20,10 @@ export function AppShell({ viewComponents }: AppShellProps) {
     <Suspense fallback={null}>
       <ShellProvider>
         <ShellOverlay>
-          <DesktopShell viewComponents={viewComponents} />
-          <MobileShell viewComponents={viewComponents} />
+          <main id={MAIN_CONTENT_ID} tabIndex={-1} className="h-full">
+            <DesktopShell viewComponents={viewComponents} />
+            <MobileShell viewComponents={viewComponents} />
+          </main>
         </ShellOverlay>
       </ShellProvider>
     </Suspense>

--- a/apps/web/src/lib/a11y/landmarks.ts
+++ b/apps/web/src/lib/a11y/landmarks.ts
@@ -1,0 +1,2 @@
+/** Target id for the page `<main>` landmark and the skip link (`href="#main-content"`). */
+export const MAIN_CONTENT_ID = "main-content";

--- a/apps/web/src/lib/i18n/locale-from-cookie.test.ts
+++ b/apps/web/src/lib/i18n/locale-from-cookie.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { getLocaleFromCookieString } from "./locale-from-cookie";
+
+describe("getLocaleFromCookieString", () => {
+  it("falls back to French when the cookie is missing or invalid", () => {
+    expect(getLocaleFromCookieString("")).toBe("fr");
+    expect(getLocaleFromCookieString("theme=dark")).toBe("fr");
+    expect(getLocaleFromCookieString("NEXT_LOCALE=de")).toBe("fr");
+  });
+
+  it("reads NEXT_LOCALE among other cookies", () => {
+    expect(getLocaleFromCookieString("theme=dark; NEXT_LOCALE=en; other=1")).toBe("en");
+    expect(getLocaleFromCookieString("NEXT_LOCALE=fr")).toBe("fr");
+  });
+});

--- a/apps/web/src/lib/i18n/locale-from-cookie.ts
+++ b/apps/web/src/lib/i18n/locale-from-cookie.ts
@@ -1,0 +1,17 @@
+import { defaultLocale, locales, type Locale } from "./constants";
+
+export function getLocaleFromCookieString(cookie: string): Locale {
+  const match = cookie.match(/(?:^|; )NEXT_LOCALE=([^;]*)/);
+  if (!match?.[1]) {
+    return defaultLocale;
+  }
+
+  let value = match[1].trim();
+  try {
+    value = decodeURIComponent(value);
+  } catch {
+    return defaultLocale;
+  }
+
+  return locales.includes(value as Locale) ? (value as Locale) : defaultLocale;
+}

--- a/apps/web/src/lib/i18n/locales-parity.test.tsx
+++ b/apps/web/src/lib/i18n/locales-parity.test.tsx
@@ -85,6 +85,10 @@ const NEW_COMMON_KEYS = [
   "legal.home",
   "legal.privacy",
   "legal.mentions",
+  "skipLink",
+  "globalError.title",
+  "globalError.description",
+  "globalError.retry",
 ] as const;
 
 const NEW_LEGAL_KEYS = [
@@ -213,5 +217,17 @@ describe("message resolution", () => {
     expect(tLegal("privacy.title")).toBe("Privacy policy");
     expect(tLegal("mentions.title")).toBe("Legal notice");
     expect(tLegal("disclaimer.title")).toBe("Sample content");
+  });
+
+  it("resolves skip link and global error keys", () => {
+    const tCommon = createTranslator({
+      locale: "en",
+      messages: { common: enCommon },
+      namespace: "common",
+    });
+
+    expect(tCommon("skipLink")).toBe("Skip to content");
+    expect(tCommon("globalError.title")).toBe("Something went wrong");
+    expect(tCommon("globalError.retry")).toBe("Try again");
   });
 });

--- a/apps/web/src/lib/i18n/locales/en/common.json
+++ b/apps/web/src/lib/i18n/locales/en/common.json
@@ -32,5 +32,11 @@
     "home": "Home",
     "privacy": "Privacy policy",
     "mentions": "Legal notice"
+  },
+  "skipLink": "Skip to content",
+  "globalError": {
+    "title": "Something went wrong",
+    "description": "An unexpected error occurred. Please try again.",
+    "retry": "Try again"
   }
 }

--- a/apps/web/src/lib/i18n/locales/fr/common.json
+++ b/apps/web/src/lib/i18n/locales/fr/common.json
@@ -32,5 +32,11 @@
     "home": "Accueil",
     "privacy": "Politique de confidentialité",
     "mentions": "Mentions légales"
+  },
+  "skipLink": "Aller au contenu",
+  "globalError": {
+    "title": "Une erreur est survenue",
+    "description": "Une erreur inattendue s'est produite. Veuillez réessayer.",
+    "retry": "Réessayer"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Fixes RGAA gaps from [#194](https://github.com/brissboss/Nirby/issues/194) / NIR-93: page zoom was blocked, the primary app shell had no `<main>` landmark, there was no skip link, and the global error page was hardcoded in English.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Style/UI update (no functional changes)
- [ ] Code refactor
- [ ] Performance improvement
- [x] Test update

## Related Issues

Closes #194

## Changes Made

- Remove `maximumScale: 1` from the root viewport (keep `viewportFit: "cover"` for iOS safe areas).
- Add a single `<main id="main-content" tabIndex={-1}>` in `AppShell` wrapping desktop and mobile chrome (both are always mounted; one `id` avoids duplicates).
- Reuse the same `id` on list, shared, auth, privacy, and mentions routes so the skip link always has a target.
- Add a skip link as the first child of `body`, visually hidden until focus (`z-popover` so it sits above the shell).
- i18n: `common.skipLink` and `common.globalError.*` in fr/en.
- Internationalize `global-error.tsx` from the `NEXT_LOCALE` cookie (this boundary replaces the root layout, so next-intl is not available).

## Testing

- [ ] Tested locally with `pnpm dev`
- [x] All quality checks pass (`pnpm lint` on changed files)
- [x] Unit tests pass (`pnpm test` in `apps/web` — 416 tests)
- [ ] Database migrations applied if needed

Automated:

- AppShell exposes a single `main#main-content`
- Skip link `href="#main-content"`
- Global error FR/EN from cookie
- Locale parity for the new common keys

Manual (please verify on review):

- Tab from page load focuses the skip link first; Enter moves focus to main content
- 200% zoom on mobile and desktop (bottom sheet / iOS safe areas)

## Screenshots/Videos

N/A

## Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated if needed
- [x] No console errors or warnings
- [x] Removed any debug code

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0003a-7bc3-70b8-9e48-3c625d43dc67?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0003a-7bc3-70b8-9e48-3c625d43dc67&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

