### PR TITLE
feat(web): add cookie consent banner and gate Sentry #198

### DIFF
--- a/apps/web/sentry.client.config.ts
+++ b/apps/web/sentry.client.config.ts
@@ -1,5 +1,3 @@
-import * as Sentry from "@sentry/nextjs";
+import { initClientSentryIfAllowed } from "./src/lib/consent/apply-sentry-consent";
 
-import { sentrySharedOptions } from "./sentry.shared";
-
-Sentry.init(sentrySharedOptions);
+initClientSentryIfAllowed();

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { NextIntlClientProvider } from "next-intl";
 import { getMessages, getLocale, getTranslations } from "next-intl/server";
 import { ThemeProvider } from "next-themes";
 
+import { CookieConsent } from "@/components/cookie-consent";
 import { SkipLink } from "@/components/skip-link";
 import { ToasterWrapper } from "@/components/ui";
 import { AuthProvider } from "@/features/auth";
@@ -63,10 +64,12 @@ export default async function RootLayout({
             enableSystem
             disableTransitionOnChange
           >
-            <QueryProvider>
-              <AuthProvider>{children}</AuthProvider>
-            </QueryProvider>
-            <ToasterWrapper />
+            <CookieConsent>
+              <QueryProvider>
+                <AuthProvider>{children}</AuthProvider>
+              </QueryProvider>
+              <ToasterWrapper />
+            </CookieConsent>
           </ThemeProvider>
         </NextIntlClientProvider>
       </body>

--- a/apps/web/src/app/privacy/page.tsx
+++ b/apps/web/src/app/privacy/page.tsx
@@ -94,6 +94,14 @@ export default async function PrivacyPage() {
             <h2 className="font-display text-lg font-semibold">{t("privacy.s8Title")}</h2>
             <p>{t("privacy.s8Body")}</p>
           </section>
+
+          <section className="space-y-3">
+            <h2 className="font-display text-lg font-semibold">{t("privacy.s9Title")}</h2>
+            <p>{t("privacy.s9Body")}</p>
+            <p>{t("privacy.s9Necessary")}</p>
+            <p>{t("privacy.s9Mapbox")}</p>
+            <p>{t("privacy.s9Sentry")}</p>
+          </section>
         </article>
 
         <footer className="text-muted-foreground mt-12 flex flex-wrap gap-x-4 gap-y-2 border-t border-border pt-8 text-sm">

--- a/apps/web/src/components/cookie-consent.test.tsx
+++ b/apps/web/src/components/cookie-consent.test.tsx
@@ -1,0 +1,90 @@
+import * as Sentry from "@sentry/nextjs";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CookieConsent, useCookieConsent } from "./cookie-consent";
+
+import { readConsent } from "@/lib/consent/consent";
+import { expectNoAxeViolations } from "@/test/axe";
+
+vi.mock("@sentry/nextjs", () => ({
+  init: vi.fn(),
+  close: vi.fn(),
+  getClient: vi.fn(() => undefined),
+}));
+
+function OpenPreferencesButton() {
+  const { openPreferences } = useCookieConsent();
+  return (
+    <button type="button" onClick={openPreferences}>
+      open-prefs
+    </button>
+  );
+}
+
+function renderBanner() {
+  return render(
+    <CookieConsent>
+      <OpenPreferencesButton />
+    </CookieConsent>
+  );
+}
+
+describe("CookieConsent", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+    vi.mocked(Sentry.getClient).mockReturnValue(undefined);
+  });
+
+  it("shows the dialog when no choice is stored", async () => {
+    renderBanner();
+
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "accept" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "refuse" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "customize" })).toBeInTheDocument();
+  });
+
+  it("hides the dialog after a choice and keeps it after a simulated reload", async () => {
+    const { unmount } = renderBanner();
+
+    await userEvent.click(await screen.findByRole("button", { name: "refuse" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+    expect(readConsent()?.sentry).toBe(false);
+
+    unmount();
+    renderBanner();
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "open-prefs" })).toBeInTheDocument();
+    });
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(readConsent()?.sentry).toBe(false);
+  });
+
+  it("does not call Sentry.init on refuse, then inits after accept", async () => {
+    renderBanner();
+
+    await userEvent.click(await screen.findByRole("button", { name: "refuse" }));
+    expect(Sentry.init).not.toHaveBeenCalled();
+    expect(readConsent()?.sentry).toBe(false);
+
+    await userEvent.click(screen.getByRole("button", { name: "open-prefs" }));
+    await userEvent.click(await screen.findByRole("button", { name: "accept" }));
+
+    expect(Sentry.init).toHaveBeenCalled();
+    expect(readConsent()?.sentry).toBe(true);
+  });
+
+  it("has no axe violations when the dialog is open", async () => {
+    renderBanner();
+    const dialog = await screen.findByRole("dialog");
+
+    await expectNoAxeViolations(dialog);
+  });
+});

