### PR TITLE
test(web): cover POI dialogs and opening-hours utils

### DIFF
--- a/apps/web/src/features/pois/components/create-poi-dialog.test.tsx
+++ b/apps/web/src/features/pois/components/create-poi-dialog.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { CreatePoiDialog } from "./create-poi-dialog";
+
+vi.mock("../forms/create-poi-form", () => ({
+  CreatePoiForm: ({
+    closeDialog,
+    onCreated,
+    listId,
+    coordinates,
+  }: {
+    closeDialog: () => void;
+    onCreated?: (poiId: string) => void;
+    listId?: string;
+    coordinates: { latitude: number; longitude: number };
+  }) => (
+    <div
+      data-testid="create-poi-form"
+      data-list-id={listId ?? ""}
+      data-lat={String(coordinates.latitude)}
+      data-lng={String(coordinates.longitude)}
+    >
+      <button type="button" onClick={closeDialog}>
+        close
+      </button>
+      <button type="button" onClick={() => onCreated?.("poi-1")}>
+        created
+      </button>
+    </div>
+  ),
+}));
+
+const coordinates = { latitude: 48.8566, longitude: 2.3522 };
+
+function stubMatchMedia(matches: boolean) {
+  window.matchMedia = (query: string) =>
+    ({
+      matches,
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    }) as unknown as MediaQueryList;
+}
+
+describe("CreatePoiDialog", () => {
+  afterEach(() => {
+    stubMatchMedia(false);
+  });
+
+  it("renders a dialog on desktop and forwards form callbacks", async () => {
+    stubMatchMedia(false);
+    const onOpenChange = vi.fn();
+    const onCreated = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <CreatePoiDialog
+        open
+        onOpenChange={onOpenChange}
+        onCreated={onCreated}
+        listId="list-1"
+        coordinates={coordinates}
+      />
+    );
+
+    expect(document.querySelector('[data-slot="dialog-content"]')).toBeTruthy();
+    expect(document.querySelector('[data-slot="drawer-content"]')).toBeNull();
+    expect(screen.getByRole("heading", { name: "create.title" })).toBeInTheDocument();
+    expect(screen.getByTestId("create-poi-form")).toHaveAttribute("data-list-id", "list-1");
+    expect(screen.getByTestId("create-poi-form")).toHaveAttribute("data-lat", "48.8566");
+
+    await user.click(screen.getByRole("button", { name: "close" }));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+
+    await user.click(screen.getByRole("button", { name: "created" }));
+    expect(onCreated).toHaveBeenCalledWith("poi-1");
+  });
+
+  it("renders a drawer on mobile", () => {
+    stubMatchMedia(true);
+
+    render(
+      <CreatePoiDialog open onOpenChange={vi.fn()} listId="list-1" coordinates={coordinates} />
+    );
+
+    expect(document.querySelector('[data-slot="drawer-content"]')).toBeTruthy();
+    expect(document.querySelector('[data-slot="dialog-content"]')).toBeNull();
+    expect(screen.getByRole("heading", { name: "create.title" })).toBeInTheDocument();
+    expect(screen.getByTestId("create-poi-form")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/pois/components/edit-poi-dialog.test.tsx
+++ b/apps/web/src/features/pois/components/edit-poi-dialog.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { EditPoiDialog } from "./edit-poi-dialog";
+
+import type { Poi } from "@/lib/api";
+
+vi.mock("../forms/edit-poi-form", () => ({
+  EditPoiForm: ({
+    closeDialog,
+    listId,
+    poi,
+  }: {
+    closeDialog: () => void;
+    listId?: string;
+    poi: Poi & { id: string };
+  }) => (
+    <div data-testid="edit-poi-form" data-list-id={listId ?? ""} data-poi-id={poi.id}>
+      <button type="button" onClick={closeDialog}>
+        close
+      </button>
+    </div>
+  ),
+}));
+
+const poi: Poi & { id: string } = {
+  id: "poi-1",
+  name: "Secret spot",
+  latitude: 48.8566,
+  longitude: 2.3522,
+};
+
+function stubMatchMedia(matches: boolean) {
+  window.matchMedia = (query: string) =>
+    ({
+      matches,
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    }) as unknown as MediaQueryList;
+}
+
+describe("EditPoiDialog", () => {
+  afterEach(() => {
+    stubMatchMedia(false);
+  });
+
+  it("renders a dialog on desktop and forwards the form close", async () => {
+    stubMatchMedia(false);
+    const onOpenChange = vi.fn();
+    const user = userEvent.setup();
+
+    render(<EditPoiDialog open onOpenChange={onOpenChange} poi={poi} listId="list-1" />);
+
+    expect(document.querySelector('[data-slot="dialog-content"]')).toBeTruthy();
+    expect(document.querySelector('[data-slot="drawer-content"]')).toBeNull();
+    expect(screen.getByRole("heading", { name: "edit.title" })).toBeInTheDocument();
+    expect(screen.getByTestId("edit-poi-form")).toHaveAttribute("data-poi-id", "poi-1");
+    expect(screen.getByTestId("edit-poi-form")).toHaveAttribute("data-list-id", "list-1");
+
+    await user.click(screen.getByRole("button", { name: "close" }));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("renders a drawer on mobile", () => {
+    stubMatchMedia(true);
+
+    render(<EditPoiDialog open onOpenChange={vi.fn()} poi={poi} listId="list-1" />);
+
+    expect(document.querySelector('[data-slot="drawer-content"]')).toBeTruthy();
+    expect(document.querySelector('[data-slot="dialog-content"]')).toBeNull();
+    expect(screen.getByRole("heading", { name: "edit.title" })).toBeInTheDocument();
+    expect(screen.getByTestId("edit-poi-form")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/pois/components/poi-opening-hours.test.tsx
+++ b/apps/web/src/features/pois/components/poi-opening-hours.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { PoiOpeningHours } from "./poi-opening-hours";
+
+describe("PoiOpeningHours", () => {
+  it("renders the open status with the open color", () => {
+    render(<PoiOpeningHours hours={{ isOpen: true, nextOpenAt: null }} />);
+
+    const status = screen.getByText("openingHours.openNow");
+    expect(status).toBeInTheDocument();
+    expect(status).toHaveClass("text-emerald-600");
+  });
+
+  it("renders the closed status without the open color", () => {
+    render(<PoiOpeningHours hours={{ isOpen: false, nextOpenAt: null }} />);
+
+    const status = screen.getByText("openingHours.closedNow");
+    expect(status).toBeInTheDocument();
+    expect(status).not.toHaveClass("text-emerald-600");
+  });
+});

--- a/apps/web/src/features/pois/utils/compute-opening-status.test.ts
+++ b/apps/web/src/features/pois/utils/compute-opening-status.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpeningHoursPeriod } from "../types/poi-display-types";
+
+import { computeOpeningStatusFromPeriods } from "./compute-opening-status";
+
+const fridayMorning: OpeningHoursPeriod = {
+  open: { day: 5, hour: 9, minute: 0 },
+  close: { day: 5, hour: 18, minute: 0 },
+};
+
+const fridayLunch: OpeningHoursPeriod = {
+  open: { day: 5, hour: 9, minute: 0 },
+  close: { day: 5, hour: 12, minute: 0 },
+};
+
+const fridayOvernight: OpeningHoursPeriod = {
+  open: { day: 5, hour: 18, minute: 0 },
+  close: { day: 6, hour: 2, minute: 0 },
+};
+
+describe("computeOpeningStatusFromPeriods", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("reports open during a same-day period", () => {
+    vi.setSystemTime(new Date(2026, 7, 21, 14, 30, 0));
+
+    expect(computeOpeningStatusFromPeriods([fridayMorning])).toEqual(
+      expect.objectContaining({ isOpen: true })
+    );
+  });
+
+  it("reports closed with nextOpenAt after hours", () => {
+    vi.setSystemTime(new Date(2026, 7, 21, 14, 30, 0));
+
+    const status = computeOpeningStatusFromPeriods([fridayLunch]);
+
+    expect(status.isOpen).toBe(false);
+    expect(status.nextOpenAt).toEqual(expect.any(String));
+    expect(Number.isNaN(Date.parse(status.nextOpenAt as string))).toBe(false);
+  });
+
+  it("treats overnight periods as open before midnight and after", () => {
+    vi.setSystemTime(new Date(2026, 7, 21, 23, 0, 0));
+    expect(computeOpeningStatusFromPeriods([fridayOvernight]).isOpen).toBe(true);
+
+    vi.setSystemTime(new Date(2026, 7, 22, 1, 0, 0));
+    expect(computeOpeningStatusFromPeriods([fridayOvernight]).isOpen).toBe(true);
+  });
+
+  it("returns closed with no next opening when periods are empty", () => {
+    vi.setSystemTime(new Date(2026, 7, 21, 14, 30, 0));
+
+    expect(computeOpeningStatusFromPeriods([])).toEqual({
+      isOpen: false,
+      nextOpenAt: null,
+    });
+  });
+});

--- a/apps/web/src/features/pois/utils/format-opening-hours.test.ts
+++ b/apps/web/src/features/pois/utils/format-opening-hours.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { formatOpeningHoursPeriods } from "./format-opening-hours";
+
+describe("formatOpeningHoursPeriods", () => {
+  it("formats same-day periods", () => {
+    expect(
+      formatOpeningHoursPeriods([
+        { open: { day: 5, hour: 9, minute: 0 }, close: { day: 5, hour: 18, minute: 0 } },
+      ])
+    ).toEqual(["Fri 09:00 – 18:00"]);
+  });
+
+  it("formats overnight periods that close on another day", () => {
+    expect(
+      formatOpeningHoursPeriods([
+        { open: { day: 5, hour: 18, minute: 0 }, close: { day: 6, hour: 2, minute: 0 } },
+      ])
+    ).toEqual(["Fri 18:00 – Sat 02:00"]);
+  });
+
+  it("falls back to the numeric day when the index is unknown", () => {
+    expect(
+      formatOpeningHoursPeriods([
+        { open: { day: 7, hour: 10, minute: 5 }, close: { day: 7, hour: 11, minute: 0 } },
+      ])
+    ).toEqual(["7 10:05 – 11:00"]);
+  });
+});

--- a/apps/web/src/features/pois/utils/format-opening-status.test.ts
+++ b/apps/web/src/features/pois/utils/format-opening-status.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { formatOpeningStatus } from "./format-opening-status";
+
+const t = vi.fn((key: string, values?: Record<string, string | number | Date>) =>
+  values ? `${key}:${JSON.stringify(values)}` : key
+);
+
+describe("formatOpeningStatus", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    t.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns openNow when the place is open", () => {
+    expect(formatOpeningStatus({ isOpen: true, nextOpenAt: null }, "en-GB", t)).toBe(
+      "openingHours.openNow"
+    );
+  });
+
+  it("returns closedNow when there is no next opening", () => {
+    expect(formatOpeningStatus({ isOpen: false, nextOpenAt: null }, "en-GB", t)).toBe(
+      "openingHours.closedNow"
+    );
+  });
+
+  it("returns opensAt when next opening is later today", () => {
+    vi.setSystemTime(new Date(2026, 7, 21, 10, 0, 0));
+    const nextOpenAt = new Date(2026, 7, 21, 18, 0, 0).toISOString();
+
+    const message = formatOpeningStatus({ isOpen: false, nextOpenAt }, "en-GB", t);
+
+    expect(message).toMatch(/^openingHours\.opensAt:/);
+    expect(t).toHaveBeenCalledWith(
+      "openingHours.opensAt",
+      expect.objectContaining({ time: expect.any(String) })
+    );
+  });
+
+  it("returns opensTomorrowAt when next opening is tomorrow", () => {
+    vi.setSystemTime(new Date(2026, 7, 21, 22, 0, 0));
+    const nextOpenAt = new Date(2026, 7, 22, 9, 0, 0).toISOString();
+
+    const message = formatOpeningStatus({ isOpen: false, nextOpenAt }, "en-GB", t);
+
+    expect(message).toMatch(/^openingHours\.opensTomorrowAt:/);
+  });
+
+  it("returns opensDayAt when next opening is later in the week", () => {
+    vi.setSystemTime(new Date(2026, 7, 21, 10, 0, 0));
+    const nextOpenAt = new Date(2026, 7, 24, 9, 0, 0).toISOString();
+
+    const message = formatOpeningStatus({ isOpen: false, nextOpenAt }, "en-GB", t);
+
+    expect(message).toMatch(/^openingHours\.opensDayAt:/);
+    expect(t).toHaveBeenCalledWith(
+      "openingHours.opensDayAt",
+      expect.objectContaining({ day: expect.any(String), time: expect.any(String) })
+    );
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds Vitest coverage for remaining POI dialogs and opening-hours utilities (Linear NIR-109, parent NIR-105).

## Type of Change

- [x] Test update

## Related Issues

Related to NIR-109 / NIR-105

## Changes Made

- `computeOpeningStatusFromPeriods`: open, closed + nextOpenAt, overnight, empty
- `formatOpeningStatus` / `formatOpeningHoursPeriods`
- `CreatePoiDialog` / `EditPoiDialog`: Dialog vs Drawer via `matchMedia`
- `PoiOpeningHours` open/closed rendering

## Testing

- [x] Unit tests pass (`pnpm -C apps/web exec vitest run` on the new files)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-836068bc-50ef-4a28-878b-c28d20dfa7ad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-836068bc-50ef-4a28-878b-c28d20dfa7ad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

