### PR TITLE
test(web): cover AuthProvider, remaining auth pages, and JWT client

### DIFF
--- a/apps/web/src/app/(auth)/forgot-password/page.test.tsx
+++ b/apps/web/src/app/(auth)/forgot-password/page.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { toast } from "sonner";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import ForgotPasswordPage from "./page";
+
+import { expectNoAxeViolations } from "@/test/axe";
+
+const back = vi.fn();
+const forgotPassword = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+    back,
+  }),
+}));
+
+vi.mock("@/features/auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/auth")>();
+  return {
+    ...actual,
+    useAuth: () => ({ forgotPassword }),
+  };
+});
+
+vi.mock("@/hooks/use-error-message", () => ({
+  useErrorMessage: () => () => "API error message",
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+describe("ForgotPasswordPage", () => {
+  beforeEach(() => {
+    back.mockClear();
+    forgotPassword.mockReset();
+    forgotPassword.mockResolvedValue(undefined);
+  });
+
+  it("shows the email-sent state after a successful request", async () => {
+    render(<ForgotPasswordPage />);
+    const user = userEvent.setup();
+
+    await user.type(screen.getByRole("textbox"), "user@example.com");
+    await user.click(screen.getByRole("button", { name: "common.buttons.send" }));
+
+    await waitFor(() => {
+      expect(forgotPassword).toHaveBeenCalledWith("user@example.com");
+      expect(screen.getByText("auth.forgotPassword.emailSentTitle")).toBeInTheDocument();
+    });
+  });
+
+  it("shows an error toast when the request fails", async () => {
+    forgotPassword.mockRejectedValue({ error: { code: "NOT_FOUND" } });
+    render(<ForgotPasswordPage />);
+    const user = userEvent.setup();
+
+    await user.type(screen.getByRole("textbox"), "user@example.com");
+    await user.click(screen.getByRole("button", { name: "common.buttons.send" }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("auth.forgotPassword.forgotPasswordError", {
+        description: "API error message",
+      });
+    });
+  });
+
+  it("goes back when the back button is clicked", async () => {
+    render(<ForgotPasswordPage />);
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole("button", { name: "common.buttons.back" }));
+
+    expect(back).toHaveBeenCalled();
+  });
+
+  it("has no axe violations", async () => {
+    const { container } = render(<ForgotPasswordPage />);
+
+    await expectNoAxeViolations(container);
+  });
+});

--- a/apps/web/src/app/(auth)/reset-password/page.test.tsx
+++ b/apps/web/src/app/(auth)/reset-password/page.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { toast } from "sonner";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import ResetPasswordPage from "./page";
+
+import { expectNoAxeViolations } from "@/test/axe";
+
+const push = vi.fn();
+const resetPassword = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push,
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+    back: vi.fn(),
+  }),
+}));
+
+vi.mock("@/features/auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/auth")>();
+  return {
+    ...actual,
+    useAuth: () => ({ resetPassword }),
+  };
+});
+
+vi.mock("@/hooks/use-error-message", () => ({
+  useErrorMessage: () => () => "API error message",
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+function fulfilledSearchParams(token?: string) {
+  const value = token ? { token } : {};
+  return {
+    status: "fulfilled" as const,
+    value,
+    then(resolve: (next: typeof value) => void) {
+      resolve(value);
+    },
+  } as unknown as Promise<{ token?: string }>;
+}
+
+function renderPage(page: ReactNode) {
+  return render(page);
+}
+
+describe("ResetPasswordPage", () => {
+  beforeEach(() => {
+    push.mockClear();
+    resetPassword.mockReset();
+    resetPassword.mockResolvedValue(undefined);
+  });
+
+  it("resets the password and redirects to login when a token is present", async () => {
+    renderPage(<ResetPasswordPage searchParams={fulfilledSearchParams("reset-token")} />);
+    const user = userEvent.setup();
+
+    await user.type(screen.getByPlaceholderText("••••••••"), "newpassword1");
+    await user.click(screen.getByRole("button", { name: "auth.resetPassword.resetPassword" }));
+
+    await waitFor(() => {
+      expect(resetPassword).toHaveBeenCalledWith("reset-token", "newpassword1");
+      expect(toast.success).toHaveBeenCalledWith("auth.resetPassword.resetPasswordSuccess", {
+        description: "auth.resetPassword.resetPasswordSuccessDescription",
+      });
+      expect(push).toHaveBeenCalledWith("/login");
+    });
+  });
+
+  it("shows an error toast when the token is missing", async () => {
+    renderPage(<ResetPasswordPage searchParams={fulfilledSearchParams()} />);
+    const user = userEvent.setup();
+
+    await user.type(screen.getByPlaceholderText("••••••••"), "newpassword1");
+    await user.click(screen.getByRole("button", { name: "auth.resetPassword.resetPassword" }));
+
+    await waitFor(() => {
+      expect(resetPassword).not.toHaveBeenCalled();
+      expect(toast.error).toHaveBeenCalledWith("auth.resetPassword.resetPasswordError", {
+        description: "API error message",
+      });
+    });
+  });
+
+  it("shows an error toast when the reset fails", async () => {
+    resetPassword.mockRejectedValue({ error: { code: "TOKEN_INVALID" } });
+    renderPage(<ResetPasswordPage searchParams={fulfilledSearchParams("reset-token")} />);
+    const user = userEvent.setup();
+
+    await user.type(screen.getByPlaceholderText("••••••••"), "newpassword1");
+    await user.click(screen.getByRole("button", { name: "auth.resetPassword.resetPassword" }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("auth.resetPassword.resetPasswordError", {
+        description: "API error message",
+      });
+      expect(push).not.toHaveBeenCalled();
+    });
+  });
+
+  it("has no axe violations", async () => {
+    const { container } = renderPage(
+      <ResetPasswordPage searchParams={fulfilledSearchParams("reset-token")} />
+    );
+
+    await expectNoAxeViolations(container);
+  });
+});

--- a/apps/web/src/app/(auth)/signup/page.test.tsx
+++ b/apps/web/src/app/(auth)/signup/page.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { toast } from "sonner";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import SignupPage from "./page";
+
+import { expectNoAxeViolations } from "@/test/axe";
+
+const signup = vi.fn();
+const resendEmail = vi.fn();
+let searchParams = new URLSearchParams();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+    back: vi.fn(),
+  }),
+  useSearchParams: () => searchParams,
+}));
+
+vi.mock("@/features/auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/auth")>();
+  return {
+    ...actual,
+    useAuth: () => ({ signup, resendEmail }),
+  };
+});
+
+vi.mock("@/hooks/use-error-message", () => ({
+  useErrorMessage: () => () => "API error message",
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+describe("SignupPage", () => {
+  beforeEach(() => {
+    signup.mockReset();
+    signup.mockResolvedValue(undefined);
+    resendEmail.mockReset();
+    resendEmail.mockResolvedValue(undefined);
+    searchParams = new URLSearchParams();
+  });
+
+  async function submitValidSignup() {
+    const user = userEvent.setup();
+    await user.type(screen.getByRole("textbox"), "user@example.com");
+    await user.type(screen.getByPlaceholderText("••••••••"), "password1");
+    await user.click(screen.getByRole("button", { name: "auth.signup.signup" }));
+    return user;
+  }
+
+  it("shows the email-sent state after a successful signup", async () => {
+    render(<SignupPage />);
+
+    await submitValidSignup();
+
+    await waitFor(() => {
+      expect(signup).toHaveBeenCalledWith("user@example.com", "password1");
+      expect(screen.getByText("auth.signup.emailSentTitle")).toBeInTheDocument();
+    });
+  });
+
+  it("resends the verification email from the success state", async () => {
+    render(<SignupPage />);
+    const user = await submitValidSignup();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "auth.verifyEmail.resendEmail" })
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "auth.verifyEmail.resendEmail" }));
+
+    await waitFor(() => {
+      expect(resendEmail).toHaveBeenCalledWith("user@example.com");
+      expect(toast.success).toHaveBeenCalledWith("auth.verifyEmail.emailResent");
+    });
+  });
+
+  it("shows an error toast when signup fails", async () => {
+    signup.mockRejectedValue({ error: { code: "EMAIL_ALREADY_EXISTS" } });
+    render(<SignupPage />);
+
+    await submitValidSignup();
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("auth.signup.signupError", {
+        description: "API error message",
+      });
+    });
+  });
+
+  it("keeps returnUrl on the login link", () => {
+    searchParams = new URLSearchParams("returnUrl=/list/list-1/join?editToken=edit-token");
+    render(<SignupPage />);
+
+    expect(screen.getByRole("link", { name: "auth.signup.login" })).toHaveAttribute(
+      "href",
+      "/login?returnUrl=%2Flist%2Flist-1%2Fjoin%3FeditToken%3Dedit-token"
+    );
+  });
+
+  it("has no axe violations", async () => {
+    const { container } = render(<SignupPage />);
+
+    await expectNoAxeViolations(container);
+  });
+});

