### PR TITLE
fix(web): add aria-current to shell view navigation

### DIFF
--- a/apps/web/src/features/app-shell/components/shared/view-tabs.component.test.tsx
+++ b/apps/web/src/features/app-shell/components/shared/view-tabs.component.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import type { ShellView } from "../../types/shell.types";
+
+import { ViewTabs } from "./view-tabs.component";
+
+function renderTabs(value: ShellView, onChange = vi.fn(), mobile = false) {
+  return render(<ViewTabs value={value} onChange={onChange} mobile={mobile} />);
+}
+
+function viewButton(name: string) {
+  return screen.getByRole("button", { name });
+}
+
+describe("ViewTabs", () => {
+  it("marks only the active view with aria-current=page", () => {
+    renderTabs("explore");
+
+    expect(viewButton("tabs.explore")).toHaveAttribute("aria-current", "page");
+    expect(viewButton("tabs.lists")).not.toHaveAttribute("aria-current");
+    expect(viewButton("tabs.profile")).not.toHaveAttribute("aria-current");
+  });
+
+  it("moves aria-current when the active view changes", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const { rerender } = renderTabs("explore", onChange);
+
+    await user.click(viewButton("tabs.lists"));
+
+    expect(onChange).toHaveBeenCalledWith("lists");
+
+    rerender(<ViewTabs value="lists" onChange={onChange} />);
+
+    expect(viewButton("tabs.lists")).toHaveAttribute("aria-current", "page");
+    expect(viewButton("tabs.explore")).not.toHaveAttribute("aria-current");
+    expect(viewButton("tabs.profile")).not.toHaveAttribute("aria-current");
+  });
+
+  it("labels the navigation landmark", () => {
+    renderTabs("explore");
+
+    expect(screen.getByRole("navigation", { name: "tabs.navLabel" })).toBeInTheDocument();
+  });
+
+  it("keeps the same ARIA on the mobile variant", () => {
+    renderTabs("profile", vi.fn(), true);
+
+    expect(screen.getByRole("navigation", { name: "tabs.navLabel" })).toBeInTheDocument();
+    expect(viewButton("tabs.profile")).toHaveAttribute("aria-current", "page");
+    expect(viewButton("tabs.explore")).not.toHaveAttribute("aria-current");
+    expect(viewButton("tabs.lists")).not.toHaveAttribute("aria-current");
+  });
+});

