### PR TITLE
test(web): cover remaining lists CRUD hooks and forms

### DIFF
--- a/apps/web/src/features/lists/components/delete-list-dialog.test.tsx
+++ b/apps/web/src/features/lists/components/delete-list-dialog.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { toast } from "sonner";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useDeleteList } from "../hooks/use-delete-list";
+
+import { DeleteListDialog } from "./delete-list-dialog";
+
+import { getErrorCode } from "@/lib/api/errors";
+
+vi.mock("../hooks/use-delete-list", () => ({
+  useDeleteList: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-error-message", () => ({
+  useErrorMessage: () => () => "API error message",
+}));
+
+vi.mock("@/lib/api/errors", () => ({
+  getErrorCode: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("DeleteListDialog", () => {
+  const mutateAsync = vi.fn();
+  const onOpenChange = vi.fn();
+  const onDeleted = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getErrorCode).mockReturnValue(null);
+    mutateAsync.mockResolvedValue({ message: "List deleted successfully" });
+    vi.mocked(useDeleteList).mockReturnValue({
+      mutateAsync,
+      isPending: false,
+    } as unknown as ReturnType<typeof useDeleteList>);
+  });
+
+  it("confirms deletion and shows a success toast", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <DeleteListDialog listId="list-1" open onOpenChange={onOpenChange} onDeleted={onDeleted} />
+    );
+
+    await user.click(screen.getByRole("button", { name: "delete.confirmSubmit" }));
+
+    expect(mutateAsync).toHaveBeenCalledWith("list-1");
+    expect(toast.success).toHaveBeenCalledWith("deleteList.success");
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onDeleted).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes without an error toast when the list is already gone", async () => {
+    const user = userEvent.setup();
+    vi.mocked(getErrorCode).mockReturnValue("LIST_NOT_FOUND");
+    mutateAsync.mockRejectedValue({ error: { code: "LIST_NOT_FOUND" } });
+
+    render(
+      <DeleteListDialog listId="list-1" open onOpenChange={onOpenChange} onDeleted={onDeleted} />
+    );
+
+    await user.click(screen.getByRole("button", { name: "delete.confirmSubmit" }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onDeleted).toHaveBeenCalledTimes(1);
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("shows an error toast for other API failures", async () => {
+    const user = userEvent.setup();
+    mutateAsync.mockRejectedValue({ error: { code: "LIST_ACCESS_DENIED" } });
+
+    render(
+      <DeleteListDialog listId="list-1" open onOpenChange={onOpenChange} onDeleted={onDeleted} />
+    );
+
+    await user.click(screen.getByRole("button", { name: "delete.confirmSubmit" }));
+
+    expect(toast.error).toHaveBeenCalledWith("deleteList.error", {
+      description: "API error message",
+    });
+    expect(onDeleted).not.toHaveBeenCalled();
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+});

--- a/apps/web/src/features/lists/forms/create-list-form.test.tsx
+++ b/apps/web/src/features/lists/forms/create-list-form.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { toast } from "sonner";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CreateListForm } from "./create-list-form";
+
+import { useCreateList } from "@/features/lists";
+
+vi.mock("@/features/lists", () => ({
+  DEFAULT_LIST_VISIBILITY: "PRIVATE",
+  useCreateList: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-error-message", () => ({
+  useErrorMessage: () => () => "API error message",
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("CreateListForm", () => {
+  const mutateAsync = vi.fn();
+  const closeDialog = vi.fn();
+  const onCreated = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mutateAsync.mockResolvedValue({ list: { id: "list-1", name: "Paris" } });
+    vi.mocked(useCreateList).mockReturnValue({
+      mutateAsync,
+      isPending: false,
+    } as unknown as ReturnType<typeof useCreateList>);
+  });
+
+  it("submits a valid list and notifies success", async () => {
+    const user = userEvent.setup();
+    render(<CreateListForm closeDialog={closeDialog} onCreated={onCreated} />);
+
+    await user.type(screen.getByLabelText("fields.name"), "Paris");
+    await user.click(screen.getByRole("button", { name: "create.submit" }));
+
+    await waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledWith({
+        name: "Paris",
+        description: undefined,
+        visibility: "PRIVATE",
+      });
+      expect(toast.success).toHaveBeenCalledWith("createList.success");
+      expect(closeDialog).toHaveBeenCalled();
+      expect(onCreated).toHaveBeenCalledWith("list-1");
+    });
+  });
+
+  it("shows an error toast when create fails", async () => {
+    mutateAsync.mockRejectedValue({ error: { code: "FORBIDDEN" } });
+    const user = userEvent.setup();
+    render(<CreateListForm closeDialog={closeDialog} onCreated={onCreated} />);
+
+    await user.type(screen.getByLabelText("fields.name"), "Paris");
+    await user.click(screen.getByRole("button", { name: "create.submit" }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("createList.error", {
+        description: "API error message",
+      });
+    });
+    expect(onCreated).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/features/lists/forms/edit-list-form.test.tsx
+++ b/apps/web/src/features/lists/forms/edit-list-form.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { toast } from "sonner";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { EditListForm } from "./edit-list-form";
+
+import { useUpdateList } from "@/features/lists";
+
+vi.mock("@/features/lists", () => ({
+  useUpdateList: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-error-message", () => ({
+  useErrorMessage: () => () => "API error message",
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const defaultValues = {
+  name: "Paris spots",
+  description: "Favorites",
+  visibility: "PRIVATE" as const,
+};
+
+describe("EditListForm", () => {
+  const mutateAsync = vi.fn();
+  const onUpdated = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mutateAsync.mockResolvedValue({ list: { id: "list-1", name: "Paris spots" } });
+    vi.mocked(useUpdateList).mockReturnValue({
+      mutateAsync,
+      isPending: false,
+    } as unknown as ReturnType<typeof useUpdateList>);
+  });
+
+  it("prefills the form and submits an update", async () => {
+    const user = userEvent.setup();
+    render(<EditListForm listId="list-1" defaultValues={defaultValues} onUpdated={onUpdated} />);
+
+    expect(screen.getByLabelText("fields.name")).toHaveValue("Paris spots");
+    expect(screen.getByLabelText("fields.description")).toHaveValue("Favorites");
+
+    await user.clear(screen.getByLabelText("fields.name"));
+    await user.type(screen.getByLabelText("fields.name"), "Lyon spots");
+    await user.click(screen.getByRole("button", { name: "edit.submit" }));
+
+    await waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledWith({
+        listId: "list-1",
+        body: {
+          name: "Lyon spots",
+          description: "Favorites",
+          visibility: "PRIVATE",
+        },
+      });
+      expect(toast.success).toHaveBeenCalledWith("updateList.success");
+      expect(onUpdated).toHaveBeenCalled();
+    });
+  });
+
+  it("shows an error toast when update fails", async () => {
+    mutateAsync.mockRejectedValue({ error: { code: "FORBIDDEN" } });
+    const user = userEvent.setup();
+    render(<EditListForm listId="list-1" defaultValues={defaultValues} onUpdated={onUpdated} />);
+
+    await user.click(screen.getByRole("button", { name: "edit.submit" }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("updateList.error", {
+        description: "API error message",
+      });
+    });
+    expect(onUpdated).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/features/lists/hooks/use-list.test.tsx
+++ b/apps/web/src/features/lists/hooks/use-list.test.tsx
@@ -1,0 +1,82 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useList } from "./use-list";
+
+import { getListById } from "@/lib/api";
+
+const useAuth = vi.fn();
+
+vi.mock("@/features/auth", () => ({
+  useAuth: () => useAuth(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  getListById: vi.fn(),
+}));
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe("useList", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    useAuth.mockReturnValue({ user: { id: "user-1" } });
+  });
+
+  it("does not fetch when listId is undefined", () => {
+    renderHook(() => useList(undefined), { wrapper: createWrapper(queryClient) });
+
+    expect(getListById).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch when the user is absent", () => {
+    useAuth.mockReturnValue({ user: null });
+
+    renderHook(() => useList("list-1"), { wrapper: createWrapper(queryClient) });
+
+    expect(getListById).not.toHaveBeenCalled();
+  });
+
+  it("fetches a list by id", async () => {
+    const data = { list: { id: "list-1", name: "Paris" } };
+    vi.mocked(getListById).mockResolvedValue({ data } as Awaited<ReturnType<typeof getListById>>);
+
+    const { result } = renderHook(() => useList("list-1"), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(getListById).toHaveBeenCalledWith({ path: { listId: "list-1" } });
+    expect(result.current.data).toEqual(data);
+  });
+
+  it("throws API error when response has no data", async () => {
+    const apiError = { message: "Not found" };
+    vi.mocked(getListById).mockResolvedValue({ error: apiError } as Awaited<
+      ReturnType<typeof getListById>
+    >);
+
+    const { result } = renderHook(() => useList("list-1"), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(result.current.error).toEqual(apiError);
+  });
+});

--- a/apps/web/src/features/lists/hooks/use-lists-infinite.test.tsx
+++ b/apps/web/src/features/lists/hooks/use-lists-infinite.test.tsx
@@ -1,0 +1,113 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useListsInfinite } from "./use-lists-infinite";
+
+import { getLists } from "@/lib/api";
+
+const useAuth = vi.fn();
+
+vi.mock("@/features/auth", () => ({
+  useAuth: () => useAuth(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  getLists: vi.fn(),
+}));
+
+function page(pageNumber: number, totalPages: number) {
+  return {
+    lists: [{ id: `list-${pageNumber}`, name: `Page ${pageNumber}` }],
+    pagination: { page: pageNumber, limit: 20, total: 40, totalPages },
+  };
+}
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe("useListsInfinite", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    useAuth.mockReturnValue({ user: { id: "user-1" } });
+  });
+
+  it("does not fetch when the user is absent", () => {
+    useAuth.mockReturnValue({ user: null });
+
+    renderHook(() => useListsInfinite(), { wrapper: createWrapper(queryClient) });
+
+    expect(getLists).not.toHaveBeenCalled();
+  });
+
+  it("fetches the first page and exposes the next page param", async () => {
+    vi.mocked(getLists).mockResolvedValue({ data: page(1, 2) } as Awaited<
+      ReturnType<typeof getLists>
+    >);
+
+    const { result } = renderHook(() => useListsInfinite({ visibility: "PRIVATE" }), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(getLists).toHaveBeenCalledWith({
+      query: { visibility: "PRIVATE", page: 1, limit: 20 },
+    });
+    expect(result.current.hasNextPage).toBe(true);
+  });
+
+  it("fetches the next page until totalPages is reached", async () => {
+    vi.mocked(getLists)
+      .mockResolvedValueOnce({ data: page(1, 2) } as Awaited<ReturnType<typeof getLists>>)
+      .mockResolvedValueOnce({ data: page(2, 2) } as Awaited<ReturnType<typeof getLists>>);
+
+    const { result } = renderHook(() => useListsInfinite(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => {
+      expect(result.current.hasNextPage).toBe(true);
+    });
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => {
+      expect(result.current.hasNextPage).toBe(false);
+    });
+
+    expect(getLists).toHaveBeenNthCalledWith(2, {
+      query: { page: 2, limit: 20 },
+    });
+    expect(result.current.data?.pages).toHaveLength(2);
+  });
+
+  it("throws API error when a page has no data", async () => {
+    const apiError = { message: "Unauthorized" };
+    vi.mocked(getLists).mockResolvedValue({ error: apiError } as Awaited<
+      ReturnType<typeof getLists>
+    >);
+
+    const { result } = renderHook(() => useListsInfinite(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(result.current.error).toEqual(apiError);
+  });
+});

--- a/apps/web/src/features/lists/hooks/use-lists.test.tsx
+++ b/apps/web/src/features/lists/hooks/use-lists.test.tsx
@@ -1,0 +1,78 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useLists } from "./use-lists";
+
+import { getLists } from "@/lib/api";
+
+const useAuth = vi.fn();
+
+vi.mock("@/features/auth", () => ({
+  useAuth: () => useAuth(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  getLists: vi.fn(),
+}));
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe("useLists", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    useAuth.mockReturnValue({ user: { id: "user-1" } });
+  });
+
+  it("does not fetch when the user is absent", () => {
+    useAuth.mockReturnValue({ user: null });
+
+    renderHook(() => useLists(), { wrapper: createWrapper(queryClient) });
+
+    expect(getLists).not.toHaveBeenCalled();
+  });
+
+  it("fetches lists with filters when the user is present", async () => {
+    const data = {
+      lists: [{ id: "list-1", name: "Paris" }],
+      pagination: { page: 1, limit: 20, total: 1, totalPages: 1 },
+    };
+    vi.mocked(getLists).mockResolvedValue({ data } as Awaited<ReturnType<typeof getLists>>);
+    const filters = { page: 1, limit: 20 };
+
+    const { result } = renderHook(() => useLists(filters), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(getLists).toHaveBeenCalledWith({ query: filters });
+    expect(result.current.data).toEqual(data);
+  });
+
+  it("throws API error when response has no data", async () => {
+    const apiError = { message: "Unauthorized" };
+    vi.mocked(getLists).mockResolvedValue({ error: apiError } as Awaited<
+      ReturnType<typeof getLists>
+    >);
+
+    const { result } = renderHook(() => useLists(), { wrapper: createWrapper(queryClient) });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(result.current.error).toEqual(apiError);
+  });
+});

--- a/apps/web/src/features/lists/hooks/use-update-list.test.tsx
+++ b/apps/web/src/features/lists/hooks/use-update-list.test.tsx
@@ -1,0 +1,93 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useUpdateList } from "./use-update-list";
+
+import { updateList } from "@/lib/api";
+import { queryKeys } from "@/lib/api/query-keys";
+
+vi.mock("@/lib/api", () => ({
+  updateList: vi.fn(),
+}));
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+function apiResponse(value: { data?: unknown; error?: unknown }) {
+  return value as Awaited<ReturnType<typeof updateList>>;
+}
+
+describe("useUpdateList", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+  });
+
+  it("calls updateList and returns data on success", async () => {
+    const body = { name: "Paris", visibility: "PRIVATE" as const };
+    const data = { list: { id: "list-1", name: "Paris" } };
+    vi.mocked(updateList).mockResolvedValue(apiResponse({ data }));
+
+    const { result } = renderHook(() => useUpdateList(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    let resolved: unknown;
+    await act(async () => {
+      resolved = await result.current.mutateAsync({ listId: "list-1", body });
+    });
+
+    expect(updateList).toHaveBeenCalledWith({ path: { listId: "list-1" }, body });
+    expect(resolved).toEqual(data);
+  });
+
+  it("invalidates list index and detail caches on success", async () => {
+    vi.mocked(updateList).mockResolvedValue(
+      apiResponse({ data: { list: { id: "list-1", name: "Paris" } } })
+    );
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useUpdateList(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        listId: "list-1",
+        body: { name: "Paris", visibility: "PRIVATE" },
+      });
+    });
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.lists.all });
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.lists.detail("list-1") });
+    });
+  });
+
+  it("throws API error when response has no data", async () => {
+    const apiError = { message: "Forbidden" };
+    vi.mocked(updateList).mockResolvedValue(apiResponse({ error: apiError }));
+
+    const { result } = renderHook(() => useUpdateList(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await expect(
+      act(async () => {
+        await result.current.mutateAsync({
+          listId: "list-1",
+          body: { name: "Paris", visibility: "PRIVATE" },
+        });
+      })
+    ).rejects.toEqual(apiError);
+  });
+});