--- a/apps/web/src/app/(auth)/verify-email/page.test.tsx
+++ b/apps/web/src/app/(auth)/verify-email/page.test.tsx
@@ -1,0 +1,127 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { toast } from "sonner";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import VerifyEmailPage from "./page";
+
+import { expectNoAxeViolations } from "@/test/axe";
+
+const verifyEmail = vi.fn();
+const resendEmail = vi.fn();
+let searchParams = new URLSearchParams();
+
+vi.mock("next-intl", async () => {
+  const actual = await vi.importActual("next-intl");
+  const t = Object.assign((key: string) => key, { has: () => false });
+  return {
+    ...actual,
+    useTranslations: () => t,
+    useLocale: () => "en",
+  };
+});
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+    back: vi.fn(),
+  }),
+  useSearchParams: () => searchParams,
+}));
+
+vi.mock("@/features/auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/auth")>();
+  return {
+    ...actual,
+    useAuth: () => ({ verifyEmail, resendEmail }),
+  };
+});
+
+vi.mock("@/hooks/use-error-message", () => ({
+  useErrorMessage: () => () => "API error message",
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+describe("VerifyEmailPage", () => {
+  beforeEach(() => {
+    verifyEmail.mockReset();
+    resendEmail.mockReset();
+    resendEmail.mockResolvedValue(undefined);
+    searchParams = new URLSearchParams();
+  });
+
+  it("shows an error when the token is missing", async () => {
+    render(<VerifyEmailPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("auth.verifyEmail.errorTitle")).toBeInTheDocument();
+    });
+    expect(verifyEmail).not.toHaveBeenCalled();
+  });
+
+  it("shows success when verification returns a user", async () => {
+    searchParams = new URLSearchParams("token=verify-token");
+    verifyEmail.mockResolvedValue({ user: { id: "1" } });
+
+    render(<VerifyEmailPage />);
+
+    await waitFor(() => {
+      expect(verifyEmail).toHaveBeenCalledWith("verify-token");
+      expect(screen.getByText("auth.verifyEmail.successTitle")).toBeInTheDocument();
+    });
+    expect(screen.getByRole("link", { name: "auth.verifyEmail.goToLogin" })).toHaveAttribute(
+      "href",
+      "/login"
+    );
+  });
+
+  it("shows an error when verification throws", async () => {
+    searchParams = new URLSearchParams("token=bad-token");
+    verifyEmail.mockRejectedValue({ error: { code: "TOKEN_INVALID" } });
+
+    render(<VerifyEmailPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("auth.verifyEmail.errorTitle")).toBeInTheDocument();
+    });
+  });
+
+  it("resends the verification email from the error state", async () => {
+    searchParams = new URLSearchParams("token=bad-token&email=user@example.com");
+    verifyEmail.mockRejectedValue({ error: { code: "TOKEN_INVALID" } });
+
+    render(<VerifyEmailPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "auth.verifyEmail.resendEmail" })
+      ).toBeInTheDocument();
+    });
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "auth.verifyEmail.resendEmail" }));
+
+    await waitFor(() => {
+      expect(resendEmail).toHaveBeenCalledWith("user@example.com");
+      expect(toast.success).toHaveBeenCalledWith("auth.verifyEmail.emailResent");
+    });
+  });
+
+  it("has no axe violations on the missing-token error state", async () => {
+    const { container } = render(<VerifyEmailPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("auth.verifyEmail.errorTitle")).toBeInTheDocument();
+    });
+
+    await expectNoAxeViolations(container);
+  });
+});