--- a/apps/web/src/components/cookie-consent.tsx
+++ b/apps/web/src/components/cookie-consent.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import Link from "next/link";
+import { useTranslations } from "next-intl";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Label,
+} from "@/components/ui";
+import { applySentryConsent } from "@/lib/consent/apply-sentry-consent";
+import { readConsent, writeConsent } from "@/lib/consent/consent";
+
+type CookieConsentContextValue = {
+  openPreferences: () => void;
+};
+
+const CookieConsentContext = createContext<CookieConsentContextValue | null>(null);
+
+export function useCookieConsent() {
+  const context = useContext(CookieConsentContext);
+  if (!context) {
+    throw new Error("useCookieConsent must be used within CookieConsent");
+  }
+  return context;
+}
+
+type Step = "main" | "customize";
+
+export function CookieConsent({ children }: { children: ReactNode }) {
+  const t = useTranslations("consent");
+  const [ready, setReady] = useState(false);
+  const [open, setOpen] = useState(false);
+  const [required, setRequired] = useState(true);
+  const [step, setStep] = useState<Step>("main");
+  const [sentryDraft, setSentryDraft] = useState(false);
+
+  useEffect(() => {
+    const existing = readConsent();
+    setRequired(!existing);
+    setOpen(!existing);
+    setSentryDraft(existing?.sentry ?? false);
+    setReady(true);
+  }, []);
+
+  const persist = useCallback((sentry: boolean) => {
+    writeConsent(sentry);
+    applySentryConsent(sentry);
+    setSentryDraft(sentry);
+    setRequired(false);
+    setStep("main");
+    setOpen(false);
+  }, []);
+
+  const openPreferences = useCallback(() => {
+    const existing = readConsent();
+    setSentryDraft(existing?.sentry ?? false);
+    setRequired(false);
+    setStep("main");
+    setOpen(true);
+  }, []);
+
+  const value = useMemo(() => ({ openPreferences }), [openPreferences]);
+
+  function handleOpenChange(next: boolean) {
+    if (!next && required) {
+      return;
+    }
+    setOpen(next);
+    if (!next) {
+      setStep("main");
+    }
+  }
+
+  return (
+    <CookieConsentContext.Provider value={value}>
+      {children}
+      {ready ? (
+        <Dialog open={open} onOpenChange={handleOpenChange}>
+          <DialogContent
+            showCloseButton={!required}
+            onPointerDownOutside={(event) => {
+              if (required) {
+                event.preventDefault();
+              }
+            }}
+            onEscapeKeyDown={(event) => {
+              if (required) {
+                event.preventDefault();
+              }
+            }}
+          >
+            <DialogHeader>
+              <DialogTitle>{t("title")}</DialogTitle>
+              <DialogDescription>
+                {t("description")}{" "}
+                <Link
+                  href="/privacy"
+                  className="text-primary underline underline-offset-4 hover:no-underline"
+                >
+                  {t("privacyLink")}
+                </Link>
+              </DialogDescription>
+            </DialogHeader>
+
+            {step === "customize" ? (
+              <div className="grid gap-4">
+                <fieldset className="grid gap-2 rounded-lg border border-border p-3">
+                  <legend className="px-1 text-sm font-medium">{t("necessaryTitle")}</legend>
+                  <p className="text-muted-foreground text-sm">{t("necessaryDescription")}</p>
+                  <label
+                    className="flex items-center gap-2 text-sm"
+                    htmlFor="cookie-consent-necessary"
+                  >
+                    <input id="cookie-consent-necessary" type="checkbox" checked disabled />
+                    {t("necessaryTitle")}
+                  </label>
+                </fieldset>
+                <fieldset className="grid gap-2 rounded-lg border border-border p-3">
+                  <legend className="px-1 text-sm font-medium">{t("sentryTitle")}</legend>
+                  <p className="text-muted-foreground text-sm">{t("sentryDescription")}</p>
+                  <Label className="text-foreground" htmlFor="cookie-consent-sentry">
+                    <input
+                      id="cookie-consent-sentry"
+                      type="checkbox"
+                      checked={sentryDraft}
+                      onChange={(event) => setSentryDraft(event.target.checked)}
+                    />
+                    {t("sentryTitle")}
+                  </Label>
+                </fieldset>
+              </div>
+            ) : null}
+
+            <DialogFooter>
+              {step === "main" ? (
+                <>
+                  <Button type="button" variant="outline" onClick={() => persist(false)}>
+                    {t("refuse")}
+                  </Button>
+                  <Button type="button" variant="outline" onClick={() => setStep("customize")}>
+                    {t("customize")}
+                  </Button>
+                  <Button type="button" onClick={() => persist(true)}>
+                    {t("accept")}
+                  </Button>
+                </>
+              ) : (
+                <>
+                  <Button type="button" variant="outline" onClick={() => setStep("main")}>
+                    {t("back")}
+                  </Button>
+                  <Button type="button" onClick={() => persist(sentryDraft)}>
+                    {t("save")}
+                  </Button>
+                </>
+              )}
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      ) : null}
+    </CookieConsentContext.Provider>
+  );
+}

--- a/apps/web/src/components/cookie-consent.tsx
+++ b/apps/web/src/components/cookie-consent.tsx
@@ -6,9 +6,9 @@ import {
   createContext,
   useCallback,
   useContext,
-  useEffect,
   useMemo,
   useState,
+  useSyncExternalStore,
   type ReactNode,
 } from "react";
 
@@ -23,7 +23,11 @@ import {
   Label,
 } from "@/components/ui";
 import { applySentryConsent } from "@/lib/consent/apply-sentry-consent";
