### PR TITLE
test(web): cover account deletion and password change

### DIFF
--- a/apps/web/src/features/profile/forms/change-password-content.test.tsx
+++ b/apps/web/src/features/profile/forms/change-password-content.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { toast } from "sonner";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ChangePasswordContent } from "./change-password-content";
+
+const changePassword = vi.fn();
+
+vi.mock("@/features/auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/auth")>();
+  return {
+    ...actual,
+    useAuth: () => ({ changePassword }),
+  };
+});
+
+vi.mock("@/hooks/use-error-message", () => ({
+  useErrorMessage: () => () => "API error message",
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+function passwordInput(name: "oldPassword" | "newPassword") {
+  const input = document.querySelector<HTMLInputElement>(`input[name="${name}"]`);
+  if (!input) {
+    throw new Error(`Missing ${name} input`);
+  }
+  return input;
+}
+
+describe("ChangePasswordContent", () => {
+  const closeDialog = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    changePassword.mockResolvedValue(undefined);
+  });
+
+  it("rejects when the new password equals the old password", async () => {
+    const user = userEvent.setup();
+    render(<ChangePasswordContent closeDialog={closeDialog} embedded />);
+
+    await user.type(passwordInput("oldPassword"), "password1");
+    await user.type(passwordInput("newPassword"), "password1");
+    await user.click(screen.getByRole("button", { name: "changePassword.save" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("errors.validation.formErrors.newPasswordSameAsOldPassword")
+      ).toBeInTheDocument();
+    });
+    expect(changePassword).not.toHaveBeenCalled();
+  });
+
+  it("changes the password and closes on success", async () => {
+    const user = userEvent.setup();
+    render(<ChangePasswordContent closeDialog={closeDialog} embedded />);
+
+    await user.type(passwordInput("oldPassword"), "oldpassword1");
+    await user.type(passwordInput("newPassword"), "newpassword1");
+    await user.click(screen.getByRole("button", { name: "changePassword.save" }));
+
+    await waitFor(() => {
+      expect(changePassword).toHaveBeenCalledWith("oldpassword1", "newpassword1");
+      expect(toast.success).toHaveBeenCalledWith("changePassword.success");
+      expect(closeDialog).toHaveBeenCalled();
+    });
+  });
+
+  it("shows an error toast and stays open when change fails", async () => {
+    changePassword.mockRejectedValue({ error: { code: "UNAUTHORIZED" } });
+    const user = userEvent.setup();
+    render(<ChangePasswordContent closeDialog={closeDialog} embedded />);
+
+    await user.type(passwordInput("oldPassword"), "oldpassword1");
+    await user.type(passwordInput("newPassword"), "newpassword1");
+    await user.click(screen.getByRole("button", { name: "changePassword.save" }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("changePassword.error", {
+        description: "API error message",
+      });
+    });
+    expect(closeDialog).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/features/profile/forms/delete-account-content.test.tsx
+++ b/apps/web/src/features/profile/forms/delete-account-content.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { toast } from "sonner";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DeleteAccountContent } from "./delete-account-content";
+
+const deleteAccount = vi.fn();
+
+vi.mock("@/features/auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/auth")>();
+  return {
+    ...actual,
+    useAuth: () => ({ deleteAccount }),
+  };
+});
+
+vi.mock("@/hooks/use-error-message", () => ({
+  useErrorMessage: () => () => "API error message",
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("DeleteAccountContent", () => {
+  const closeDialog = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    deleteAccount.mockResolvedValue(undefined);
+  });
+
+  it("requires a password before submitting", async () => {
+    const user = userEvent.setup();
+    render(<DeleteAccountContent closeDialog={closeDialog} embedded />);
+
+    await user.click(screen.getByRole("button", { name: "deleteAccount.delete" }));
+
+    expect(deleteAccount).not.toHaveBeenCalled();
+    expect(closeDialog).not.toHaveBeenCalled();
+  });
+
+  it("deletes the account and closes on success", async () => {
+    const user = userEvent.setup();
+    render(<DeleteAccountContent closeDialog={closeDialog} embedded />);
+
+    await user.type(screen.getByLabelText("common.labels.password"), "password1");
+    await user.click(screen.getByRole("button", { name: "deleteAccount.delete" }));
+
+    await waitFor(() => {
+      expect(deleteAccount).toHaveBeenCalledWith("password1");
+      expect(toast.success).toHaveBeenCalledWith("deleteAccount.success");
+      expect(closeDialog).toHaveBeenCalled();
+    });
+  });
+
+  it("shows an error toast and stays open when delete fails", async () => {
+    deleteAccount.mockRejectedValue({ error: { code: "UNAUTHORIZED" } });
+    const user = userEvent.setup();
+    render(<DeleteAccountContent closeDialog={closeDialog} embedded />);
+
+    await user.type(screen.getByLabelText("common.labels.password"), "password1");
+    await user.click(screen.getByRole("button", { name: "deleteAccount.delete" }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("deleteAccount.error", {
+        description: "API error message",
+      });
+    });
+    expect(closeDialog).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/features/profile/views/profile-change-password-view.component.test.tsx
+++ b/apps/web/src/features/profile/views/profile-change-password-view.component.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { ProfileChangePasswordView } from "./profile-change-password-view.component";
+
+import { expectNoAxeViolations } from "@/test/axe";
+
+vi.mock("../forms/change-password-content", () => ({
+  ChangePasswordContent: ({
+    closeDialog,
+    embedded,
+  }: {
+    closeDialog: () => void;
+    embedded?: boolean;
+  }) => (
+    <div data-testid="change-password-content" data-embedded={embedded ? "1" : "0"}>
+      <button type="button" onClick={closeDialog}>
+        close-form
+      </button>
+    </div>
+  ),
+}));
+
+describe("ProfileChangePasswordView", () => {
+  it("renders the embedded form and goes back", async () => {
+    const onBack = vi.fn();
+    const user = userEvent.setup();
+    render(<ProfileChangePasswordView onBack={onBack} />);
+
+    expect(screen.getByRole("heading", { name: "changePassword.title" })).toBeInTheDocument();
+    expect(screen.getByTestId("change-password-content")).toHaveAttribute("data-embedded", "1");
+
+    await user.click(screen.getByRole("button", { name: "common.buttons.back" }));
+    expect(onBack).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole("button", { name: "close-form" }));
+    expect(onBack).toHaveBeenCalledTimes(2);
+  });
+
+  it("has no axe violations", async () => {
+    const { container } = render(<ProfileChangePasswordView onBack={vi.fn()} />);
+
+    await expectNoAxeViolations(container);
+  });
+});

--- a/apps/web/src/features/profile/views/profile-delete-account-view.component.test.tsx
+++ b/apps/web/src/features/profile/views/profile-delete-account-view.component.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { ProfileDeleteAccountView } from "./profile-delete-account-view.component";
+
+import { expectNoAxeViolations } from "@/test/axe";
+
+vi.mock("../forms/delete-account-content", () => ({
+  DeleteAccountContent: ({
+    closeDialog,
+    embedded,
+  }: {
+    closeDialog: () => void;
+    embedded?: boolean;
+  }) => (
+    <div data-testid="delete-account-content" data-embedded={embedded ? "1" : "0"}>
+      <button type="button" onClick={closeDialog}>
+        close-form
+      </button>
+    </div>
+  ),
+}));
+
+describe("ProfileDeleteAccountView", () => {
+  it("renders the embedded form and goes back", async () => {
+    const onBack = vi.fn();
+    const user = userEvent.setup();
+    render(<ProfileDeleteAccountView onBack={onBack} />);
+
+    expect(screen.getByRole("heading", { name: "deleteAccount.title" })).toBeInTheDocument();
+    expect(screen.getByTestId("delete-account-content")).toHaveAttribute("data-embedded", "1");
+
+    await user.click(screen.getByRole("button", { name: "common.buttons.back" }));
+    expect(onBack).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole("button", { name: "close-form" }));
+    expect(onBack).toHaveBeenCalledTimes(2);
+  });
+
+  it("has no axe violations", async () => {
+    const { container } = render(<ProfileDeleteAccountView onBack={vi.fn()} />);
+
+    await expectNoAxeViolations(container);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds Vitest coverage for account deletion and password change (Linear NIR-108, parent NIR-105).

## Type of Change

- [x] Test update

## Related Issues

Related to NIR-108 / NIR-105

## Changes Made

- `DeleteAccountContent`: required password, success, error toast
- `ChangePasswordContent`: reject new === old, success, error toast
- Profile views for both flows (embedded form, back, axe)

## Testing

- [x] Unit tests pass (`pnpm -C apps/web exec vitest run` on the new files)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-836068bc-50ef-4a28-878b-c28d20dfa7ad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-836068bc-50ef-4a28-878b-c28d20dfa7ad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