--- a/apps/web/src/features/auth/components/auth-gate.component.test.tsx
+++ b/apps/web/src/features/auth/components/auth-gate.component.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { AuthGate } from "./auth-gate.component";
+
+import { AuthContext, type AuthContextType } from "@/features/auth/context";
+
+function authValue(overrides: Partial<AuthContextType> = {}): AuthContextType {
+  return {
+    user: null,
+    accessToken: null,
+    isLoading: false,
+    login: vi.fn(),
+    logout: vi.fn(),
+    signup: vi.fn(),
+    refresh: vi.fn(),
+    forgotPassword: vi.fn(),
+    resetPassword: vi.fn(),
+    verifyEmail: vi.fn(),
+    resendEmail: vi.fn(),
+    updateProfile: vi.fn(),
+    changePassword: vi.fn(),
+    deleteAccount: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("AuthGate", () => {
+  it("shows a loading spinner while auth is resolving", () => {
+    render(
+      <AuthContext.Provider value={authValue({ isLoading: true })}>
+        <AuthGate>
+          <p>Protected</p>
+        </AuthGate>
+      </AuthContext.Provider>
+    );
+
+    expect(screen.getByLabelText("Loading")).toBeInTheDocument();
+    expect(screen.queryByText("Protected")).not.toBeInTheDocument();
+  });
+
+  it("shows AuthRequiredPrompt when there is no user", () => {
+    render(
+      <AuthContext.Provider value={authValue({ isLoading: false, user: null })}>
+        <AuthGate>
+          <p>Protected</p>
+        </AuthGate>
+      </AuthContext.Provider>
+    );
+
+    expect(screen.getByRole("heading", { name: "title" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "login" })).toHaveAttribute("href", "/login");
+    expect(screen.queryByText("Protected")).not.toBeInTheDocument();
+  });
+
+  it("renders children when the user is authenticated", () => {
+    render(
+      <AuthContext.Provider
+        value={authValue({
+          isLoading: false,
+          user: { id: "1", email: "user@example.com", name: "User", emailVerified: true },
+        })}
+      >
+        <AuthGate>
+          <p>Protected</p>
+        </AuthGate>
+      </AuthContext.Provider>
+    );
+
+    expect(screen.getByText("Protected")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/auth/components/auth-required-prompt.component.test.tsx
+++ b/apps/web/src/features/auth/components/auth-required-prompt.component.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { AuthRequiredPrompt } from "./auth-required-prompt.component";
+
+describe("AuthRequiredPrompt", () => {
+  it("links to login and signup without a return path", () => {
+    render(<AuthRequiredPrompt />);
+
+    expect(screen.getByRole("heading", { name: "title" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "login" })).toHaveAttribute("href", "/login");
+    expect(screen.getByRole("link", { name: "signup" })).toHaveAttribute("href", "/signup");
+  });
+
+  it("keeps a safe returnPath on the login and signup links", () => {
+    render(<AuthRequiredPrompt returnPath="/list/list-1/join?editToken=edit-token" />);
+
+    expect(screen.getByRole("link", { name: "login" })).toHaveAttribute(
+      "href",
+      "/login?returnUrl=%2Flist%2Flist-1%2Fjoin%3FeditToken%3Dedit-token"
+    );
+    expect(screen.getByRole("link", { name: "signup" })).toHaveAttribute(
+      "href",
+      "/signup?returnUrl=%2Flist%2Flist-1%2Fjoin%3FeditToken%3Dedit-token"
+    );
+  });
+
+  it("falls back to /login and /signup when returnPath is unsafe", () => {
+    render(<AuthRequiredPrompt returnPath="https://evil.example" />);
+
+    expect(screen.getByRole("link", { name: "login" })).toHaveAttribute("href", "/login");
+    expect(screen.getByRole("link", { name: "signup" })).toHaveAttribute("href", "/signup");
+  });
+});

--- a/apps/web/src/features/auth/provider.test.tsx
+++ b/apps/web/src/features/auth/provider.test.tsx
@@ -1,0 +1,339 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AuthProvider } from "./provider";
+
+import { useAuth } from "@/features/auth/hooks";
+import {
+  login,
+  logout,
+  signup,
+  refreshToken,
+  getMe,
+  forgotPassword,
+  resetPassword,
+  verifyEmail,
+  resendVerification,
+  updateMe,
+  changePassword,
+  deleteAccount,
+} from "@/lib/api";
+
+vi.mock("@/lib/api", () => ({
+  login: vi.fn(),
+  logout: vi.fn(),
+  signup: vi.fn(),
+  refreshToken: vi.fn(),
+  getMe: vi.fn(),
+  forgotPassword: vi.fn(),
+  resetPassword: vi.fn(),
+  verifyEmail: vi.fn(),
+  resendVerification: vi.fn(),
+  updateMe: vi.fn(),
+  changePassword: vi.fn(),
+  deleteAccount: vi.fn(),
+}));
+
+const mockUser = {
+  id: "user-1",
+  email: "user@example.com",
+  name: "Test User",
+  emailVerified: true,
+};
+
+function apiResponse(value: { data?: unknown; error?: unknown }) {
+  return value as { data?: unknown; error?: unknown };
+}
+
+describe("AuthProvider", () => {
+  let queryClient: QueryClient;
+
+  function wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>{children}</AuthProvider>
+      </QueryClientProvider>
+    );
+  }
+
+  async function renderAuth() {
+    const hook = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => {
+      expect(hook.result.current.isLoading).toBe(false);
+    });
+    return hook;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    vi.mocked(refreshToken).mockResolvedValue(apiResponse({}) as never);
+  });
+
+  it("finishes bootstrap with isLoading false and no user when refresh has no data", async () => {
+    const { result } = await renderAuth();
+
+    expect(result.current.user).toBeNull();
+    expect(result.current.accessToken).toBeNull();
+    expect(refreshToken).toHaveBeenCalled();
+  });
+
+  it("loads the session when refresh and getMe succeed on mount", async () => {
+    vi.mocked(refreshToken).mockResolvedValue(
+      apiResponse({ data: { accessToken: "boot-token" } }) as never
+    );
+    vi.mocked(getMe).mockResolvedValue(apiResponse({ data: { user: mockUser } }) as never);
+
+    const { result } = await renderAuth();
+
+    expect(result.current.accessToken).toBe("boot-token");
+    expect(result.current.user).toEqual(mockUser);
+  });
+
+  it("logs in, stores the token, and fetches the user", async () => {
+    vi.mocked(login).mockResolvedValue(apiResponse({ data: { accessToken: "access-1" } }) as never);
+    vi.mocked(getMe).mockResolvedValue(apiResponse({ data: { user: mockUser } }) as never);
+
+    const { result } = await renderAuth();
+
+    await act(async () => {
+      await result.current.login("user@example.com", "password1");
+    });
+
+    expect(login).toHaveBeenCalledWith({
+      body: { email: "user@example.com", password: "password1" },
+    });
+    expect(result.current.accessToken).toBe("access-1");
+    expect(result.current.user).toEqual(mockUser);
+  });
+
+  it("throws the API error when login has no data", async () => {
+    const apiError = { code: "UNAUTHORIZED", message: "Invalid credentials" };
+    vi.mocked(login).mockResolvedValue(apiResponse({ error: apiError }) as never);
+
+    const { result } = await renderAuth();
+
+    await expect(
+      act(async () => {
+        await result.current.login("user@example.com", "wrong");
+      })
+    ).rejects.toEqual(apiError);
+  });
+
+  it("signs up and returns the API payload", async () => {
+    const data = { message: "Verify your email" };
+    vi.mocked(signup).mockResolvedValue(apiResponse({ data }) as never);
+
+    const { result } = await renderAuth();
+
+    let resolved: unknown;
+    await act(async () => {
+      resolved = await result.current.signup("user@example.com", "password1", "fr");
+    });
+
+    expect(signup).toHaveBeenCalledWith({
+      body: { email: "user@example.com", password: "password1", language: "fr" },
+    });
+    expect(resolved).toEqual(data);
+  });
+
+  it("throws when signup has no data", async () => {
+    const apiError = { code: "EMAIL_ALREADY_EXISTS" };
+    vi.mocked(signup).mockResolvedValue(apiResponse({ error: apiError }) as never);
+
+    const { result } = await renderAuth();
+
+    await expect(
+      act(async () => {
+        await result.current.signup("user@example.com", "password1");
+      })
+    ).rejects.toEqual(apiError);
+  });
+
+  it("clears session and query cache on logout even if the API fails", async () => {
+    vi.mocked(login).mockResolvedValue(apiResponse({ data: { accessToken: "access-1" } }) as never);
+    vi.mocked(getMe).mockResolvedValue(apiResponse({ data: { user: mockUser } }) as never);
+    vi.mocked(logout).mockRejectedValue(new Error("network"));
+    const clearSpy = vi.spyOn(queryClient, "clear");
+
+    const { result } = await renderAuth();
+
+    await act(async () => {
+      await result.current.login("user@example.com", "password1");
+    });
+
+    await act(async () => {
+      await expect(result.current.logout()).rejects.toThrow("network");
+    });
+
+    expect(result.current.user).toBeNull();
+    expect(result.current.accessToken).toBeNull();
+    expect(clearSpy).toHaveBeenCalled();
+  });
+
+  it("sends a forgot-password request", async () => {
+    vi.mocked(forgotPassword).mockResolvedValue(apiResponse({ data: { message: "ok" } }) as never);
+
+    const { result } = await renderAuth();
+
+    await act(async () => {
+      await result.current.forgotPassword("user@example.com", "en");
+    });
+
+    expect(forgotPassword).toHaveBeenCalledWith({
+      body: { email: "user@example.com", language: "en" },
+    });
+  });
+
+  it("throws when forgot-password has no data", async () => {
+    const apiError = { code: "NOT_FOUND" };
+    vi.mocked(forgotPassword).mockResolvedValue(apiResponse({ error: apiError }) as never);
+
+    const { result } = await renderAuth();
+
+    await expect(
+      act(async () => {
+        await result.current.forgotPassword("user@example.com");
+      })
+    ).rejects.toEqual(apiError);
+  });
+
+  it("resets the password with the token", async () => {
+    vi.mocked(resetPassword).mockResolvedValue(apiResponse({ data: { message: "ok" } }) as never);
+
+    const { result } = await renderAuth();
+
+    await act(async () => {
+      await result.current.resetPassword("reset-token", "newpassword1");
+    });
+
+    expect(resetPassword).toHaveBeenCalledWith({
+      body: { token: "reset-token", password: "newpassword1" },
+    });
+  });
+
+  it("verifies email and returns the payload", async () => {
+    const data = { user: mockUser };
+    vi.mocked(verifyEmail).mockResolvedValue(apiResponse({ data }) as never);
+
+    const { result } = await renderAuth();
+
+    let resolved: unknown;
+    await act(async () => {
+      resolved = await result.current.verifyEmail("verify-token");
+    });
+
+    expect(verifyEmail).toHaveBeenCalledWith({ query: { token: "verify-token" } });
+    expect(resolved).toEqual(data);
+  });
+
+  it("resends the verification email", async () => {
+    vi.mocked(resendVerification).mockResolvedValue(
+      apiResponse({ data: { message: "ok" } }) as never
+    );
+
+    const { result } = await renderAuth();
+
+    await act(async () => {
+      await result.current.resendEmail("user@example.com");
+    });
+
+    expect(resendVerification).toHaveBeenCalledWith({ body: { email: "user@example.com" } });
+  });
+
+  it("updates the profile user on success", async () => {
+    const updated = { ...mockUser, name: "New Name", bio: "Hello" };
+    vi.mocked(updateMe).mockResolvedValue(apiResponse({ data: { user: updated } }) as never);
+
+    const { result } = await renderAuth();
+
+    await act(async () => {
+      await result.current.updateProfile("New Name", "https://cdn/avatar.png", "Hello");
+    });
+
+    expect(updateMe).toHaveBeenCalledWith({
+      body: { name: "New Name", avatarUrl: "https://cdn/avatar.png", bio: "Hello" },
+    });
+    expect(result.current.user).toEqual(updated);
+  });
+
+  it("changes the password", async () => {
+    vi.mocked(changePassword).mockResolvedValue(apiResponse({ data: { message: "ok" } }) as never);
+
+    const { result } = await renderAuth();
+
+    await act(async () => {
+      await result.current.changePassword("oldpassword1", "newpassword1");
+    });
+
+    expect(changePassword).toHaveBeenCalledWith({
+      body: { oldPassword: "oldpassword1", newPassword: "newpassword1" },
+    });
+  });
+
+  it("clears token and user after a successful account deletion", async () => {
+    vi.mocked(login).mockResolvedValue(apiResponse({ data: { accessToken: "access-1" } }) as never);
+    vi.mocked(getMe).mockResolvedValue(apiResponse({ data: { user: mockUser } }) as never);
+    vi.mocked(deleteAccount).mockResolvedValue(apiResponse({ data: { message: "ok" } }) as never);
+
+    const { result } = await renderAuth();
+
+    await act(async () => {
+      await result.current.login("user@example.com", "password1");
+    });
+
+    await act(async () => {
+      await result.current.deleteAccount("password1", "fr");
+    });
+
+    expect(deleteAccount).toHaveBeenCalledWith({
+      body: { password: "password1", language: "fr" },
+    });
+    expect(result.current.user).toBeNull();
+    expect(result.current.accessToken).toBeNull();
+  });
+
+  it("clears the session when refresh returns no data", async () => {
+    vi.mocked(login).mockResolvedValue(apiResponse({ data: { accessToken: "access-1" } }) as never);
+    vi.mocked(getMe).mockResolvedValue(apiResponse({ data: { user: mockUser } }) as never);
+
+    const { result } = await renderAuth();
+
+    await act(async () => {
+      await result.current.login("user@example.com", "password1");
+    });
+
+    vi.mocked(refreshToken).mockResolvedValue(apiResponse({}) as never);
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(result.current.user).toBeNull();
+    expect(result.current.accessToken).toBeNull();
+  });
+
+  it("clears the session when refresh throws", async () => {
+    vi.mocked(login).mockResolvedValue(apiResponse({ data: { accessToken: "access-1" } }) as never);
+    vi.mocked(getMe).mockResolvedValue(apiResponse({ data: { user: mockUser } }) as never);
+
+    const { result } = await renderAuth();
+
+    await act(async () => {
+      await result.current.login("user@example.com", "password1");
+    });
+
+    vi.mocked(refreshToken).mockRejectedValue(new Error("offline"));
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(result.current.user).toBeNull();
+    expect(result.current.accessToken).toBeNull();
+  });
+});

--- a/apps/web/src/lib/api/client.test.ts
+++ b/apps/web/src/lib/api/client.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { apiClient, getAccessToken, setAccessToken, setRefreshTokenFn } from "./client";
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("apiClient interceptors", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+    setAccessToken(null);
+    setRefreshTokenFn(async () => null);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    setAccessToken(null);
+    setRefreshTokenFn(async () => null);
+  });
+
+  it("sets the Authorization header when an access token is present", async () => {
+    setAccessToken("access-token");
+    fetchMock.mockResolvedValue(jsonResponse({ ok: true }));
+
+    await apiClient.get({ url: "/list" });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const request = fetchMock.mock.calls[0][0] as Request;
+    expect(request.headers.get("Authorization")).toBe("Bearer access-token");
+  });
+
+  it("does not set Authorization when there is no access token", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ ok: true }));
+
+    await apiClient.get({ url: "/list" });
+
+    const request = fetchMock.mock.calls[0][0] as Request;
+    expect(request.headers.get("Authorization")).toBeNull();
+  });
+
+  it("does not retry 401 responses on auth routes", async () => {
+    setAccessToken("access-token");
+    const refresh = vi.fn().mockResolvedValue("new-token");
+    setRefreshTokenFn(refresh);
+    fetchMock.mockResolvedValue(jsonResponse({ error: "unauthorized" }, 401));
+
+    await apiClient.post({ url: "/auth/login", body: { email: "a@b.c", password: "x" } });
+
+    expect(refresh).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a 401 with the refreshed token on non-auth routes", async () => {
+    setAccessToken("old-token");
+    const refresh = vi.fn().mockResolvedValue("new-token");
+    setRefreshTokenFn(refresh);
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ error: "unauthorized" }, 401))
+      .mockResolvedValueOnce(jsonResponse({ lists: [] }, 200));
+
+    const result = await apiClient.get({ url: "/list" });
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const retryRequest = fetchMock.mock.calls[1][0] as Request | string;
+    const retryInit = fetchMock.mock.calls[1][1] as RequestInit | undefined;
+    const retryHeaders =
+      retryInit?.headers instanceof Headers
+        ? retryInit.headers
+        : retryRequest instanceof Request
+          ? retryRequest.headers
+          : new Headers(retryInit?.headers);
+    expect(retryHeaders.get("Authorization")).toBe("Bearer new-token");
+    expect(result.data).toEqual({ lists: [] });
+  });
+
+  it("clears the access token when refresh throws during a 401 retry", async () => {
+    setAccessToken("old-token");
+    setRefreshTokenFn(async () => {
+      throw new Error("refresh failed");
+    });
+    fetchMock.mockResolvedValue(jsonResponse({ error: "unauthorized" }, 401));
+
+    await apiClient.get({ url: "/list" });
+
+    expect(getAccessToken()).toBeNull();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds Vitest coverage for the remaining critical auth paths on the web app (Linear NIR-106, parent NIR-105).

## Type of Change

- [x] Test update

## Related Issues

Related to NIR-106 / NIR-105

## Changes Made

- `AuthProvider` success/error paths (login, signup, logout cache clear, refresh, forgot/reset/verify/resend, profile, password, delete account)
- `AuthGate` loading / anonymous / authenticated
- `AuthRequiredPrompt` login/signup links and safe `returnPath`
- Pages: signup, forgot-password, reset-password, verify-email (axe included)
- `lib/api/client` Bearer header, no retry on `/auth/*`, 401 refresh retry, clear token on refresh failure

## Testing

- [x] Unit tests pass (`pnpm -C apps/web test` on the new files)
- [ ] Tested locally with `pnpm dev`
- [x] All quality checks pass (`pnpm lint` via pre-commit)

## Checklist

- [x] Code follows project style guidelines
- [x] No console errors or warnings
- [x] Removed any debug code

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-836068bc-50ef-4a28-878b-c28d20dfa7ad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-836068bc-50ef-4a28-878b-c28d20dfa7ad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