-import { readConsent, writeConsent } from "@/lib/consent/consent";
+import { readConsent, subscribeConsent, writeConsent } from "@/lib/consent/consent";
+
+function subscribeNever() {
+  return () => {};
+}
 
 type CookieConsentContextValue = {
   openPreferences: () => void;
@@ -43,35 +47,29 @@ type Step = "main" | "customize";
 
 export function CookieConsent({ children }: { children: ReactNode }) {
   const t = useTranslations("consent");
-  const [ready, setReady] = useState(false);
-  const [open, setOpen] = useState(false);
-  const [required, setRequired] = useState(true);
+  const isClient = useSyncExternalStore(
+    subscribeNever,
+    () => true,
+    () => false
+  );
+  const consent = useSyncExternalStore(subscribeConsent, readConsent, () => null);
+  const required = isClient && consent === null;
+  const [preferencesOpen, setPreferencesOpen] = useState(false);
   const [step, setStep] = useState<Step>("main");
   const [sentryDraft, setSentryDraft] = useState(false);
-
-  useEffect(() => {
-    const existing = readConsent();
-    setRequired(!existing);
-    setOpen(!existing);
-    setSentryDraft(existing?.sentry ?? false);
-    setReady(true);
-  }, []);
 
   const persist = useCallback((sentry: boolean) => {
     writeConsent(sentry);
     applySentryConsent(sentry);
     setSentryDraft(sentry);
-    setRequired(false);
     setStep("main");
-    setOpen(false);
+    setPreferencesOpen(false);
   }, []);
 
   const openPreferences = useCallback(() => {
-    const existing = readConsent();
-    setSentryDraft(existing?.sentry ?? false);
-    setRequired(false);
+    setSentryDraft(readConsent()?.sentry ?? false);
     setStep("main");
-    setOpen(true);
+    setPreferencesOpen(true);
   }, []);
 
   const value = useMemo(() => ({ openPreferences }), [openPreferences]);
@@ -80,7 +78,7 @@ export function CookieConsent({ children }: { children: ReactNode }) {
     if (!next && required) {
       return;
     }
-    setOpen(next);
+    setPreferencesOpen(next);
     if (!next) {
       setStep("main");
     }
@@ -89,8 +87,8 @@ export function CookieConsent({ children }: { children: ReactNode }) {
   return (
     <CookieConsentContext.Provider value={value}>
       {children}
-      {ready ? (
-        <Dialog open={open} onOpenChange={handleOpenChange}>
+      {isClient ? (
+        <Dialog open={required || preferencesOpen} onOpenChange={handleOpenChange}>
           <DialogContent
             showCloseButton={!required}
             onPointerDownOutside={(event) => {

--- a/apps/web/src/components/index.ts
+++ b/apps/web/src/components/index.ts
@@ -2,3 +2,4 @@ export * from "./ui";
 export * from "./logo";
 export * from "./legal-links";
 export * from "./skip-link";
+export * from "./cookie-consent";

--- a/apps/web/src/features/profile/views/profile-privacy-view.component.test.tsx
+++ b/apps/web/src/features/profile/views/profile-privacy-view.component.test.tsx
@@ -5,6 +5,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ProfilePrivacyView } from "./profile-privacy-view.component";
 
+import { CookieConsent } from "@/components/cookie-consent";
+import { CONSENT_STORAGE_KEY, CONSENT_VERSION } from "@/lib/consent/consent";
+
 const logout = vi.fn();
 const exportMe = vi.fn();
 
@@ -35,8 +38,25 @@ describe("ProfilePrivacyView", () => {
   const onBack = vi.fn();
   const click = vi.fn();
 
+  function renderPrivacy() {
+    return render(
+      <CookieConsent>
+        <ProfilePrivacyView onBack={onBack} />
+      </CookieConsent>
+    );
+  }
+
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
+    localStorage.setItem(
+      CONSENT_STORAGE_KEY,
+      JSON.stringify({
+        version: CONSENT_VERSION,
+        sentry: false,
+        decidedAt: "2026-01-01T00:00:00.000Z",
+      })
+    );
     logout.mockResolvedValue(undefined);
     exportMe.mockResolvedValue({
       data: {
@@ -59,7 +79,7 @@ describe("ProfilePrivacyView", () => {
   });
 
   it("downloads a JSON export and toasts success", async () => {
-    render(<ProfilePrivacyView onBack={onBack} />);
+    renderPrivacy();
 
     await userEvent.click(screen.getByRole("button", { name: "privacy.exportDownload" }));
 
@@ -73,7 +93,7 @@ describe("ProfilePrivacyView", () => {
   it("toasts an error when export fails", async () => {
     exportMe.mockResolvedValue({ data: undefined, error: { error: { code: "INTERNAL_ERROR" } } });
 
-    render(<ProfilePrivacyView onBack={onBack} />);
+    renderPrivacy();
 
     await userEvent.click(screen.getByRole("button", { name: "privacy.exportDownload" }));
 
@@ -86,12 +106,22 @@ describe("ProfilePrivacyView", () => {
   });
 
   it("links to the privacy policy and legal notice pages", () => {
-    render(<ProfilePrivacyView onBack={onBack} />);
+    renderPrivacy();
 
     expect(screen.getByRole("link", { name: "legal.privacy" })).toHaveAttribute("href", "/privacy");
     expect(screen.getByRole("link", { name: "legal.mentions" })).toHaveAttribute(
       "href",
       "/mentions"
     );
+  });
+
+  it("reopens the cookie dialog from Manage cookies", async () => {
+    renderPrivacy();
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "manage" }));
+
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/profile/views/profile-privacy-view.component.tsx
+++ b/apps/web/src/features/profile/views/profile-privacy-view.component.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { Download, LogOut, Shield } from "lucide-react";
+import { Cookie, Download, LogOut, Shield } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
 import { toast } from "sonner";
 
 import { ProfileSectionLayout } from "../components/ui/profile-section-layout.component";
 
+import { useCookieConsent } from "@/components/cookie-consent";
 import { LegalLinks } from "@/components/legal-links";
 import { Button, Card, CardInset } from "@/components/ui";
 import { useAuth } from "@/features/auth";
@@ -32,6 +33,8 @@ function downloadJsonFile(data: unknown, filename: string) {
 export function ProfilePrivacyView({ onBack }: ProfilePrivacyViewProps) {
   const t = useTranslations("profile");
   const tCommon = useTranslations();
+  const tConsent = useTranslations("consent");
+  const { openPreferences } = useCookieConsent();
   const { logout } = useAuth();
   const getErrorMessage = useErrorMessage();
   const [isExporting, setIsExporting] = useState(false);
@@ -78,6 +81,15 @@ export function ProfilePrivacyView({ onBack }: ProfilePrivacyViewProps) {
         >
           <Download className="mr-2 size-4" />
           {t("privacy.exportDownload")}
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          className="w-full justify-start"
+          onClick={() => openPreferences()}
+        >
+          <Cookie className="mr-2 size-4" />
+          {tConsent("manage")}
         </Button>
         <LegalLinks variant="stack" />
         <Button

--- a/apps/web/src/instrumentation-client.ts
+++ b/apps/web/src/instrumentation-client.ts
@@ -1,7 +1,7 @@
 import * as Sentry from "@sentry/nextjs";
 
-import { sentrySharedOptions } from "../sentry.shared";
+import { initClientSentryIfAllowed } from "@/lib/consent/apply-sentry-consent";
 
-Sentry.init(sentrySharedOptions);
+initClientSentryIfAllowed();
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/apps/web/src/lib/consent/apply-sentry-consent.test.ts
+++ b/apps/web/src/lib/consent/apply-sentry-consent.test.ts
@@ -1,0 +1,56 @@
+import * as Sentry from "@sentry/nextjs";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { applySentryConsent, initClientSentryIfAllowed } from "./apply-sentry-consent";
+import { CONSENT_STORAGE_KEY, writeConsent } from "./consent";
+
+vi.mock("@sentry/nextjs", () => ({
+  init: vi.fn(),
+  close: vi.fn(),
+  getClient: vi.fn(),
+}));
+
+describe("apply sentry consent", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+    vi.mocked(Sentry.getClient).mockReturnValue(undefined);
+  });
+
+  it("does not init Sentry when consent is missing or refused", () => {
+    initClientSentryIfAllowed();
+    expect(Sentry.init).not.toHaveBeenCalled();
+
+    writeConsent(false);
+    initClientSentryIfAllowed();
+    expect(Sentry.init).not.toHaveBeenCalled();
+  });
+
+  it("inits Sentry when consent is granted and no client exists", () => {
+    writeConsent(true);
+    initClientSentryIfAllowed();
+    expect(Sentry.init).toHaveBeenCalledOnce();
+  });
+
+  it("does not init again when a client already exists", () => {
+    writeConsent(true);
+    vi.mocked(Sentry.getClient).mockReturnValue({} as ReturnType<typeof Sentry.getClient>);
+    initClientSentryIfAllowed();
+    expect(Sentry.init).not.toHaveBeenCalled();
+  });
+
+  it("closes Sentry when consent is revoked", () => {
+    applySentryConsent(false);
+    expect(Sentry.close).toHaveBeenCalled();
+    expect(Sentry.init).not.toHaveBeenCalled();
+  });
+
+  it("inits Sentry when applySentryConsent(true) follows a stored accept", () => {
+    localStorage.setItem(
+      CONSENT_STORAGE_KEY,
+      JSON.stringify({ version: 1, sentry: true, decidedAt: "2026-08-14T15:00:00.000Z" })
+    );
+    applySentryConsent(true);
+    expect(Sentry.init).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/lib/consent/apply-sentry-consent.ts
+++ b/apps/web/src/lib/consent/apply-sentry-consent.ts
@@ -1,0 +1,30 @@
+import * as Sentry from "@sentry/nextjs";
+
+import { sentrySharedOptions } from "../../../sentry.shared";
+
+import { readConsent } from "./consent";
+
+export function initClientSentryIfAllowed() {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  if (!readConsent()?.sentry) {
+    return;
+  }
+
+  if (Sentry.getClient()) {
+    return;
+  }
+
+  Sentry.init(sentrySharedOptions);
+}
+
+export function applySentryConsent(sentry: boolean) {
+  if (sentry) {
+    initClientSentryIfAllowed();
+    return;
+  }
+
+  void Sentry.close();
+}

--- a/apps/web/src/lib/consent/consent.test.ts
+++ b/apps/web/src/lib/consent/consent.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { CONSENT_STORAGE_KEY, CONSENT_VERSION, readConsent, writeConsent } from "./consent";
+
+describe("cookie consent storage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("returns null when nothing is stored", () => {
+    expect(readConsent()).toBeNull();
+  });
+
+  it("returns null for invalid JSON or an unexpected version", () => {
+    localStorage.setItem(CONSENT_STORAGE_KEY, "{");
+    expect(readConsent()).toBeNull();
+
+    localStorage.setItem(
+      CONSENT_STORAGE_KEY,
+      JSON.stringify({ version: 99, sentry: true, decidedAt: "2026-01-01T00:00:00.000Z" })
+    );
+    expect(readConsent()).toBeNull();
+  });
+
+  it("writes accept and refuse with an ISO decidedAt and reads them back", () => {
+    const accepted = writeConsent(true);
+
+    expect(accepted).toEqual({
+      version: CONSENT_VERSION,
+      sentry: true,
+      decidedAt: accepted.decidedAt,
+    });
+    expect(accepted.decidedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+    expect(readConsent()).toEqual(accepted);
+
+    const refused = writeConsent(false);
+    expect(refused.sentry).toBe(false);
+    expect(readConsent()?.sentry).toBe(false);
+    expect(readConsent()?.decidedAt).toBe(refused.decidedAt);
+  });
+});

--- a/apps/web/src/lib/consent/consent.ts
+++ b/apps/web/src/lib/consent/consent.ts
@@ -7,6 +7,18 @@ export type CookieConsentState = {
   decidedAt: string;
 };
 
+const listeners = new Set<() => void>();
+
+let cachedRaw: string | null | undefined;
+let cachedState: CookieConsentState | null = null;
+
+export function subscribeConsent(onStoreChange: () => void) {
+  listeners.add(onStoreChange);
+  return () => {
+    listeners.delete(onStoreChange);
+  };
+}
+
 export function readConsent(): CookieConsentState | null {
   if (typeof window === "undefined") {
     return null;
@@ -14,7 +26,13 @@ export function readConsent(): CookieConsentState | null {
 
   try {
     const raw = window.localStorage.getItem(CONSENT_STORAGE_KEY);
+    if (raw === cachedRaw) {
+      return cachedState;
+    }
+
+    cachedRaw = raw;
     if (!raw) {
+      cachedState = null;
       return null;
     }
 
@@ -24,15 +42,19 @@ export function readConsent(): CookieConsentState | null {
       typeof parsed.sentry !== "boolean" ||
       typeof parsed.decidedAt !== "string"
     ) {
+      cachedState = null;
       return null;
     }
 
-    return {
+    cachedState = {
       version: CONSENT_VERSION,
       sentry: parsed.sentry,
       decidedAt: parsed.decidedAt,
     };
+    return cachedState;
   } catch {
+    cachedRaw = undefined;
+    cachedState = null;
     return null;
   }
 }
@@ -44,6 +66,10 @@ export function writeConsent(sentry: boolean): CookieConsentState {
     decidedAt: new Date().toISOString(),
   };
 
-  window.localStorage.setItem(CONSENT_STORAGE_KEY, JSON.stringify(state));
+  const raw = JSON.stringify(state);
+  window.localStorage.setItem(CONSENT_STORAGE_KEY, raw);
+  cachedRaw = raw;
+  cachedState = state;
+  listeners.forEach((listener) => listener());
   return state;
 }

--- a/apps/web/src/lib/consent/consent.ts
+++ b/apps/web/src/lib/consent/consent.ts
@@ -1,0 +1,49 @@
+export const CONSENT_STORAGE_KEY = "nirby.cookie-consent";
+export const CONSENT_VERSION = 1;
+
+export type CookieConsentState = {
+  version: typeof CONSENT_VERSION;
+  sentry: boolean;
+  decidedAt: string;
+};
+
+export function readConsent(): CookieConsentState | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(CONSENT_STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+
+    const parsed = JSON.parse(raw) as Partial<CookieConsentState>;
+    if (
+      parsed.version !== CONSENT_VERSION ||
+      typeof parsed.sentry !== "boolean" ||
+      typeof parsed.decidedAt !== "string"
+    ) {
+      return null;
+    }
+
+    return {
+      version: CONSENT_VERSION,
+      sentry: parsed.sentry,
+      decidedAt: parsed.decidedAt,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function writeConsent(sentry: boolean): CookieConsentState {
+  const state: CookieConsentState = {
+    version: CONSENT_VERSION,
+    sentry,
+    decidedAt: new Date().toISOString(),
+  };
+
+  window.localStorage.setItem(CONSENT_STORAGE_KEY, JSON.stringify(state));
+  return state;
+}

--- a/apps/web/src/lib/i18n/locales-parity.test.tsx
+++ b/apps/web/src/lib/i18n/locales-parity.test.tsx
@@ -2,12 +2,14 @@ import { createTranslator } from "next-intl";
 import { describe, expect, it } from "vitest";
 
 import enCommon from "./locales/en/common.json";
+import enConsent from "./locales/en/consent.json";
 import enExplore from "./locales/en/explore.json";
 import enLegal from "./locales/en/legal.json";
 import enLists from "./locales/en/lists.json";
 import enPoi from "./locales/en/poi.json";
 import enShell from "./locales/en/shell.json";
 import frCommon from "./locales/fr/common.json";
+import frConsent from "./locales/fr/consent.json";
 import frExplore from "./locales/fr/explore.json";
 import frLegal from "./locales/fr/legal.json";
 import frLists from "./locales/fr/lists.json";
@@ -101,6 +103,11 @@ const NEW_LEGAL_KEYS = [
   "privacy.title",
   "privacy.s6Body",
   "privacy.s7Body",
+  "privacy.s9Title",
+  "privacy.s9Body",
+  "privacy.s9Necessary",
+  "privacy.s9Mapbox",
+  "privacy.s9Sentry",
   "mentions.metaTitle",
   "mentions.title",
   "mentions.s3Body",
@@ -129,6 +136,22 @@ const NEW_POI_KEYS = [
 ] as const;
 
 const NEW_SHELL_KEYS = ["tabs.navLabel"] as const;
+
+const NEW_CONSENT_KEYS = [
+  "title",
+  "description",
+  "privacyLink",
+  "accept",
+  "refuse",
+  "customize",
+  "save",
+  "back",
+  "necessaryTitle",
+  "necessaryDescription",
+  "sentryTitle",
+  "sentryDescription",
+  "manage",
+] as const;
 
 function expectNonEmptyStrings(obj: JsonObject, keys: readonly string[], locale: string) {
   for (const key of keys) {
@@ -163,6 +186,10 @@ describe("locales parity", () => {
     expectLocaleParity(enShell, frShell, "shell");
   });
 
+  it("consent.json has the same keys in en and fr", () => {
+    expectLocaleParity(enConsent, frConsent, "consent");
+  });
+
   it("new lists keys are non-empty strings in both locales", () => {
     expectNonEmptyStrings(enLists, NEW_LISTS_KEYS, "en");
     expectNonEmptyStrings(frLists, NEW_LISTS_KEYS, "fr");
@@ -191,6 +218,11 @@ describe("locales parity", () => {
   it("new shell keys are non-empty strings in both locales", () => {
     expectNonEmptyStrings(enShell, NEW_SHELL_KEYS, "en");
     expectNonEmptyStrings(frShell, NEW_SHELL_KEYS, "fr");
+  });
+
+  it("new consent keys are non-empty strings in both locales", () => {
+    expectNonEmptyStrings(enConsent, NEW_CONSENT_KEYS, "en");
+    expectNonEmptyStrings(frConsent, NEW_CONSENT_KEYS, "fr");
   });
 
   it("does not keep the removed detail.poisComingSoon key", () => {
@@ -230,6 +262,18 @@ describe("message resolution", () => {
     expect(tLegal("privacy.title")).toBe("Privacy policy");
     expect(tLegal("mentions.title")).toBe("Legal notice");
     expect(tLegal("disclaimer.title")).toBe("Sample content");
+    expect(tLegal("privacy.s9Title")).toBe("9. Cookies and trackers");
+  });
+
+  it("resolves consent namespace", () => {
+    const tConsent = createTranslator({
+      locale: "en",
+      messages: { consent: enConsent },
+      namespace: "consent",
+    });
+
+    expect(tConsent("title")).toBe("Cookies and tracking");
+    expect(tConsent("manage")).toBe("Manage cookies");
   });
 
   it("resolves skip link and global error keys", () => {

--- a/apps/web/src/lib/i18n/locales/en/consent.json
+++ b/apps/web/src/lib/i18n/locales/en/consent.json
@@ -1,0 +1,15 @@
+{
+  "title": "Cookies and tracking",
+  "description": "We use strictly necessary cookies to sign you in and remember your language. Optional error monitoring (Sentry) runs only with your consent.",
+  "privacyLink": "Privacy policy",
+  "accept": "Accept",
+  "refuse": "Refuse",
+  "customize": "Customize",
+  "save": "Save",
+  "back": "Back",
+  "necessaryTitle": "Strictly necessary",
+  "necessaryDescription": "Authentication, language, and display. Always on.",
+  "sentryTitle": "Error monitoring (Sentry)",
+  "sentryDescription": "Helps diagnose crashes. Optional; loaded only if you allow it.",
+  "manage": "Manage cookies"
+}

--- a/apps/web/src/lib/i18n/locales/en/legal.json
+++ b/apps/web/src/lib/i18n/locales/en/legal.json
@@ -8,7 +8,7 @@
     "metaTitle": "Privacy policy | Nirby",
     "metaDescription": "Privacy policy of the Nirby service (sample content)",
     "title": "Privacy policy",
-    "updatedAt": "Last updated: 29 March 2026",
+    "updatedAt": "Last updated: 14 August 2026",
     "s1Title": "1. Data controller",
     "s1Body": "RNCP demonstration project “Nirby” (fictitious publisher: Société Exemple SARL), fictitious registered office: 12 rue du Parchemin, 75000 Paris, France.",
     "s1Contact": "Personal data contact:",
@@ -26,7 +26,12 @@
     "s7Title": "7. Your rights",
     "s7Body": "Access, rectification, erasure, restriction, objection where provided by the GDPR, and a complaint to the CNIL (<cnil>cnil.fr</cnil>). To exercise your rights: use the contact in section 1.",
     "s8Title": "8. Security",
-    "s8Body": "Technical measures described in the project report (authentication, input validation, development practices). Details: “Technical specifications — security”."
+    "s8Body": "Technical measures described in the project report (authentication, input validation, development practices). Details: “Technical specifications — security”.",
+    "s9Title": "9. Cookies and trackers",
+    "s9Body": "Nirby uses strictly necessary cookies to run the service. Optional error monitoring is loaded only with your consent. You can change this choice at any time from your profile (Privacy).",
+    "s9Necessary": "Strictly necessary (no prior consent): the httpOnly refreshToken cookie (authentication, SameSite=strict); the NEXT_LOCALE cookie (language preference, 1 year, SameSite=lax). Display theme is stored in localStorage (next-themes) and is not a tracker.",
+    "s9Mapbox": "Mapbox GL loads map tiles required for the product. It is not gated by the consent banner: refusing it would break the map. Google Places is called only through the Nirby API; the browser does not set a Google cookie for place search.",
+    "s9Sentry": "Optional: the Sentry client SDK (error telemetry). It is initialised only if you accept it in the cookie banner. Server-side Sentry does not set a browser cookie."
   },
   "mentions": {
     "metaTitle": "Legal notice | Nirby",

--- a/apps/web/src/lib/i18n/locales/fr/consent.json
+++ b/apps/web/src/lib/i18n/locales/fr/consent.json
@@ -1,0 +1,15 @@
+{
+  "title": "Cookies et traceurs",
+  "description": "Nous utilisons des cookies strictement nécessaires pour vous connecter et mémoriser la langue. La télémétrie d’erreurs (Sentry) n’est chargée qu’avec votre consentement.",
+  "privacyLink": "Politique de confidentialité",
+  "accept": "Accepter",
+  "refuse": "Refuser",
+  "customize": "Personnaliser",
+  "save": "Enregistrer",
+  "back": "Retour",
+  "necessaryTitle": "Strictement nécessaires",
+  "necessaryDescription": "Authentification, langue et affichage. Toujours actifs.",
+  "sentryTitle": "Suivi des erreurs (Sentry)",
+  "sentryDescription": "Aide à diagnostiquer les pannes. Optionnel ; chargé uniquement si vous l’autorisez.",
+  "manage": "Gérer les cookies"
+}

--- a/apps/web/src/lib/i18n/locales/fr/legal.json
+++ b/apps/web/src/lib/i18n/locales/fr/legal.json
@@ -8,7 +8,7 @@
     "metaTitle": "Politique de confidentialité | Nirby",
     "metaDescription": "Politique de confidentialité du service Nirby (contenu d'exemple)",
     "title": "Politique de confidentialité",
-    "updatedAt": "Dernière mise à jour : 29 mars 2026",
+    "updatedAt": "Dernière mise à jour : 14 août 2026",
     "s1Title": "1. Responsable du traitement",
     "s1Body": "Projet de démonstration RNCP « Nirby » (éditeur fictif : Société Exemple SARL), siège social fictif : 12 rue du Parchemin, 75000 Paris, France.",
     "s1Contact": "Contact données personnelles :",
@@ -26,7 +26,12 @@
     "s7Title": "7. Vos droits",
     "s7Body": "Accès, rectification, effacement, limitation, opposition dans les cas prévus par le RGPD, et réclamation auprès de la CNIL (<cnil>cnil.fr</cnil>). Pour exercer vos droits : contact indiqué en section 1.",
     "s8Title": "8. Sécurité",
-    "s8Body": "Mesures techniques décrites dans le mémoire du projet (authentification, validation des entrées, bonnes pratiques de développement). Détail : document « Spécifications techniques — sécurité »."
+    "s8Body": "Mesures techniques décrites dans le mémoire du projet (authentification, validation des entrées, bonnes pratiques de développement). Détail : document « Spécifications techniques — sécurité ».",
+    "s9Title": "9. Cookies et traceurs",
+    "s9Body": "Nirby utilise des cookies strictement nécessaires au fonctionnement du service. La télémétrie d’erreurs optionnelle n’est chargée qu’avec votre consentement. Vous pouvez modifier ce choix à tout moment depuis le profil (Confidentialité).",
+    "s9Necessary": "Strictement nécessaires (pas de consentement préalable) : le cookie httpOnly refreshToken (authentification, SameSite=strict) ; le cookie NEXT_LOCALE (préférence de langue, 1 an, SameSite=lax). Le thème d’affichage est stocké dans localStorage (next-themes) et n’est pas un traceur.",
+    "s9Mapbox": "Mapbox GL charge les tuiles indispensables au produit carte. Il n’est pas soumis au bandeau : le refuser casserait la carte. Google Places est appelé uniquement via l’API Nirby ; le navigateur ne dépose pas de cookie Google pour la recherche de lieux.",
+    "s9Sentry": "Optionnel : le SDK Sentry côté client (télémétrie d’erreurs). Il n’est initialisé que si vous l’acceptez dans le bandeau. Sentry serveur ne dépose pas de cookie navigateur."
   },
   "mentions": {
     "metaTitle": "Mentions légales | Nirby",

--- a/docs/gdpr-cookies.md
+++ b/docs/gdpr-cookies.md
@@ -1,0 +1,69 @@
+# Cookies, traceurs et consentement
+
+Document d’argumentaire RNCP (Bloc 2 : RGPD / mentions légales).  
+Complète le ticket [NIR-97](https://linear.app/nirbyfr/issue/NIR-97/add-cookie-consent-banner) / GitHub [#198](https://github.com/brissboss/Nirby/issues/198).
+
+UI : bandeau modal (`CookieConsent`) + bouton « Gérer les cookies » dans `ProfilePrivacyView`.  
+Le choix (et sa date) est stocké dans `localStorage` sous `nirby.cookie-consent`.  
+La classification ci-dessous est celle que le jury interrogera, plus que le composant.
+
+Le droit à la portabilité est décrit dans [gdpr-data-export.md](./gdpr-data-export.md) ; l’effacement dans [gdpr-account-deletion.md](./gdpr-account-deletion.md).
+
+---
+
+## 1. Cadre
+
+Le RGPD et la directive ePrivacy (reprise en droit français) distinguent :
+
+- les traceurs **strictement nécessaires** au service demandé (pas de consentement préalable) ;
+- les traceurs **non nécessaires** (mesure d’audience, télémétrie, publicité) — consentement libre, éclairé, spécifique, et révocable.
+
+Nirby n’a **pas** de mesure d’audience (pas de GA, Matomo, etc.). Le seul traceur optionnel côté navigateur est **Sentry client**.
+
+---
+
+## 2. Strictement nécessaires (pas de consentement)
+
+| Nom            | Type                         | Finalité                                        | Durée / attributs                                         |
+| -------------- | ---------------------------- | ----------------------------------------------- | --------------------------------------------------------- |
+| `refreshToken` | Cookie httpOnly              | Session authentifiée (renouvellement JWT)       | TTL refresh, `Secure` (prod), `SameSite=strict`, `path=/` |
+| `NEXT_LOCALE`  | Cookie                       | Langue de l’interface (`fr` / `en`)             | 1 an, `SameSite=lax`, `path=/`                            |
+| `theme`        | localStorage (`next-themes`) | Préférence d’affichage clair / sombre / système | Persistant ; **pas un traceur**                           |
+
+**Mapbox GL** charge des tuiles et un style depuis `*.mapbox.com`. C’est indispensable au produit (carte de POI) : le refuser casserait l’application. Il n’est **pas** soumis au bandeau.
+
+**Google Places** est appelé **uniquement via l’API Nirby** (`POST /google-place/search`, photos proxifiées). Le navigateur ne dépose pas de cookie Google pour la recherche.
+
+---
+
+## 3. Optionnel (consentement requis)
+
+| Nom                 | Type                     | Finalité                                       |
+| ------------------- | ------------------------ | ---------------------------------------------- |
+| Sentry (SDK client) | Script + stockage Sentry | Télémétrie d’erreurs (`tracesSampleRate: 0.1`) |
+
+- `Sentry.init` n’est appelé que si `sentry: true` dans `nirby.cookie-consent`.
+- Points d’entrée : `sentry.client.config.ts`, `instrumentation-client.ts`, et après un choix dans le bandeau (`applySentryConsent`).
+- Un refus (ou une révocation) n’initialise pas le SDK ; `Sentry.close()` est appelé si le client était déjà actif.
+- Sentry **serveur / edge** n’écrit pas de cookie navigateur : inchangé (erreurs d’infrastructure).
+
+En développement, `sentrySharedOptions.enabled` reste `false` même après consentement (pas de DSN / `NODE_ENV === development`).
+
+---
+
+## 4. Choix utilisateur
+
+```json
+{ "version": 1, "sentry": true, "decidedAt": "2026-08-14T15:00:00.000Z" }
+```
+
+- **Accepter** → `sentry: true` puis `Sentry.init` si autorisé.
+- **Refuser** → `sentry: false`, pas d’init.
+- **Personnaliser** → case Sentry ; les nécessaires restent toujours actifs.
+- Le choix se modifie depuis Profil → Confidentialité.
+
+---
+
+## 5. Ce que ce n’est pas
+
+Pas de CMP tierce, pas de gate Mapbox, pas de cookies publicitaires, pas de Sentry conditionné côté serveur.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Description

Bandeau de consentement cookies (NIR-97 / #198) : dialog obligatoire tant qu’aucun choix n’est fait, persistance dans `localStorage`, et `Sentry.init` client uniquement après opt-in.

## 🎯 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 📝 Documentation update
- [x] ✅ Test update

## 🔗 Related Issues

Closes #198
Related to NIR-97 / parent NIR-92

## 🚀 Changes Made

- Module `readConsent` / `writeConsent` (`nirby.cookie-consent` : `{ version, sentry, decidedAt }`)
- Gate de `Sentry.init` dans `sentry.client.config.ts` et `instrumentation-client.ts` ; `Sentry.close()` si révocation
- Dialog Radix (focus trap) : Accepter / Refuser / Personnaliser ; pas de fermeture sans décision
- Hydratation via `useSyncExternalStore` (pas de `setState` dans un effet)
- Bouton « Gérer les cookies » dans Profil → Confidentialité
- Section **9. Cookies et traceurs** sur `/privacy` + i18n `consent.json` (fr/en)
- Classification documentée dans `docs/gdpr-cookies.md` (nécessaires vs Sentry optionnel ; Mapbox non gated)

## 🧪 Testing

- [ ] Tested locally with `pnpm dev`
- [x] All quality checks pass (`pnpm lint` dans `apps/web`)
- [x] Unit tests pass (`pnpm test` dans `apps/web` — 443 tests)
- [ ] Database migrations applied if needed

## 📸 Screenshots/Videos

N/A

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated if needed
- [x] No console errors or warnings
- [x] Removed any debug code

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0003a-7bc3-70b8-9e48-3c625d43dc67?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0003a-7bc3-70b8-9e48-3c625d43dc67&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

