### PR TITLE
test(web): add jsx-a11y recommended rules and axe checks

### DIFF
--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -2,10 +2,18 @@ import { defineConfig, globalIgnores } from "eslint/config";
 import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
 import importPlugin from "eslint-plugin-import";
+import jsxA11y from "eslint-plugin-jsx-a11y";
 
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
+  {
+    rules: {
+      ...jsxA11y.flatConfigs.recommended.rules,
+      // `role` on React components is a domain prop (OWNER/EDITOR), not an ARIA role.
+      "jsx-a11y/aria-role": ["error", { ignoreNonDOM: true }],
+    },
+  },
   // Override default ignores of eslint-config-next.
   globalIgnores([
     // Default ignores of eslint-config-next:

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -56,11 +56,13 @@
     "@vitest/ui": "4.1.8",
     "eslint": "^9.39.4",
     "eslint-config-next": "16.2.6",
+    "eslint-plugin-jsx-a11y": "^6.10.2",
     "jsdom": "^27.4.0",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5",
     "vite": "7.3.2",
-    "vitest": "^4.1.8"
+    "vitest": "^4.1.8",
+    "vitest-axe": "^0.1.0"
   }
 }

--- a/apps/web/src/app/(auth)/login/page.test.tsx
+++ b/apps/web/src/app/(auth)/login/page.test.tsx
@@ -4,6 +4,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import LoginPage from "./page";
 
+import { expectNoAxeViolations } from "@/test/axe";
+
 const push = vi.fn();
 const login = vi.fn();
 const resendEmail = vi.fn();
@@ -133,5 +135,17 @@ describe("LoginPage email verification", () => {
     await waitFor(() => {
       expect(resendEmail).toHaveBeenCalledWith("user@example.com");
     });
+  });
+});
+
+describe("LoginPage accessibility", () => {
+  beforeEach(() => {
+    searchParams = new URLSearchParams();
+  });
+
+  it("has no axe violations", async () => {
+    const { container } = render(<LoginPage />);
+
+    await expectNoAxeViolations(container);
   });
 });

--- a/apps/web/src/features/lists/views/lists-detail-view.test.tsx
+++ b/apps/web/src/features/lists/views/lists-detail-view.test.tsx
@@ -11,6 +11,7 @@ import { ListsDetailView } from "./lists-detail-view";
 import type { MapPoi } from "@/features/pois";
 import type { ListWithRole } from "@/lib/api";
 import { getErrorCode } from "@/lib/api/errors";