--- a/apps/web/src/features/app-shell/components/shared/view-tabs.component.tsx
+++ b/apps/web/src/features/app-shell/components/shared/view-tabs.component.tsx
@@ -17,7 +17,11 @@ export function ViewTabs({ value, onChange, mobile = false }: ViewTabsProps) {
   const t = useTranslations("shell");
 
   return (
-    <nav className={cn("grid grid-cols-3 gap-2 px-4 pb-4", mobile && "px-0 pb-0")}>
+    // URL-driven app views (`?view=`), not in-page tabpanels — use aria-current, not tablist.
+    <nav
+      aria-label={t("tabs.navLabel")}
+      className={cn("grid grid-cols-3 gap-2 px-4 pb-4", mobile && "px-0 pb-0")}
+    >
       {SHELL_VIEWS.map((item) => {
         const Icon = item.icon;
         const isActive = value === item.id;
@@ -26,6 +30,7 @@ export function ViewTabs({ value, onChange, mobile = false }: ViewTabsProps) {
           <button
             key={item.id}
             type="button"
+            aria-current={isActive ? "page" : undefined}
             onClick={() => onChange(item.id)}
             className={cn(
               "flex items-center justify-center gap-2 rounded-2xl px-3 py-2.5 text-sm font-semibold transition",

--- a/apps/web/src/lib/i18n/locales-parity.test.tsx
+++ b/apps/web/src/lib/i18n/locales-parity.test.tsx
@@ -6,11 +6,13 @@ import enExplore from "./locales/en/explore.json";
 import enLegal from "./locales/en/legal.json";
 import enLists from "./locales/en/lists.json";
 import enPoi from "./locales/en/poi.json";
+import enShell from "./locales/en/shell.json";
 import frCommon from "./locales/fr/common.json";
 import frExplore from "./locales/fr/explore.json";
 import frLegal from "./locales/fr/legal.json";
 import frLists from "./locales/fr/lists.json";
 import frPoi from "./locales/fr/poi.json";
+import frShell from "./locales/fr/shell.json";
 
 type JsonObject = Record<string, unknown>;
 
@@ -126,6 +128,8 @@ const NEW_POI_KEYS = [
   "updatePoi.error",
 ] as const;
 
+const NEW_SHELL_KEYS = ["tabs.navLabel"] as const;
+
 function expectNonEmptyStrings(obj: JsonObject, keys: readonly string[], locale: string) {
   for (const key of keys) {
     const value = getValue(obj, key);
@@ -155,6 +159,10 @@ describe("locales parity", () => {
     expectLocaleParity(enCommon, frCommon, "common");
   });
 
+  it("shell.json has the same keys in en and fr", () => {
+    expectLocaleParity(enShell, frShell, "shell");
+  });
+
   it("new lists keys are non-empty strings in both locales", () => {
     expectNonEmptyStrings(enLists, NEW_LISTS_KEYS, "en");
     expectNonEmptyStrings(frLists, NEW_LISTS_KEYS, "fr");
@@ -178,6 +186,11 @@ describe("locales parity", () => {
   it("new common legal keys are non-empty strings in both locales", () => {
     expectNonEmptyStrings(enCommon, NEW_COMMON_KEYS, "en");
     expectNonEmptyStrings(frCommon, NEW_COMMON_KEYS, "fr");
+  });
+
+  it("new shell keys are non-empty strings in both locales", () => {
+    expectNonEmptyStrings(enShell, NEW_SHELL_KEYS, "en");
+    expectNonEmptyStrings(frShell, NEW_SHELL_KEYS, "fr");
   });
 
   it("does not keep the removed detail.poisComingSoon key", () => {
@@ -229,5 +242,16 @@ describe("message resolution", () => {
     expect(tCommon("skipLink")).toBe("Skip to content");
     expect(tCommon("globalError.title")).toBe("Something went wrong");
     expect(tCommon("globalError.retry")).toBe("Try again");
+  });
+
+  it("resolves shell namespace", () => {
+    const tShell = createTranslator({
+      locale: "en",
+      messages: { shell: enShell },
+      namespace: "shell",
+    });
+
+    expect(tShell("tabs.navLabel")).toBe("Main navigation");
+    expect(tShell("tabs.explore")).toBe("Explore");
   });
 });

--- a/apps/web/src/lib/i18n/locales/en/shell.json
+++ b/apps/web/src/lib/i18n/locales/en/shell.json
@@ -9,6 +9,7 @@
   "tabs": {
     "explore": "Explore",
     "lists": "Lists",
-    "profile": "Profile"
+    "profile": "Profile",
+    "navLabel": "Main navigation"
   }
 }

--- a/apps/web/src/lib/i18n/locales/fr/shell.json
+++ b/apps/web/src/lib/i18n/locales/fr/shell.json
@@ -9,6 +9,7 @@
   "tabs": {
     "explore": "Explorer",
     "lists": "Listes",
-    "profile": "Profil"
+    "profile": "Profil",
+    "navLabel": "Navigation principale"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds ARIA semantics to the shell view switcher (Explore / Lists / Profile) so screen readers can tell which view is current. Fixes [#195](https://github.com/brissboss/Nirby/issues/195) / NIR-94.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Style/UI update (no functional changes)
- [ ] Code refactor
- [ ] Performance improvement
- [x] Test update

## Related Issues

Closes #195

## Changes Made

- Pattern chosen: `<nav>` + `aria-current="page"` (not `role="tablist"`). The switcher changes the URL (`?view=`), with no associated tabpanel — documented in a comment on the component.
- Active control gets `aria-current="page"`; inactive controls omit the attribute.
- `aria-label` on the `<nav>` (`shell.tabs.navLabel`: « Navigation principale » / « Main navigation »).
- Desktop sidebar and mobile bottom sheet already share `ViewTabs`; no layout changes.

## Testing

- [ ] Tested locally with `pnpm dev`
- [x] Lint on changed files
- [x] Unit tests pass (`pnpm test` in `apps/web` — 423 tests)

Automated:

- Only the active view has `aria-current="page"`
- Clicking another view moves the attribute
- Nav landmark is labelled
- Same ARIA on the `mobile` variant
- `shell.json` locale parity

Manual: VoiceOver / NVDA should announce the current view in the main navigation.

## Screenshots/Videos

N/A

## Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated if needed
- [x] No console errors or warnings
- [x] Removed any debug code

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0003a-7bc3-70b8-9e48-3c625d43dc67?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0003a-7bc3-70b8-9e48-3c625d43dc67&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