--- a/apps/web/src/features/lists/views/join-flow-view.test.tsx
+++ b/apps/web/src/features/lists/views/join-flow-view.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { JoinFlowView } from "./join-flow-view";
+
+vi.mock("@/hooks/use-error-message", () => ({
+  useErrorMessage: () => () => "API error message",
+}));
+
+const baseProps = {
+  mode: "edit" as const,
+  returnPath: "/list/list-1/join?editToken=token",
+  token: "edit-token",
+  isAuthLoading: false,
+  isAuthenticated: true,
+  isJoining: false,
+  error: null,
+};
+
+describe("JoinFlowView", () => {
+  it("shows a loading spinner while auth is resolving", () => {
+    render(<JoinFlowView {...baseProps} isAuthLoading />);
+
+    expect(screen.getByLabelText("Loading")).toBeInTheDocument();
+    expect(screen.queryByRole("heading")).not.toBeInTheDocument();
+  });
+
+  it("shows AuthRequiredPrompt when the user is anonymous", () => {
+    render(<JoinFlowView {...baseProps} isAuthenticated={false} token={null} />);
+
+    expect(screen.getByRole("heading", { name: "join.edit.title" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "login" })).toHaveAttribute(
+      "href",
+      "/login?returnUrl=%2Flist%2Flist-1%2Fjoin%3FeditToken%3Dtoken"
+    );
+  });
+
+  it("shows a missing-token alert when authenticated without a token", () => {
+    render(<JoinFlowView {...baseProps} token={null} />);
+
+    expect(screen.getByRole("alert")).toHaveTextContent("join.missingToken");
+  });
+
+  it("shows the error message when join fails", () => {
+    render(<JoinFlowView {...baseProps} error={{ message: "boom" }} />);
+
+    expect(screen.getByRole("alert")).toHaveTextContent("API error message");
+  });
+
+  it("shows the joining state when authenticated with a token and no error", () => {
+    render(<JoinFlowView {...baseProps} isJoining />);
+
+    expect(screen.getByLabelText("join.joining")).toBeInTheDocument();
+    expect(screen.getByText("join.joining")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/lists/views/lists-create-view.test.tsx
+++ b/apps/web/src/features/lists/views/lists-create-view.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { ListsCreateView } from "./lists-create-view";
+
+vi.mock("../forms/create-list-form", () => ({
+  CreateListForm: ({
+    closeDialog,
+    onCreated,
+    embedded,
+  }: {
+    closeDialog?: () => void;
+    onCreated?: (listId: string) => void;
+    embedded?: boolean;
+  }) => (
+    <div data-testid="create-list-form" data-embedded={embedded ? "1" : "0"}>
+      <button type="button" onClick={() => closeDialog?.()}>
+        close
+      </button>
+      <button type="button" onClick={() => onCreated?.("list-1")}>
+        created
+      </button>
+    </div>
+  ),
+}));
+
+describe("ListsCreateView", () => {
+  it("renders the create title and embedded form", () => {
+    render(<ListsCreateView onBack={vi.fn()} />);
+
+    expect(screen.getByRole("heading", { name: "create.title" })).toBeInTheDocument();
+    expect(screen.getByTestId("create-list-form")).toHaveAttribute("data-embedded", "1");
+  });
+
+  it("goes back from the header and after create/close", async () => {
+    const onBack = vi.fn();
+    const user = userEvent.setup();
+    render(<ListsCreateView onBack={onBack} />);
+
+    await user.click(screen.getByRole("button", { name: "common.buttons.back" }));
+    expect(onBack).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole("button", { name: "close" }));
+    expect(onBack).toHaveBeenCalledTimes(2);
+
+    await user.click(screen.getByRole("button", { name: "created" }));
+    expect(onBack).toHaveBeenCalledTimes(3);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds Vitest coverage for remaining lists CRUD hooks and forms (Linear NIR-107, parent NIR-105).

## Type of Change

- [x] Test update

## Related Issues

Related to NIR-107 / NIR-105

## Changes Made

- Hooks: `useLists`, `useList`, `useListsInfinite`, `useUpdateList`
- Forms: `CreateListForm`, `EditListForm`, `ListsCreateView`
- `DeleteListDialog` (success, LIST_NOT_FOUND, other errors)
- `JoinFlowView` (loading, anonymous, missing token, error, joining)

## Testing

- [x] Unit tests pass (`pnpm -C apps/web exec vitest run` on the new files)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-836068bc-50ef-4a28-878b-c28d20dfa7ad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-836068bc-50ef-4a28-878b-c28d20dfa7ad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

