### PR TITLE
fix(ci): point OWASP ZAP baseline at localhost

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -270,8 +270,7 @@ jobs:
         uses: zaproxy/action-baseline@v0.14.0
         continue-on-error: true
         with:
-          target: "http://host.docker.internal:4000"
-          docker_options: "-u root --add-host=host.docker.internal:host-gateway"
+          target: "http://localhost:4000"
           allow_issue_writing: false
 
       - name: Upload ZAP report


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Description

Corrige le scan OWASP ZAP Baseline du job `api-docker`. Ticket Linear : [NIR-104](https://linear.app/nirbyfr/issue/NIR-104/fix-owasp-zap-baseline-target-in-api-docker-ci).

`zaproxy/action-baseline@v0.14.0` rejetait `docker_options` (input invalide). La cible `http://host.docker.internal:4000` n’est pas résolue sur le runner Ubuntu (`Name or service not known`, exit 3) : `report_html.html` n’est pas produit et l’artifact `zap-baseline-report` est absent.

L’API CI et l’action ZAP tournent déjà en `--network host`. La cible correcte est `http://localhost:4000`.

## 🎯 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI update (no functional changes)
- [ ] ♻️ Code refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update

## 🔗 Related Issues

Related to NIR-104

## 🚀 Changes Made

- Pointer ZAP vers `http://localhost:4000`
- Supprimer l’input invalide `docker_options`
- Conserver `continue-on-error`, l’upload `report_html.html` et le cleanup

## 🧪 Testing

- [ ] Tested locally with `pnpm dev`
- [x] Workflow YAML validé (step ZAP : `localhost:4000`, plus de `docker_options`)
- [ ] Unit tests pass (`pnpm test`) — N/A (changement CI uniquement)
- [ ] Database migrations applied if needed

Le scan reste non bloquant. L’artifact `zap-baseline-report` doit apparaître après un run `api-docker` (vert ou `continue-on-error`).

## 📸 Screenshots/Videos

N/A

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated if needed
- [x] No console errors or warnings
- [x] Removed any debug code

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f80383f9-9e38-44e9-b8e4-20a8a1df78aa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f80383f9-9e38-44e9-b8e4-20a8a1df78aa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