+import { expectNoAxeViolations } from "@/test/axe";
 
 vi.mock("../hooks/use-list", () => ({
   useList: vi.fn(),
@@ -332,5 +333,15 @@ describe("ListsDetailView", () => {
     render(<ListsDetailView listId="list-1" onBack={onBack} onEdit={onEdit} onDelete={onDelete} />);
 
     expect(screen.getByTestId("poi-markers-layer")).toHaveAttribute("data-ids", "");
+  });
+
+  it("has no axe violations when the list is loaded", async () => {
+    mockListQuery();
+
+    const { container } = render(
+      <ListsDetailView listId="list-1" onBack={onBack} onEdit={onEdit} onDelete={onDelete} />
+    );
+
+    await expectNoAxeViolations(container);
   });
 });

--- a/apps/web/src/features/lists/views/lists-index-view.test.tsx
+++ b/apps/web/src/features/lists/views/lists-index-view.test.tsx
@@ -7,6 +7,7 @@ import { useListsInfinite } from "../hooks/use-lists-infinite";
 import { ListsIndexView } from "./lists-index-view";
 
 import type { ListWithRole } from "@/lib/api";
+import { expectNoAxeViolations } from "@/test/axe";
 
 vi.mock("../hooks/use-lists-infinite", () => ({
   useListsInfinite: vi.fn(),
@@ -167,5 +168,25 @@ describe("ListsIndexView", () => {
     await user.click(screen.getByRole("button", { name: /Paris spots/i }));
 
     expect(onSelectList).toHaveBeenCalledWith("list-1");
+  });
+});
+
+describe("ListsIndexView accessibility", () => {
+  it("has no axe violations with lists loaded", async () => {
+    mockInfiniteQuery({
+      data: {
+        pageParams: [1],
+        pages: [
+          {
+            lists: [mockList, mockList2],
+            pagination: { page: 1, limit: 20, total: 2, totalPages: 1 },
+          },
+        ],
+      },
+    });
+
+    const { container } = render(<ListsIndexView onCreate={vi.fn()} onSelectList={vi.fn()} />);
+
+    await expectNoAxeViolations(container);
   });
 });

--- a/apps/web/src/features/pois/forms/create-poi-form.test.tsx
+++ b/apps/web/src/features/pois/forms/create-poi-form.test.tsx
@@ -9,6 +9,7 @@ import { useUploadPoiPhoto } from "../hooks/use-upload-poi-photo";
 import { CreatePoiForm } from "./create-poi-form";
 
 import { useAddPoiToList, useLists } from "@/features/lists";
+import { expectNoAxeViolations } from "@/test/axe";
 
 vi.mock("../hooks/use-create-poi", () => ({
   useCreatePoi: vi.fn(),
@@ -296,5 +297,13 @@ describe("CreatePoiForm", () => {
     expect(createPoi).toHaveBeenCalled();
     expect(closeDialog).not.toHaveBeenCalled();
     expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it("has no axe violations", async () => {
+    const { container } = render(
+      <CreatePoiForm coordinates={coordinates} closeDialog={closeDialog} />
+    );
+
+    await expectNoAxeViolations(container);
   });
 });

--- a/apps/web/src/features/pois/forms/poi-form-fields.tsx
+++ b/apps/web/src/features/pois/forms/poi-form-fields.tsx
@@ -201,6 +201,7 @@ export function PoiFormFields({
           accept="image/jpeg, image/png, image/webp"
           className="hidden"
           disabled={disabled}
+          aria-label={tPoi("photo.title")}
           onChange={(event) => {
             onPhotoChange(event.target.files?.[0] ?? null);
             event.target.value = "";
@@ -219,7 +220,7 @@ export function PoiFormFields({
             disabled={disabled}
             onClick={() => photoInputRef.current?.click()}
           >
-            <ImagePlusIcon className="size-4" />
+            <ImagePlusIcon className="size-4" aria-hidden />
             {existingPhotoUrl ? tPoi("photo.replaceHint") : tPoi("photo.hint")}
           </Button>
           {photoFile ? (

--- a/apps/web/src/test/axe.ts
+++ b/apps/web/src/test/axe.ts
@@ -1,0 +1,15 @@
+import { expect } from "vitest";
+import { axe } from "vitest-axe";
+
+/** jsdom cannot compute contrast; component tests omit page landmarks (`<main>`). */
+const jsdomAxeOptions = {
+  rules: {
+    "color-contrast": { enabled: false },
+    region: { enabled: false },
+  },
+};
+
+export async function expectNoAxeViolations(container: HTMLElement) {
+  const results = await axe(container, jsdomAxeOptions);
+  expect(results).toHaveNoViolations();
+}

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -1,6 +1,9 @@
 import "@testing-library/jest-dom";
 import { cleanup } from "@testing-library/react";
-import { afterEach, vi } from "vitest";
+import { afterEach, expect, vi } from "vitest";
+import * as axeMatchers from "vitest-axe/matchers";
+
+expect.extend(axeMatchers);
 
 afterEach(() => {
   cleanup();
@@ -8,6 +11,10 @@ afterEach(() => {
 
 // jsdom ships no matchMedia: default every media query to "does not match" so components
 // relying on `useMediaQuery` render their base variant instead of throwing.
+if (typeof document !== "undefined") {
+  document.documentElement.lang = "en";
+}
+
 if (typeof window !== "undefined" && !window.matchMedia) {
   window.matchMedia = (query: string) =>
     ({

--- a/apps/web/vitest-env.d.ts
+++ b/apps/web/vitest-env.d.ts
@@ -1,2 +1,3 @@
 /// <reference types="vitest/globals" />
+/// <reference types="vitest-axe/extend-expect" />
 import "@testing-library/jest-dom";

--- a/apps/web/vitest-env.d.ts
+++ b/apps/web/vitest-env.d.ts
@@ -1,3 +1,11 @@
 /// <reference types="vitest/globals" />
-/// <reference types="vitest-axe/extend-expect" />
 import "@testing-library/jest-dom";
+
+declare module "vitest" {
+  interface Assertion {
+    toHaveNoViolations(): void;
+  }
+  interface AsymmetricMatchersContaining {
+    toHaveNoViolations(): void;
+  }
+}

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -16,16 +16,17 @@ Complète les slides Figma et sert de base si le jury demande les plans de tests
 
 ## 2. Pyramide et outils
 
-| Niveau                   | Outil                                | Périmètre                                                         | Statut                   |
-| ------------------------ | ------------------------------------ | ----------------------------------------------------------------- | ------------------------ |
-| Unitaires                | Vitest                               | Règles métier (`list-policy`, `poi-policy`), schémas, utils front | ✅ Implémenté            |
-| Intégration API          | Vitest + Supertest                   | Routes Express, middleware auth, base PostgreSQL de test          | ✅ Implémenté            |
-| Composants / pages front | Vitest + Testing Library + jsdom     | Vues listes, hooks, formulaires                                   | ✅ Implémenté            |
-| Smoke / health check     | Docker + `curl` (CI) + `HEALTHCHECK` | Conteneurs API et web non-root, `/health` et `/` répondent        | ✅ Implémenté            |
-| Sécurité (OWASP)         | Vitest + Supertest                   | Injection, IDOR, XSS stocké, upload malveillant                   | ✅ Implémenté            |
-| Audit dépendances (SCA)  | `pnpm audit` + Dependabot            | CVE dans `pnpm-lock.yaml`, PRs de mise à jour hebdomadaires       | ✅ Implémenté            |
-| DAST                     | OWASP ZAP Baseline (CI)              | Scan passif/actif sur l’API Docker en CI                          | ✅ Implémenté            |
-| E2E                      | Playwright                           | Parcours utilisateur complets                                     | ⏳ Prévu, non implémenté |
+| Niveau                   | Outil                                | Périmètre                                                                  | Statut                   |
+| ------------------------ | ------------------------------------ | -------------------------------------------------------------------------- | ------------------------ |
+| Unitaires                | Vitest                               | Règles métier (`list-policy`, `poi-policy`), schémas, utils front          | ✅ Implémenté            |
+| Intégration API          | Vitest + Supertest                   | Routes Express, middleware auth, base PostgreSQL de test                   | ✅ Implémenté            |
+| Composants / pages front | Vitest + Testing Library + jsdom     | Vues listes, hooks, formulaires                                            | ✅ Implémenté            |
+| Accessibilité            | ESLint `jsx-a11y` recommended + axe  | Login, index/détail listes, create POI (jsdom ; pas les primitives shadcn) | ✅ Implémenté            |
+| Smoke / health check     | Docker + `curl` (CI) + `HEALTHCHECK` | Conteneurs API et web non-root, `/health` et `/` répondent                 | ✅ Implémenté            |
+| Sécurité (OWASP)         | Vitest + Supertest                   | Injection, IDOR, XSS stocké, upload malveillant                            | ✅ Implémenté            |
+| Audit dépendances (SCA)  | `pnpm audit` + Dependabot            | CVE dans `pnpm-lock.yaml`, PRs de mise à jour hebdomadaires                | ✅ Implémenté            |
+| DAST                     | OWASP ZAP Baseline (CI)              | Scan passif/actif sur l’API Docker en CI                                   | ✅ Implémenté            |
+| E2E                      | Playwright                           | Parcours utilisateur complets                                              | ⏳ Prévu, non implémenté |
 
 **Rapports de tests :**
 
@@ -40,14 +41,15 @@ Complète les slides Figma et sert de base si le jury demande les plans de tests
 ### Local
 
 - API : PostgreSQL `nirby_test`, Redis, variables définies dans `apps/api/vitest.config.ts`.
-- Web : jsdom, mocks Next.js (`next/navigation`, `next-intl`) dans `apps/web/src/test/setup.ts`.
+- Web : jsdom, mocks Next.js (`next/navigation`, `next-intl`) et matchers axe (`vitest-axe`) dans `apps/web/src/test/setup.ts`.
 - Lancement : `pnpm test` (racine, via Turbo) ou `pnpm -C apps/api test` / `pnpm -C apps/web test`.
 
 ### CI (GitHub Actions)
 
 - Déclenchement : **pull request** et **push** sur `main` / `staging`.
 - Job `ci-api` : PostGIS 16, base `nirby_test`, migrations Prisma, Redis, secrets factices (`JWT_SECRET`, `GOOGLE_PLACES_API_KEY`, …), tests + couverture (seuils 70 %) + artifact `api-coverage-report`.
-- Job `ci-web` : tests + couverture (seuils 36 / 30 / 26) + artifact `web-coverage-report` + build de vérification.
+- Job `ci-web` : tests + couverture (seuils 36 / 30 / 26) + assertions axe (login, listes, create POI) + artifact `web-coverage-report` + build de vérification.
+- Job `setup` : `pnpm lint` (dont `jsx-a11y` recommended sur `apps/web`).
 - Job `api-docker` : image API (`USER node`), health check HTTP + assert uid ≠ 0, scan OWASP ZAP Baseline (rapport artifact).
 - Job `security-audit` : `pnpm audit --audit-level=high` (rapport artifact, non bloquant).
 - Job `web-docker` : image web (`USER node`), health check HTTP + assert uid ≠ 0.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -308,6 +308,9 @@ importers:
       eslint-config-next:
         specifier: 16.2.6
         version: 16.2.6(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      eslint-plugin-jsx-a11y:
+        specifier: ^6.10.2
+        version: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       jsdom:
         specifier: ^27.4.0
         version: 27.4.0(@noble/hashes@1.8.0)
@@ -326,6 +329,9 @@ importers:
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.29)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.2(@types/node@20.19.29)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.20.6)(yaml@2.8.1))
+      vitest-axe:
+        specifier: ^0.1.0
+        version: 0.1.0(vitest@4.1.8)
 
 packages:
   "@acemir/cssom@0.9.31":
@@ -5448,6 +5454,13 @@ packages:
       }
     engines: { node: ">=10" }
 
+  chalk@5.6.2:
+    resolution:
+      {
+        integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==,
+      }
+    engines: { node: ^12.17.0 || ^14.13 || >=16.0.0 }
+
   chart.js@4.5.1:
     resolution:
       {
@@ -5704,6 +5717,7 @@ packages:
       {
         integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==,
       }
+    deprecated: Active development of CryptoJS has been discontinued. This library is no longer maintained.
 
   css-tree@3.1.0:
     resolution:
@@ -7651,6 +7665,12 @@ packages:
         integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==,
       }
     engines: { node: ">=10" }
+
+  lodash-es@4.18.1:
+    resolution:
+      {
+        integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==,
+      }
 
   lodash.get@4.4.2:
     resolution:
@@ -10124,6 +10144,14 @@ packages:
         optional: true
       yaml:
         optional: true
+
+  vitest-axe@0.1.0:
+    resolution:
+      {
+        integrity: sha512-jvtXxeQPg8R/2ANTY8QicA5pvvdRP4F0FsVUAHANJ46YCDASie/cuhlSzu0DGcLmZvGBSBNsNuK3HqfaeknyvA==,
+      }
+    peerDependencies:
+      vitest: ">=0.16.0"
 
   vitest@4.1.8:
     resolution:
@@ -13544,7 +13572,7 @@ snapshots:
       call-bind: 1.0.8
       call-bound: 1.0.4
       define-properties: 1.2.1
-      es-abstract: 1.24.0
+      es-abstract: 1.24.1
       es-object-atoms: 1.1.1
       get-intrinsic: 1.3.0
       is-string: 1.1.1
@@ -13580,7 +13608,7 @@ snapshots:
     dependencies:
       call-bind: 1.0.8
       define-properties: 1.2.1
-      es-abstract: 1.24.0
+      es-abstract: 1.24.1
       es-shim-unscopables: 1.1.0
 
   array.prototype.tosorted@1.1.4:
@@ -13596,7 +13624,7 @@ snapshots:
       array-buffer-byte-length: 1.0.2
       call-bind: 1.0.8
       define-properties: 1.2.1
-      es-abstract: 1.24.0
+      es-abstract: 1.24.1
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
@@ -13781,6 +13809,8 @@ snapshots:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  chalk@5.6.2: {}
 
   chart.js@4.5.1:
     dependencies:
@@ -14300,7 +14330,7 @@ snapshots:
       "@next/eslint-plugin-next": 16.2.6
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
@@ -14327,7 +14357,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       "@nolyfill/is-core-module": 1.0.39
       debug: 4.4.3
@@ -14342,14 +14372,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       "@typescript-eslint/parser": 8.61.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -14364,7 +14394,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -15273,6 +15303,8 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash-es@4.18.1: {}
+
   lodash.get@4.4.2: {}
 
   lodash.includes@4.3.0: {}
@@ -15570,7 +15602,7 @@ snapshots:
     dependencies:
       call-bind: 1.0.8
       define-properties: 1.2.1
-      es-abstract: 1.24.0
+      es-abstract: 1.24.1
       es-object-atoms: 1.1.1
 
   object.groupby@1.0.3:
@@ -16404,7 +16436,7 @@ snapshots:
       call-bound: 1.0.4
       define-data-property: 1.1.4
       define-properties: 1.2.1
-      es-abstract: 1.24.0
+      es-abstract: 1.24.1
       es-object-atoms: 1.1.1
       has-property-descriptors: 1.0.2
 
@@ -16834,6 +16866,16 @@ snapshots:
       terser: 5.48.0
       tsx: 4.20.6
       yaml: 2.8.1
+
+  vitest-axe@0.1.0(vitest@4.1.8):
+    dependencies:
+      aria-query: 5.3.2
+      axe-core: 4.11.1
+      chalk: 5.6.2
+      dom-accessibility-api: 0.5.16
+      lodash-es: 4.18.1
+      redent: 3.0.0
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.29)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.2(@types/node@20.19.29)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.20.6)(yaml@2.8.1))
 
   vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.29)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.2(@types/node@20.19.29)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.20.6)(yaml@2.8.1)):
     dependencies:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds automated accessibility guards so RGAA work from NIR-91 does not regress silently. Fixes [#196](https://github.com/brissboss/Nirby/issues/196) / NIR-95.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Style/UI update
- [ ] Code refactor
- [ ] Performance improvement
- [x] Test update

## Related Issues

Closes #196

## Changes Made

- Enable `eslint-plugin-jsx-a11y` **recommended** in `apps/web/eslint.config.mjs` (Next only shipped a subset). Plugin already registered by Next, so rules are spread without re-declaring it.
- `jsx-a11y/aria-role` uses `ignoreNonDOM: true` so list membership `role="OWNER"` props are not treated as ARIA.
- `vitest-axe` matchers in the web test setup + `expectNoAxeViolations` helper (`color-contrast` and `region` off in jsdom).
- Axe assertions on login, lists index (2 lists), list detail (OWNER loaded), and create-POI form.
- Hidden POI photo `<input type="file">` now has `aria-label` (real axe finding).
- `docs/test-strategy.md`: a11y row in the test pyramid; lint in `setup`, axe in `ci-web`.
- Type `toHaveNoViolations` on Vitest 4 `Assertion` (`vitest-axe` 0.1.0 still augments the legacy `Vi` namespace, which broke `tsc` in `ci-web`).

## Testing

- [ ] Tested locally with `pnpm dev`
- [x] `pnpm -C apps/web lint` passes
- [x] `pnpm -C apps/web exec tsc --noEmit` passes
- [x] `pnpm -C apps/web test` — 427 tests
- [ ] Database migrations applied if needed

No workflow change: lint already runs in `setup` (`pnpm lint`); axe tests run in `ci-web` via `test:coverage`.

## Screenshots/Videos

N/A

## Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated if needed
- [x] No console errors or warnings
- [x] Removed any debug code

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0003a-7bc3-70b8-9e48-3c625d43dc67?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0003a-7bc3-70b8-9e48-3c625d43dc67&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

